### PR TITLE
1.1.5における不具合修正

### DIFF
--- a/src/main/scala/com/github/unchama/seichiassist/ActiveSkillEffect.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/ActiveSkillEffect.scala
@@ -10,6 +10,7 @@ import org.bukkit.entity.Player
 import org.bukkit.inventory.ItemStack
 import org.bukkit.scheduler.BukkitTask
 import org.bukkit.{Location, Material}
+import org.bukkit.ChatColor._
 
 sealed abstract class ActiveSkillEffect(val num: Int,
                                         val nameOnDatabase: String,
@@ -75,16 +76,16 @@ object ActiveSkillEffect extends Enum[ActiveSkillEffect] {
 
   def getNameByNum(effectNum: Int): String = ActiveSkillEffect.values
     .filter(_.isInstanceOf[ActiveSkillEffect])
-    .map[ActiveSkillEffect](_.asInstanceOf)
     .find(activeSkillEffect => activeSkillEffect.num == effectNum)
     .map(_.nameOnUI)
     .getOrElse("未設定")
 
   def fromSqlName(sqlName: String): Option[ActiveSkillEffect] = ActiveSkillEffect.values.find(_.nameOnDatabase == sqlName)
 
-  case object Explosion extends ActiveSkillEffect(1, s"ef_explosion", "${RED}エクスプロージョン", "単純な爆発", 50, Material.TNT)
+  case object Explosion extends ActiveSkillEffect(1, s"ef_explosion", s"${RED}エクスプロージョン", "単純な爆発", 50, Material.TNT)
 
-  case object Blizzard extends ActiveSkillEffect(2, s"ef_blizzard", "${AQUA}ブリザード", "凍らせる", 70, Material.PACKED_ICE)
+  case object Blizzard extends ActiveSkillEffect(2, s"ef_blizzard", s"${AQUA}ブリザード", "凍らせる", 70, Material.PACKED_ICE)
 
-  case object Meteo extends ActiveSkillEffect(3, s"ef_meteo", "${DARK_RED}メテオ", "隕石を落とす", 100, Material.FIREBALL)
+  case object Meteo extends ActiveSkillEffect(3, s"ef_meteo", s"${DARK_RED}メテオ", "隕石を落とす", 100, Material.FIREBALL)
+
 }

--- a/src/main/scala/com/github/unchama/seichiassist/listener/invlistener/OnClickTitleMenu.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/listener/invlistener/OnClickTitleMenu.scala
@@ -81,7 +81,7 @@ object OnClickTitleMenu extends Listener {
         //表示内容をLVに変更
         if (itemstackcurrent.getType == Material.REDSTONE_TORCH_ON) {
           // Zero clear
-          playerdata.updateNickname(style = PlayerNickName.Style.Level)
+          playerdata.updateNickname(id1 = 0, id2 = 0, id3 = 0, style = PlayerNickName.Style.Level)
           player.playSound(player.getLocation, Sound.BLOCK_STONE_BUTTON_CLICK_ON, 1f, 1f)
           player.openInventory(MenuInventoryData.getTitleMenuData(player))
         } else if (isSkull && (itemstackcurrent.getItemMeta.asInstanceOf[SkullMeta]).getOwner == "MHF_Present2") {

--- a/src/main/scala/com/github/unchama/seichiassist/listener/invlistener/OnClickTitleMenu.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/listener/invlistener/OnClickTitleMenu.scala
@@ -65,7 +65,7 @@ object OnClickTitleMenu extends Listener {
     val isSkull = itemstackcurrent.getType == Material.SKULL_ITEM
     val prefix = s"${DARK_PURPLE}${BOLD}"
     title match {
-      case s"${prefix}実績・二つ名システム " => {
+      case s"${prefix}実績・二つ名システム" => {
         event.setCancelled(true)
 
         //プレイヤーインベントリのクリックの場合終了
@@ -136,7 +136,7 @@ object OnClickTitleMenu extends Listener {
         //予約付与システム受け取り処理
       }
 
-      case s"${prefix}カテゴリ「整地」 " => {
+      case s"${prefix}カテゴリ「整地」" => {
         event.setCancelled(true)
 
         //実績解除処理部分の読みこみ
@@ -167,7 +167,7 @@ object OnClickTitleMenu extends Listener {
         } //実績メニューに戻る
       }
 
-      case s"${prefix}カテゴリ「建築」 " => {
+      case s"${prefix}カテゴリ「建築」" => {
         event.setCancelled(true)
 
         //実績解除処理部分の読みこみ
@@ -185,7 +185,7 @@ object OnClickTitleMenu extends Listener {
 
       }
 
-      case s"${prefix}カテゴリ「ログイン」 " => {
+      case s"${prefix}カテゴリ「ログイン」" => {
         event.setCancelled(true)
 
         //実績解除処理部分の読みこみ
@@ -223,7 +223,7 @@ object OnClickTitleMenu extends Listener {
 
       }
 
-      case s"${prefix}カテゴリ「やりこみ」 " => {
+      case s"${prefix}カテゴリ「やりこみ」" => {
         event.setCancelled(true)
 
         //実績解除処理部分の読みこみ
@@ -241,7 +241,7 @@ object OnClickTitleMenu extends Listener {
 
       }
 
-      case s"${prefix}カテゴリ「特殊」 " => {
+      case s"${prefix}カテゴリ「特殊」" => {
         event.setCancelled(true)
 
         //実績解除処理部分の読みこみ
@@ -273,7 +273,7 @@ object OnClickTitleMenu extends Listener {
 
       }
 
-      case s"${prefix}二つ名組合せシステム " => {
+      case s"${prefix}二つ名組合せシステム" => {
         event.setCancelled(true)
 
         //実績解除処理部分の読みこみ
@@ -347,7 +347,7 @@ object OnClickTitleMenu extends Listener {
 
       }
 
-      case s"${prefix}二つ名組合せ「前」 " => {
+      case s"${prefix}二つ名組合せ「前」" => {
         event.setCancelled(true)
 
         //実績解除処理部分の読みこみ
@@ -389,7 +389,7 @@ object OnClickTitleMenu extends Listener {
 
       }
 
-      case s"${prefix}二つ名組合せ「中」 " => {
+      case s"${prefix}二つ名組合せ「中」" => {
         event.setCancelled(true)
 
         //実績解除処理部分の読みこみ
@@ -431,7 +431,7 @@ object OnClickTitleMenu extends Listener {
 
       }
 
-      case s"${prefix}二つ名組合せ「後」 " => {
+      case s"${prefix}二つ名組合せ「後」" => {
         event.setCancelled(true)
 
         //実績解除処理部分の読みこみ
@@ -473,7 +473,7 @@ object OnClickTitleMenu extends Listener {
 
       }
 
-      case s"${prefix}実績ポイントショップ " => {
+      case s"${prefix}実績ポイントショップ" => {
         event.setCancelled(true)
 
         //実績解除処理部分の読みこみ
@@ -537,7 +537,7 @@ object OnClickTitleMenu extends Listener {
 
       }
 
-      case s"${prefix}実績「整地神ランキング」 " => {
+      case s"${prefix}実績「整地神ランキング」" => {
         event.setCancelled(true)
 
         //実績解除処理部分の読みこみ
@@ -593,7 +593,7 @@ object OnClickTitleMenu extends Listener {
         } //実績メニューに戻る
       }
 
-      case s"${prefix}実績「整地量」 " => {
+      case s"${prefix}実績「整地量」" => {
         event.setCancelled(true)
 
         //実績解除処理部分の読みこみ
@@ -643,7 +643,7 @@ object OnClickTitleMenu extends Listener {
         } //実績メニューに戻る
       }
 
-      case s"${prefix}実績「参加時間」 " => {
+      case s"${prefix}実績「参加時間」" => {
         event.setCancelled(true)
 
         //実績解除処理部分の読みこみ
@@ -754,7 +754,7 @@ object OnClickTitleMenu extends Listener {
         } //実績メニューに戻る
       }
 
-      case s"${prefix}実績「通算ログイン」 " => {
+      case s"${prefix}実績「通算ログイン」" => {
         event.setCancelled(true)
 
         //プレイヤーインベントリのクリックの場合終了
@@ -839,7 +839,7 @@ object OnClickTitleMenu extends Listener {
         } //実績メニューに戻る
       }
 
-      case s"${prefix}実績「連続ログイン」 " => {
+      case s"${prefix}実績「連続ログイン」" => {
         event.setCancelled(true)
 
         //プレイヤーインベントリのクリックの場合終了
@@ -877,7 +877,7 @@ object OnClickTitleMenu extends Listener {
         } //実績メニューに戻る
       }
 
-      case s"${prefix}実績「JMS投票数」 " => {
+      case s"${prefix}実績「JMS投票数」" => {
         event.setCancelled(true)
 
         //実績解除処理部分の読みこみ
@@ -930,7 +930,7 @@ object OnClickTitleMenu extends Listener {
         } //実績メニューに戻る
       }
 
-      case s"${prefix}実績「公式イベント」 " => {
+      case s"${prefix}実績「公式イベント」" => {
         event.setCancelled(true)
 
         //実績解除処理部分の読みこみ
@@ -1063,7 +1063,7 @@ object OnClickTitleMenu extends Listener {
         } //実績メニューに戻る
       }
 
-      case s"${prefix}実績「記念日」 " => {
+      case s"${prefix}実績「記念日」" => {
         event.setCancelled(true)
 
         //プレイヤーインベントリのクリックの場合終了
@@ -1207,7 +1207,7 @@ object OnClickTitleMenu extends Listener {
 
       }
 
-      case s"${prefix}実績「極秘任務」 " => {
+      case s"${prefix}実績「極秘任務」" => {
         event.setCancelled(true)
 
         //実績解除処理部分の読みこみ

--- a/src/main/scala/com/github/unchama/seichiassist/listener/invlistener/OnClickTitleMenu.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/listener/invlistener/OnClickTitleMenu.scala
@@ -47,15 +47,17 @@ object OnClickTitleMenu extends Listener {
     val player = he.asInstanceOf[Player]
     val playerdata = SeichiAssist.playermap(player.getUniqueId)
 
-    def setTitle(first: Int = 0, second: Int = 0, third: Int = 0, message: String =
-    """二つ名$first「
+    def _setTitle(first: Int = 0, second: Int = 0, third: Int = 0)(message: String =
+    s"""二つ名$first「
       |${getTitle(1, first)}
       |${if (second != 0) getTitle(2, second) else ""}
       |${if (third != 0) getTitle(3, third) else ""}
-      |」が設定されました。""".trim.filter(_ != '\n')): Unit = {
+      |」が設定されました。""".stripMargin.filter(_ != '\n')): Unit = {
       playerdata.updateNickname(first, second, third)
       player.sendMessage(message)
     }
+
+    def setTitle(first: Int = 0, second: Int = 0, third: Int = 0): Unit = _setTitle(first, second, third)()
 
     //経験値変更用のクラスを設定
     //ExperienceManager expman = new ExperienceManager(player);

--- a/src/main/scala/com/github/unchama/seichiassist/listener/invlistener/OnClickTitleMenu.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/listener/invlistener/OnClickTitleMenu.scala
@@ -65,7 +65,7 @@ object OnClickTitleMenu extends Listener {
     val isSkull = itemstackcurrent.getType == Material.SKULL_ITEM
     val prefix = s"$DARK_PURPLE$BOLD"
     title match {
-      case s"${prefix}実績・二つ名システム " =>
+      case s"${prefix}実績・二つ名システム" =>
         event.setCancelled(true)
 
         //プレイヤーインベントリのクリックの場合終了
@@ -135,7 +135,7 @@ object OnClickTitleMenu extends Listener {
         //「二つ名組合せシステム」を開く
         //予約付与システム受け取り処理
 
-      case s"${prefix}カテゴリ「整地」 " =>
+      case s"${prefix}カテゴリ「整地」" =>
         event.setCancelled(true)
 
         //実績解除処理部分の読みこみ
@@ -165,7 +165,7 @@ object OnClickTitleMenu extends Listener {
           return
         } //実績メニューに戻る
 
-      case s"${prefix}カテゴリ「建築」 " =>
+      case s"${prefix}カテゴリ「建築」" =>
         event.setCancelled(true)
 
         //実績解除処理部分の読みこみ
@@ -181,7 +181,7 @@ object OnClickTitleMenu extends Listener {
         //実績未実装のカテゴリです。
         //実績メニューに戻る
 
-      case s"${prefix}カテゴリ「ログイン」 " =>
+      case s"${prefix}カテゴリ「ログイン」" =>
         event.setCancelled(true)
 
         //実績解除処理部分の読みこみ
@@ -217,7 +217,7 @@ object OnClickTitleMenu extends Listener {
         //クリックしたボタンに応じた各処理内容の記述ここから
         //実績「参加時間」を開く
 
-      case s"${prefix}カテゴリ「やりこみ」 " =>
+      case s"${prefix}カテゴリ「やりこみ」" =>
         event.setCancelled(true)
 
         //実績解除処理部分の読みこみ
@@ -233,7 +233,7 @@ object OnClickTitleMenu extends Listener {
         //実績未実装のカテゴリです。
         //実績メニューに戻る
 
-      case s"${prefix}カテゴリ「特殊」 " =>
+      case s"${prefix}カテゴリ「特殊」" =>
         event.setCancelled(true)
 
         //実績解除処理部分の読みこみ
@@ -263,7 +263,7 @@ object OnClickTitleMenu extends Listener {
         //クリックしたボタンに応じた各処理内容の記述ここから
         //実績「公式イベント」を開く
 
-      case s"${prefix}二つ名組合せシステム " =>
+      case s"${prefix}二つ名組合せシステム" =>
         event.setCancelled(true)
 
         //実績解除処理部分の読みこみ
@@ -329,7 +329,7 @@ object OnClickTitleMenu extends Listener {
           return
         } //実績メニューに戻る
 
-      case s"${prefix}二つ名組合せ「前」 " =>
+      case s"${prefix}二つ名組合せ「前」" =>
         event.setCancelled(true)
 
         //実績解除処理部分の読みこみ
@@ -368,7 +368,7 @@ object OnClickTitleMenu extends Listener {
         //組み合わせメイン
         //パーツ未選択に
 
-      case s"${prefix}二つ名組合せ「中」 " =>
+      case s"${prefix}二つ名組合せ「中」" =>
         event.setCancelled(true)
 
         //実績解除処理部分の読みこみ
@@ -407,7 +407,7 @@ object OnClickTitleMenu extends Listener {
         //組み合わせメインへ移動
         //パーツ未選択に
 
-      case s"${prefix}二つ名組合せ「後」 " =>
+      case s"${prefix}二つ名組合せ「後」" =>
         event.setCancelled(true)
 
         //実績解除処理部分の読みこみ
@@ -446,7 +446,7 @@ object OnClickTitleMenu extends Listener {
         //組み合わせメイン
         //パーツ未選択に
 
-      case s"${prefix}実績ポイントショップ " =>
+      case s"${prefix}実績ポイントショップ" =>
         event.setCancelled(true)
 
         //実績解除処理部分の読みこみ
@@ -508,7 +508,7 @@ object OnClickTitleMenu extends Listener {
         } //次ページ
         //組み合わせメイン
 
-      case s"${prefix}実績「整地神ランキング」 " =>
+      case s"${prefix}実績「整地神ランキング」" =>
         event.setCancelled(true)
 
         //実績解除処理部分の読みこみ
@@ -563,7 +563,7 @@ object OnClickTitleMenu extends Listener {
           return
         } //実績メニューに戻る
 
-      case s"${prefix}実績「整地量」 " =>
+      case s"${prefix}実績「整地量」" =>
         event.setCancelled(true)
 
         //実績解除処理部分の読みこみ
@@ -612,7 +612,7 @@ object OnClickTitleMenu extends Listener {
           return
         } //実績メニューに戻る
 
-      case s"${prefix}実績「参加時間」 " =>
+      case s"${prefix}実績「参加時間」" =>
         event.setCancelled(true)
 
         //実績解除処理部分の読みこみ
@@ -722,7 +722,7 @@ object OnClickTitleMenu extends Listener {
           return
         } //実績メニューに戻る
 
-      case s"${prefix}実績「通算ログイン」 " =>
+      case s"${prefix}実績「通算ログイン」" =>
         event.setCancelled(true)
 
         //プレイヤーインベントリのクリックの場合終了
@@ -806,7 +806,7 @@ object OnClickTitleMenu extends Listener {
           return
         } //実績メニューに戻る
 
-      case s"${prefix}実績「連続ログイン」 " =>
+      case s"${prefix}実績「連続ログイン」" =>
         event.setCancelled(true)
 
         //プレイヤーインベントリのクリックの場合終了
@@ -843,7 +843,7 @@ object OnClickTitleMenu extends Listener {
           return
         } //実績メニューに戻る
 
-      case s"${prefix}実績「JMS投票数」 " =>
+      case s"${prefix}実績「JMS投票数」" =>
         event.setCancelled(true)
 
         //実績解除処理部分の読みこみ
@@ -895,7 +895,7 @@ object OnClickTitleMenu extends Listener {
           return
         } //実績メニューに戻る
 
-      case s"${prefix}実績「公式イベント」 " =>
+      case s"${prefix}実績「公式イベント」" =>
         event.setCancelled(true)
 
         //実績解除処理部分の読みこみ
@@ -1027,7 +1027,7 @@ object OnClickTitleMenu extends Listener {
           return
         } //実績メニューに戻る
 
-      case s"${prefix}実績「記念日」 " =>
+      case s"${prefix}実績「記念日」" =>
         event.setCancelled(true)
 
         //プレイヤーインベントリのクリックの場合終了
@@ -1169,7 +1169,7 @@ object OnClickTitleMenu extends Listener {
         } //次ページ
         //実績メニューに戻る
 
-      case s"${prefix}実績「極秘任務」 " =>
+      case s"${prefix}実績「極秘任務」" =>
         event.setCancelled(true)
 
         //実績解除処理部分の読みこみ

--- a/src/main/scala/com/github/unchama/seichiassist/util/BreakUtil.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/util/BreakUtil.scala
@@ -149,7 +149,9 @@ object BreakUtil {
     //拾った時のサブIDに合わせる
     if (itemstack.getType == Material.RAILS
       || itemstack.getType == Material.HUGE_MUSHROOM_1
-      || itemstack.getType == Material.HUGE_MUSHROOM_2) {
+      || itemstack.getType == Material.HUGE_MUSHROOM_2
+      || itemstack.getType == Material.PURPUR_STAIRS
+      || itemstack.getType == Material.BONE_BLOCK) {
 
       itemstack.setDurability(0.toShort)
     }


### PR DESCRIPTION
・実績画面のアイテム取り出せる問題
・二つ名Lv表記に戻せない問題
・骨ブロック・プルファの階段ブロックがアサルトスキルで破壊した時にMineStackに入らない問題
・整地スキルの演出効果のメニューが開けない問題
・実績設定時のメッセージが謎出力される問題
以上5項目の修正です。
