### PR TITLE
[Fix] MineStackのMaterialに各種Headを追加した際のエラーを修正

### DIFF
--- a/src/com/github/unchama/seichiassist/listener/PlayerInventoryListener.java
+++ b/src/com/github/unchama/seichiassist/listener/PlayerInventoryListener.java
@@ -1982,28 +1982,31 @@ public class PlayerInventoryListener implements Listener {
 			 * クリックしたボタンに応じた各処理内容の記述ここから
 			 */
 			//ページ変更処理
-			if (itemstackcurrent.getType().equals(Material.SKULL_ITEM) && ((SkullMeta)itemstackcurrent.getItemMeta()).getOwner().equals("MHF_ArrowLeft")) {
-				/* ArrowLeftを使っているのはメインメニューに戻るボタンのみ。その部分の処理 */
-				//開く音を再生
-				player.playSound(player.getLocation(), Sound.BLOCK_FENCE_GATE_OPEN, 1, (float) 0.1);
-				player.openInventory(MenuInventoryData.getMineStackMainMenu(player));
-				return;
-			}
+			if (itemstackcurrent.getType().equals(Material.SKULL_ITEM)) {
+				SkullMeta skullMeta = (SkullMeta) itemstackcurrent.getItemMeta();
+				if (skullMeta.hasOwner()) {
+					switch (skullMeta.getOwner()) {
+						case "MHF_ArrowLeft": {
+							player.playSound(player.getLocation(), Sound.BLOCK_FENCE_GATE_OPEN, 1, (float) 0.1);
+							player.openInventory(MenuInventoryData.getMineStackMainMenu(player));
+							return;
+						}
 
-			//追加
-			if (itemstackcurrent.getType().equals(Material.SKULL_ITEM) && ((SkullMeta)itemstackcurrent.getItemMeta()).getOwner().equals("MHF_ArrowDown")) {
-				/* ArrowDownならば、次ページ移行処理 */
-				ItemMeta itemmeta = itemstackcurrent.getItemMeta();
-				MineStackMenuTransfer(topinventory, player, itemmeta);
-				return;
-			}
+						case "MHF_ArrowDown": {
+							/* ArrowDownならば、次ページ移行処理 */
+							ItemMeta itemmeta = itemstackcurrent.getItemMeta();
+							MineStackMenuTransfer(topinventory, player, itemmeta);
+							return;
+						}
 
-			//追加
-			if (itemstackcurrent.getType().equals(Material.SKULL_ITEM) && ((SkullMeta)itemstackcurrent.getItemMeta()).getOwner().equals("MHF_ArrowUp")) {
-				/* ArrowUpならば、前ページ移行処理 */
-				ItemMeta itemmeta = itemstackcurrent.getItemMeta();
-				MineStackMenuTransfer(topinventory, player, itemmeta);
-				return;
+						case "MHF_ArrowUp": {
+							/* ArrowUpならば、前ページ移行処理 */
+							ItemMeta itemmeta = itemstackcurrent.getItemMeta();
+							MineStackMenuTransfer(topinventory, player, itemmeta);
+							return;
+						}
+					}
+				}
 			}
 
 			if (itemstackcurrent.getType().equals(Material.IRON_PICKAXE)) {


### PR DESCRIPTION
メニューの移動で矢印の頭を使っているが、その判定用に
https://github.com/GiganticMinecraft/SeichiAssist/blob/51813164ff0438e5d427c6c2f1f76f2d2f6fdc42/src/com/github/unchama/seichiassist/listener/PlayerInventoryListener.java#L1741
上記の様なメソッドを呼んでいるが、ドラゴンの頭等はOwnerが居ないのでnullが返ってきてエラーが出てしまっている。
そのため、skullのOwnerがいるかどうかを判断し、いる場合のみ矢印の判定を行う様変更した。