### PR TITLE
fix #19 MineStackの自動収納切り替えピッケルにエフェクトが掛かっていない不具合を修正

### DIFF
--- a/src/com/github/unchama/seichiassist/data/MenuInventoryData.java
+++ b/src/com/github/unchama/seichiassist/data/MenuInventoryData.java
@@ -1149,7 +1149,8 @@ public class MenuInventoryData {
 	public static ItemMeta MineStackToggleMeta(PlayerData playerdata,ItemMeta itemmeta){
 		List<String> lore = new ArrayList<String>();
 		if(playerdata.minestackflag){
-			itemmeta.addEnchant(Enchantment.DIG_SPEED, 100, false);
+			itemmeta.addEnchant(Enchantment.DIG_SPEED, 1, false);
+			itemmeta.addItemFlags(ItemFlag.HIDE_ENCHANTS);
 			lore.add(ChatColor.RESET + "" +  ChatColor.GREEN + "現在ONです");
 			lore.add(ChatColor.RESET + "" +  ChatColor.DARK_RED + "" + ChatColor.UNDERLINE + "クリックでOFF");
 		}else{


### PR DESCRIPTION
#19 の修正で、MineStackの自動収納がONの際に、鉄ピッケルにエンチャントのエフェクトが掛かるようにしました