### PR TITLE
二つ名組み合わせメニューに不必要な二つ名が表示されてしまう・未選択時に不適切な二つ名が表示される問題を修正

### DIFF
--- a/src/main/scala/com/github/unchama/seichiassist/Config.java
+++ b/src/main/scala/com/github/unchama/seichiassist/Config.java
@@ -1,8 +1,5 @@
 package com.github.unchama.seichiassist;
 
-import com.github.unchama.seichiassist.achievement.NicknameParts;
-import com.github.unchama.seichiassist.achievement.Nicknames;
-import com.github.unchama.seichiassist.achievement.Undefined;
 import com.github.unchama.seichiassist.util.TypeConverter;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.entity.Player;
@@ -136,23 +133,6 @@ public class Config {
 
     public String getLvMessage(int i) {
         return config.getString("lv" + i + "message", "");
-    }
-
-    private NicknameParts getNickname(final int i) {
-        // もしも存在しないIDであれば二つ名の代わりにエラーメッセージを返す
-        return Nicknames.map().get(i).getOrElse(() -> (NicknameParts) new Undefined(i));
-    }
-
-    public String getTitle1(int i) {
-        return getNickname(i).head().get();
-    }
-
-    public String getTitle2(int i) {
-        return getNickname(i).middle().get();
-    }
-
-    public String getTitle3(int i) {
-        return getNickname(i).tail().get();
     }
 
     //サーバー番号取得

--- a/src/main/scala/com/github/unchama/seichiassist/achievement/NicknameMapping.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/achievement/NicknameMapping.scala
@@ -3,6 +3,7 @@ package com.github.unchama.seichiassist.achievement
 import com.github.unchama.seichiassist.SeichiAssist
 
 object NicknameMapping {
+
   case class NicknameCombination(first: Option[AchievementId],
                                  second: Option[AchievementId] = None,
                                  third: Option[AchievementId] = None)
@@ -181,12 +182,10 @@ object NicknameMapping {
     8003 -> NicknameCombination(Some(8003), None, Some(8003)),
   )
 
-  def getTitleFor(id: AchievementId): Option[String] =
+  def getTitleFor(id: AchievementId): Option[Title] =
     mapping.get(id).map { case NicknameCombination(first, second, third) =>
-      val config = SeichiAssist.seichiAssistConfig
-
-      first.map(config.getTitle1).getOrElse("") +
-        second.map(config.getTitle2).getOrElse("") +
-        third.map(config.getTitle3).getOrElse("")
+      first.flatMap(Nicknames.getHeadPartFor).getOrElse("") +
+        second.flatMap(Nicknames.getMiddlePartFor).getOrElse("") +
+        third.flatMap(Nicknames.getTailPartFor).getOrElse("")
     }
 }

--- a/src/main/scala/com/github/unchama/seichiassist/achievement/NicknameMapping.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/achievement/NicknameMapping.scala
@@ -1,7 +1,5 @@
 package com.github.unchama.seichiassist.achievement
 
-import com.github.unchama.seichiassist.SeichiAssist
-
 object NicknameMapping {
 
   case class NicknameCombination(first: Option[AchievementId],

--- a/src/main/scala/com/github/unchama/seichiassist/achievement/NicknameMapping.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/achievement/NicknameMapping.scala
@@ -180,7 +180,7 @@ object NicknameMapping {
     8003 -> NicknameCombination(Some(8003), None, Some(8003)),
   )
 
-  def getTitleFor(id: AchievementId): Option[Title] =
+  def getTitleFor(id: AchievementId): Option[Nickname] =
     mapping.get(id).map { case NicknameCombination(first, second, third) =>
       first.flatMap(Nicknames.getHeadPartFor).getOrElse("") +
         second.flatMap(Nicknames.getMiddlePartFor).getOrElse("") +

--- a/src/main/scala/com/github/unchama/seichiassist/achievement/Nicknames.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/achievement/Nicknames.scala
@@ -283,7 +283,7 @@ case class HeadMiddle(private val _head: String, private val _middle: String) ex
 }
 
 case class Undefined(private val id: Int) extends NicknameParts {
-  val head = Some(s"[?H$id]")
-  val middle = Some(s"[?M$id]")
-  val tail = Some(s"[?T$id]")
+  val head = Some("")
+  val middle = Some("")
+  val tail = Some("")
 }

--- a/src/main/scala/com/github/unchama/seichiassist/achievement/Nicknames.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/achievement/Nicknames.scala
@@ -1,5 +1,7 @@
 package com.github.unchama.seichiassist.achievement
 
+import org.bukkit.Bukkit
+
 object Nicknames {
   val map: Map[Int, NicknameParts] = Map(
     // 前後パーツ(購入用)
@@ -242,6 +244,20 @@ object Nicknames {
     9035 -> HeadTail(s"無尽蔵", s"気力"),
     9036 -> HeadTail(s"猛毒", s"直撃"),
   )
+
+  def getNicknameFor(achievementId: AchievementId): Option[NicknameParts] = Nicknames.map.get(achievementId)
+
+  def getHeadPartFor(achievementId: AchievementId): Option[NicknamePart] = getNicknameFor(achievementId).flatMap(_.head())
+
+  def getMiddlePartFor(achievementId: AchievementId): Option[NicknamePart] = getNicknameFor(achievementId).flatMap(_.middle())
+
+  def getTailPartFor(achievementId: AchievementId): Option[NicknamePart] = getNicknameFor(achievementId).flatMap(_.tail())
+
+  def getTitleFor(headAchievementId: AchievementId, middleAchievementId: AchievementId, tailAchievementId: AchievementId): String = {
+    getHeadPartFor(headAchievementId).getOrElse("") +
+      getMiddlePartFor(middleAchievementId).getOrElse("") +
+      getTailPartFor(tailAchievementId).getOrElse("")
+  }
 }
 
 sealed trait NicknameParts {
@@ -280,10 +296,4 @@ case class HeadMiddle(private val _head: String, private val _middle: String) ex
   val head = Some(_head)
   val middle = Some(_middle)
   val tail = None
-}
-
-case class Undefined(private val id: Int) extends NicknameParts {
-  val head = Some("")
-  val middle = Some("")
-  val tail = Some("")
 }

--- a/src/main/scala/com/github/unchama/seichiassist/achievement/Nicknames.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/achievement/Nicknames.scala
@@ -251,10 +251,26 @@ object Nicknames {
 
   def getTailPartFor(achievementId: AchievementId): Option[PartialNickname] = getNicknameFor(achievementId).flatMap(_.tail())
 
-  def getTitleFor(headAchievementId: AchievementId, middleAchievementId: AchievementId, tailAchievementId: AchievementId): String = {
+  /**
+   * @deprecated use [[getCombinedNicknameFor]] where possible
+   */
+  @deprecated def getTitleFor(headAchievementId: AchievementId, middleAchievementId: AchievementId, tailAchievementId: AchievementId): String = {
     getHeadPartFor(headAchievementId).getOrElse("") +
       getMiddlePartFor(middleAchievementId).getOrElse("") +
       getTailPartFor(tailAchievementId).getOrElse("")
+  }
+
+  def getCombinedNicknameFor(head: AchievementId, middle: AchievementId, tail: AchievementId): Option[Nickname] = {
+    val definedParts = List(
+      getHeadPartFor(head),
+      getMiddlePartFor(middle),
+      getTailPartFor(tail)
+    ).flatten
+
+    definedParts match {
+      case nonEmptyParts@ ::(_, _) => Some(nonEmptyParts.mkString(""))
+      case Nil => None
+    }
   }
 }
 

--- a/src/main/scala/com/github/unchama/seichiassist/achievement/Nicknames.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/achievement/Nicknames.scala
@@ -1,9 +1,7 @@
 package com.github.unchama.seichiassist.achievement
 
-import org.bukkit.Bukkit
-
 object Nicknames {
-  val map: Map[Int, NicknameParts] = Map(
+  val map: Map[Int, TitleNicknames] = Map(
     // 前後パーツ(購入用)
     9801 -> HeadTail(s"お兄さん", s"お兄さん"),
     9802 -> HeadTail(s"戦隊", s"戦隊"),
@@ -245,13 +243,13 @@ object Nicknames {
     9036 -> HeadTail(s"猛毒", s"直撃"),
   )
 
-  def getNicknameFor(achievementId: AchievementId): Option[NicknameParts] = Nicknames.map.get(achievementId)
+  def getNicknameFor(achievementId: AchievementId): Option[TitleNicknames] = Nicknames.map.get(achievementId)
 
-  def getHeadPartFor(achievementId: AchievementId): Option[NicknamePart] = getNicknameFor(achievementId).flatMap(_.head())
+  def getHeadPartFor(achievementId: AchievementId): Option[PartialNickname] = getNicknameFor(achievementId).flatMap(_.head())
 
-  def getMiddlePartFor(achievementId: AchievementId): Option[NicknamePart] = getNicknameFor(achievementId).flatMap(_.middle())
+  def getMiddlePartFor(achievementId: AchievementId): Option[PartialNickname] = getNicknameFor(achievementId).flatMap(_.middle())
 
-  def getTailPartFor(achievementId: AchievementId): Option[NicknamePart] = getNicknameFor(achievementId).flatMap(_.tail())
+  def getTailPartFor(achievementId: AchievementId): Option[PartialNickname] = getNicknameFor(achievementId).flatMap(_.tail())
 
   def getTitleFor(headAchievementId: AchievementId, middleAchievementId: AchievementId, tailAchievementId: AchievementId): String = {
     getHeadPartFor(headAchievementId).getOrElse("") +
@@ -260,39 +258,43 @@ object Nicknames {
   }
 }
 
-sealed trait NicknameParts {
+/**
+ * この構造で持たれる二つ名は、対応する実績を解除、または対応する二つ名を購入していれば、
+ * 二つ名組み合わせ設定で使用できるようになる。
+ */
+sealed trait TitleNicknames {
   def head(): Option[String]
-  
+
   def middle(): Option[String]
-  
+
   def tail(): Option[String]
 }
 
-case class HeadTail(private val _head: String, private val _tail: String) extends NicknameParts {
+case class HeadTail(private val _head: String, private val _tail: String) extends TitleNicknames {
   val head = Some(_head)
   val middle = None
   val tail = Some(_tail)
 }
 
-case class MiddleOnly(private val _middle: String) extends NicknameParts {
+case class MiddleOnly(private val _middle: String) extends TitleNicknames {
   val head = None
   val middle = Some(_middle)
   val tail = None
 }
 
-case class HeadOnly(private val _head: String) extends NicknameParts {
+case class HeadOnly(private val _head: String) extends TitleNicknames {
   val head = Some(_head)
   val middle = None
   val tail = None
 }
 
-case class FullSet(private val _head: String, private val _middle: String, private val _tail: String) extends NicknameParts {
+case class FullSet(private val _head: String, private val _middle: String, private val _tail: String) extends TitleNicknames {
   val head = Some(_head)
   val middle = Some(_middle)
   val tail = Some(_tail)
 }
 
-case class HeadMiddle(private val _head: String, private val _middle: String) extends NicknameParts {
+case class HeadMiddle(private val _head: String, private val _middle: String) extends TitleNicknames {
   val head = Some(_head)
   val middle = Some(_middle)
   val tail = None

--- a/src/main/scala/com/github/unchama/seichiassist/achievement/package.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/achievement/package.scala
@@ -5,6 +5,8 @@ import org.bukkit.entity.Player
 
 package object achievement {
   type AchievementId = Int
+  type NicknamePart = String
+  type Title = String
   type PlayerPredicate = Player => IO[Boolean]
   type ParameterizedText[A] = A => String
 }

--- a/src/main/scala/com/github/unchama/seichiassist/achievement/package.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/achievement/package.scala
@@ -6,7 +6,7 @@ import org.bukkit.entity.Player
 package object achievement {
   type AchievementId = Int
   type PartialNickname = String
-  type Title = String
+  type Nickname = String
   type PlayerPredicate = Player => IO[Boolean]
   type ParameterizedText[A] = A => String
 }

--- a/src/main/scala/com/github/unchama/seichiassist/achievement/package.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/achievement/package.scala
@@ -5,7 +5,7 @@ import org.bukkit.entity.Player
 
 package object achievement {
   type AchievementId = Int
-  type NicknamePart = String
+  type PartialNickname = String
   type Title = String
   type PlayerPredicate = Player => IO[Boolean]
   type ParameterizedText[A] = A => String

--- a/src/main/scala/com/github/unchama/seichiassist/data/MenuInventoryData.java
+++ b/src/main/scala/com/github/unchama/seichiassist/data/MenuInventoryData.java
@@ -2,7 +2,6 @@ package com.github.unchama.seichiassist.data;
 
 import com.github.unchama.itemstackbuilder.IconItemStackBuilder;
 import com.github.unchama.seichiassist.*;
-import com.github.unchama.seichiassist.achievement.NicknameParts;
 import com.github.unchama.seichiassist.achievement.Nicknames;
 import com.github.unchama.seichiassist.data.player.PlayerData;
 import com.github.unchama.seichiassist.data.player.PlayerNickname;
@@ -23,7 +22,6 @@ import org.bukkit.inventory.ItemFlag;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.inventory.meta.SkullMeta;
-import scala.Function0;
 import scala.Option;
 import scala.collection.mutable.HashMap;
 

--- a/src/main/scala/com/github/unchama/seichiassist/data/MenuInventoryData.java
+++ b/src/main/scala/com/github/unchama/seichiassist/data/MenuInventoryData.java
@@ -952,7 +952,7 @@ public class MenuInventoryData {
                             checkInv++;
                         }
                     }
-                } else if (Nicknames.getMiddlePartFor(checkTitle2).nonEmpty()) {
+                } else if (maybeMiddlePart.nonEmpty()) {
                     itemstack = new ItemStack(Material.MILK_BUCKET, 1);
                     itemmeta = Bukkit.getItemFactory().getItemMeta(Material.MILK_BUCKET);
                     itemmeta.setDisplayName(String.valueOf(checkTitle2));

--- a/src/main/scala/com/github/unchama/seichiassist/data/MenuInventoryData.java
+++ b/src/main/scala/com/github/unchama/seichiassist/data/MenuInventoryData.java
@@ -2,7 +2,10 @@ package com.github.unchama.seichiassist.data;
 
 import com.github.unchama.itemstackbuilder.IconItemStackBuilder;
 import com.github.unchama.seichiassist.*;
+import com.github.unchama.seichiassist.achievement.NicknameParts;
+import com.github.unchama.seichiassist.achievement.Nicknames;
 import com.github.unchama.seichiassist.data.player.PlayerData;
+import com.github.unchama.seichiassist.data.player.PlayerNickname;
 import com.github.unchama.seichiassist.database.DatabaseGateway;
 import com.github.unchama.seichiassist.task.VotingFairyTask;
 import com.github.unchama.seichiassist.util.AsyncInventorySetter;
@@ -20,6 +23,8 @@ import org.bukkit.inventory.ItemFlag;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.inventory.meta.SkullMeta;
+import scala.Function0;
+import scala.Option;
 import scala.collection.mutable.HashMap;
 
 import java.util.ArrayList;
@@ -744,8 +749,9 @@ public class MenuInventoryData {
         itemstack = new ItemStack(Material.BOOK, 1);
         itemmeta = Bukkit.getItemFactory().getItemMeta(Material.BOOK);
         itemmeta.setDisplayName(ChatColor.YELLOW + "" + ChatColor.UNDERLINE + "" + ChatColor.BOLD + "現在の二つ名の確認");
-        lore = Arrays.asList(ChatColor.RESET + "" + ChatColor.RED + "「" + SeichiAssist.seichiAssistConfig().getTitle1(playerdata.settings().nickname().id1())
-                + SeichiAssist.seichiAssistConfig().getTitle2(playerdata.settings().nickname().id2()) + SeichiAssist.seichiAssistConfig().getTitle3(playerdata.settings().nickname().id3()) + "」");
+        PlayerNickname nickname = playerdata.settings().nickname();
+        String playerTitle = Nicknames.getTitleFor(nickname.id1(), nickname.id2(), nickname.id3());
+        lore = Arrays.asList(ChatColor.RESET + "" + ChatColor.RED + "「" + playerTitle + "」");
         itemmeta.addItemFlags(ItemFlag.HIDE_ATTRIBUTES);
         itemmeta.setLore(lore);
         itemstack.setItemMeta(itemmeta);
@@ -837,12 +843,12 @@ public class MenuInventoryData {
         for (; checkTitle1 < 9900; ) {
             if (checkInv < 27) {
                 if (playerdata.TitleFlags().contains(checkTitle1)) {
-                    if (SeichiAssist.seichiAssistConfig().getTitle1(checkTitle1) == null || SeichiAssist.seichiAssistConfig().getTitle1(checkTitle1).equals("")) {
-                    } else {
+                    Option<String> maybeHeadPart = Nicknames.getHeadPartFor(checkTitle1);
+                    if (maybeHeadPart.nonEmpty()) {
                         itemstack = new ItemStack(Material.WATER_BUCKET, 1);
                         itemmeta = Bukkit.getItemFactory().getItemMeta(Material.WATER_BUCKET);
                         itemmeta.setDisplayName(String.valueOf(checkTitle1));
-                        lore = Arrays.asList(ChatColor.RESET + "" + ChatColor.RED + "前パーツ「" + SeichiAssist.seichiAssistConfig().getTitle1(checkTitle1) + "」");
+                        lore = Arrays.asList(ChatColor.RESET + "" + ChatColor.RED + "前パーツ「" + maybeHeadPart.get() + "」");
                         itemmeta.addItemFlags(ItemFlag.HIDE_ATTRIBUTES);
                         itemmeta.setLore(lore);
                         itemstack.setItemMeta(itemmeta);
@@ -929,15 +935,15 @@ public class MenuInventoryData {
         int checkInv = 0;
         for (; checkTitle2 < 9999; ) {
             if (checkInv < 27) {
+                Option<String> maybeMiddlePart = Nicknames.getMiddlePartFor(checkTitle2);
                 //一部の「隠し中パーツ」は取得しているかの確認
                 if (9911 <= checkTitle2  /*&& checkTitle2 <= 9927*/) {
                     if (playerdata.TitleFlags().contains(checkTitle2)) {
-                        if (SeichiAssist.seichiAssistConfig().getTitle2(checkTitle2) == null || SeichiAssist.seichiAssistConfig().getTitle2(checkTitle2).equals("")) {
-                        } else {
+                        if (maybeMiddlePart.nonEmpty()) {
                             itemstack = new ItemStack(Material.MILK_BUCKET, 1);
                             itemmeta = Bukkit.getItemFactory().getItemMeta(Material.MILK_BUCKET);
                             itemmeta.setDisplayName(String.valueOf(checkTitle2));
-                            lore = Arrays.asList(ChatColor.RESET + "" + ChatColor.RED + "中パーツ「" + SeichiAssist.seichiAssistConfig().getTitle2(checkTitle2) + "」");
+                            lore = Arrays.asList(ChatColor.RESET + "" + ChatColor.RED + "中パーツ「" + maybeMiddlePart.get() + "」");
                             itemmeta.addItemFlags(ItemFlag.HIDE_ATTRIBUTES);
                             itemmeta.setLore(lore);
                             itemstack.setItemMeta(itemmeta);
@@ -946,12 +952,11 @@ public class MenuInventoryData {
                             checkInv++;
                         }
                     }
-                } else if (SeichiAssist.seichiAssistConfig().getTitle2(checkTitle2) == null || SeichiAssist.seichiAssistConfig().getTitle2(checkTitle2).equals("")) {
-                } else {
+                } else if (Nicknames.getMiddlePartFor(checkTitle2).nonEmpty()) {
                     itemstack = new ItemStack(Material.MILK_BUCKET, 1);
                     itemmeta = Bukkit.getItemFactory().getItemMeta(Material.MILK_BUCKET);
                     itemmeta.setDisplayName(String.valueOf(checkTitle2));
-                    lore = Arrays.asList(ChatColor.RESET + "" + ChatColor.RED + "中パーツ「" + SeichiAssist.seichiAssistConfig().getTitle2(checkTitle2) + "」");
+                    lore = Arrays.asList(ChatColor.RESET + "" + ChatColor.RED + "中パーツ「" + maybeMiddlePart.get() + "」");
                     itemmeta.addItemFlags(ItemFlag.HIDE_ATTRIBUTES);
                     itemmeta.setLore(lore);
                     itemstack.setItemMeta(itemmeta);
@@ -1035,12 +1040,12 @@ public class MenuInventoryData {
         for (; checkTitle3 < 9900; ) {
             if (checkInv < 27) {
                 if (playerdata.TitleFlags().contains(checkTitle3)) {
-                    if (SeichiAssist.seichiAssistConfig().getTitle3(checkTitle3) == null || SeichiAssist.seichiAssistConfig().getTitle3(checkTitle3).equals("")) {
-                    } else {
+                    Option<String> maybeTailPart = Nicknames.getTailPartFor(checkTitle3);
+                    if (maybeTailPart.nonEmpty()) {
                         itemstack = new ItemStack(Material.LAVA_BUCKET, 1);
                         itemmeta = Bukkit.getItemFactory().getItemMeta(Material.LAVA_BUCKET);
                         itemmeta.setDisplayName(String.valueOf(checkTitle3));
-                        lore = Arrays.asList(ChatColor.RESET + "" + ChatColor.RED + "後パーツ「" + SeichiAssist.seichiAssistConfig().getTitle3(checkTitle3) + "」");
+                        lore = Arrays.asList(ChatColor.RESET + "" + ChatColor.RED + "後パーツ「" + maybeTailPart.get() + "」");
                         itemmeta.addItemFlags(ItemFlag.HIDE_ATTRIBUTES);
                         itemmeta.setLore(lore);
                         itemstack.setItemMeta(itemmeta);
@@ -1144,7 +1149,7 @@ public class MenuInventoryData {
                     itemstack = new ItemStack(Material.BEDROCK, 1);
                     itemmeta = ItemMetaFactory.BEDROCK.getValue();
                     itemmeta.setDisplayName(String.valueOf(checkTitleS));
-                    lore = Arrays.asList(ChatColor.RESET + "" + ChatColor.RED + "前・後パーツ「" + SeichiAssist.seichiAssistConfig().getTitle1(checkTitleS) + "」"
+                    lore = Arrays.asList(ChatColor.RESET + "" + ChatColor.RED + "前・後パーツ「" + Nicknames.getHeadPartFor(checkTitleS).getOrElse(() -> "") + "」"
                             , ChatColor.RESET + "" + ChatColor.GREEN + "必要ポイント：20"
                             , ChatColor.RESET + "" + ChatColor.AQUA + "クリックで購入できます");
                     itemmeta.addItemFlags(ItemFlag.HIDE_ATTRIBUTES);
@@ -1181,7 +1186,7 @@ public class MenuInventoryData {
                     itemstack = new ItemStack(Material.BEDROCK, 1);
                     itemmeta = ItemMetaFactory.BEDROCK.getValue();
                     itemmeta.setDisplayName(String.valueOf(checkTitleS));
-                    lore = Arrays.asList(ChatColor.RESET + "" + ChatColor.RED + "中パーツ「" + SeichiAssist.seichiAssistConfig().getTitle2(checkTitleS) + "」"
+                    lore = Arrays.asList(ChatColor.RESET + "" + ChatColor.RED + "中パーツ「" + Nicknames.getMiddlePartFor(checkTitleS).getOrElse(() -> "") + "」"
                             , ChatColor.RESET + "" + ChatColor.GREEN + "必要ポイント：35"
                             , ChatColor.RESET + "" + ChatColor.AQUA + "クリックで購入できます");
                     itemmeta.addItemFlags(ItemFlag.HIDE_ATTRIBUTES);

--- a/src/main/scala/com/github/unchama/seichiassist/data/player/PlayerData.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/data/player/PlayerData.scala
@@ -312,7 +312,7 @@ class PlayerData(
 
   //表示される名前に整地レベルor二つ名を追加
   def setDisplayName(): Unit = {
-    var displayName = player.getName
+    val playerName = player.getName
 
     //放置時に色を変える
     val idleColor: String =
@@ -320,23 +320,28 @@ class PlayerData(
       else if (idleMinute >= 3) s"$GRAY"
       else ""
 
-    displayName = idleColor + {
-      val nickname = settings.nickname
-      val hasNothingSet = Seq(nickname.id1, nickname.id2, nickname.id3).forall(_ == 0)
+    val newDisplayName = idleColor + {
+      val nicknameSettings = settings.nickname
+      val currentNickname =
+        Option.unless(nicknameSettings.style == NicknameStyle.Level)(
+          Nicknames.getCombinedNicknameFor(nicknameSettings.id1, nicknameSettings.id2, nicknameSettings.id3)
+        ).flatten
 
-      if (hasNothingSet || (nickname.style == NicknameStyle.Level)) {
-        if (totalStarLevel <= 0)
-          s"[ Lv$level ]$displayName$WHITE"
-        else
-          s"[Lv$level☆$totalStarLevel]$displayName$WHITE"
-      } else {
-        val playerTitle = Nicknames.getTitleFor(nickname.id1, nickname.id2, nickname.id3)
-        s"[$playerTitle]$displayName$WHITE"
+      currentNickname.fold {
+        val levelPart =
+          if (totalStarLevel <= 0)
+            s"[ Lv$level ]"
+          else
+            s"[Lv$level☆$totalStarLevel]"
+
+        s"$levelPart$playerName$WHITE"
+      } { nickname =>
+        s"[$nickname]$playerName$WHITE"
       }
     }
 
-    player.setDisplayName(displayName)
-    player.setPlayerListName(displayName)
+    player.setDisplayName(newDisplayName)
+    player.setPlayerListName(newDisplayName)
   }
 
   /**

--- a/src/main/scala/com/github/unchama/seichiassist/data/player/PlayerData.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/data/player/PlayerData.scala
@@ -6,6 +6,7 @@ import java.util.{GregorianCalendar, UUID}
 import cats.effect.IO
 import com.github.unchama.menuinventory.syntax._
 import com.github.unchama.seichiassist._
+import com.github.unchama.seichiassist.achievement.Nicknames
 import com.github.unchama.seichiassist.data.player.settings.PlayerSettings
 import com.github.unchama.seichiassist.data.potioneffect.FastDiggingEffect
 import com.github.unchama.seichiassist.data.subhome.SubHome
@@ -329,12 +330,8 @@ class PlayerData(
         else
           s"[Lv$level☆$totalStarLevel]$displayName$WHITE"
       } else {
-        val config = SeichiAssist.seichiAssistConfig
-        val displayTitle1 = config.getTitle1(nickname.id1)
-        val displayTitle2 = config.getTitle2(nickname.id2)
-        val displayTitle3 = config.getTitle3(nickname.id3)
-
-        s"[$displayTitle1$displayTitle2$displayTitle3]$displayName$WHITE"
+        val playerTitle = Nicknames.getTitleFor(nickname.id1, nickname.id2, nickname.id3)
+        s"[$playerTitle]$displayName$WHITE"
       }
     }
 
@@ -469,7 +466,7 @@ class PlayerData(
   def updateNickname(id1: Int = settings.nickname.id1,
                      id2: Int = settings.nickname.id2,
                      id3: Int = settings.nickname.id3,
-                     style: NicknameStyle = settings.nickname.style): Unit = {
+                     style: NicknameStyle = NicknameStyle.TitleCombination): Unit = {
     settings.nickname = settings.nickname.copy(id1 = id1, id2 = id2, id3 = id3, style = style)
   }
 

--- a/src/main/scala/com/github/unchama/seichiassist/listener/invlistener/OnClickTitleMenu.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/listener/invlistener/OnClickTitleMenu.scala
@@ -1,7 +1,9 @@
 package com.github.unchama.seichiassist.listener.invlistener
 
 import com.github.unchama.seichiassist
+import com.github.unchama.seichiassist.achievement.Nicknames
 import com.github.unchama.seichiassist.data.MenuInventoryData
+import com.github.unchama.seichiassist.data.player.NicknameStyle
 import com.github.unchama.seichiassist.menus.stickmenu.StickMenu
 import com.github.unchama.seichiassist.{CommonSoundEffects, SeichiAssist}
 import com.github.unchama.targetedeffect.sequentialEffect
@@ -135,12 +137,11 @@ object OnClickTitleMenu extends Listener {
         val itemmeta = itemstackcurrent.getItemMeta
         player.playSound(player.getLocation, Sound.BLOCK_STONE_BUTTON_CLICK_ON, 1f, 1f)
 
-        val forcheck = (SeichiAssist.seichiAssistConfig.getTitle1(Integer.parseInt(itemmeta.getDisplayName))
-          + SeichiAssist.seichiAssistConfig.getTitle2(playerdata.settings.nickname.id2)
-          + SeichiAssist.seichiAssistConfig.getTitle3(playerdata.settings.nickname.id3))
-        if (forcheck.length < 9) {
+        val length = Nicknames.getTitleFor(Integer.parseInt(itemmeta.getDisplayName),
+          playerdata.settings.nickname.id2, playerdata.settings.nickname.id3).length
+        if (length < 9) {
           playerdata.updateNickname(id1 = Integer.parseInt(itemmeta.getDisplayName))
-          player.sendMessage("前パーツ「" + SeichiAssist.seichiAssistConfig.getTitle1(playerdata.settings.nickname.id1) + "」をセットしました。")
+          player.sendMessage("前パーツ「" + Nicknames.getHeadPartFor(playerdata.settings.nickname.id1).getOrElse("") + "」をセットしました。")
         } else {
           player.sendMessage("全パーツ合計で8文字以内になるよう設定してください。")
         }
@@ -174,12 +175,11 @@ object OnClickTitleMenu extends Listener {
         val itemmeta = itemstackcurrent.getItemMeta
         player.playSound(player.getLocation, Sound.BLOCK_STONE_BUTTON_CLICK_ON, 1f, 1f)
 
-        val forcheck = (SeichiAssist.seichiAssistConfig.getTitle1(playerdata.settings.nickname.id1)
-          + SeichiAssist.seichiAssistConfig.getTitle2(Integer.parseInt(itemmeta.getDisplayName))
-          + SeichiAssist.seichiAssistConfig.getTitle3(playerdata.settings.nickname.id3))
-        if (forcheck.length < 9) {
+        val length = Nicknames.getTitleFor(playerdata.settings.nickname.id1,
+          Integer.parseInt(itemmeta.getDisplayName), playerdata.settings.nickname.id3).length
+        if (length < 9) {
           playerdata.updateNickname(id2 = Integer.parseInt(itemmeta.getDisplayName))
-          player.sendMessage("中パーツ「" + SeichiAssist.seichiAssistConfig.getTitle2(playerdata.settings.nickname.id2) + "」をセットしました。")
+          player.sendMessage("中パーツ「" + Nicknames.getMiddlePartFor(playerdata.settings.nickname.id2).getOrElse("") + "」をセットしました。")
         } else {
           player.sendMessage("全パーツ合計で8文字以内になるよう設定してください。")
         }
@@ -213,12 +213,11 @@ object OnClickTitleMenu extends Listener {
         val itemmeta = itemstackcurrent.getItemMeta
         player.playSound(player.getLocation, Sound.BLOCK_STONE_BUTTON_CLICK_ON, 1f, 1f)
 
-        val forcheck = (SeichiAssist.seichiAssistConfig.getTitle1(playerdata.settings.nickname.id1)
-          + SeichiAssist.seichiAssistConfig.getTitle2(playerdata.settings.nickname.id2)
-          + SeichiAssist.seichiAssistConfig.getTitle3(Integer.parseInt(itemmeta.getDisplayName)))
-        if (forcheck.length < 9) {
+        val length = Nicknames.getTitleFor(playerdata.settings.nickname.id1,
+          playerdata.settings.nickname.id2, Integer.parseInt(itemmeta.getDisplayName)).length
+        if (length < 9) {
           playerdata.updateNickname(id3 = Integer.parseInt(itemmeta.getDisplayName))
-          player.sendMessage("後パーツ「" + SeichiAssist.seichiAssistConfig.getTitle3(playerdata.settings.nickname.id3) + "」をセットしました。")
+          player.sendMessage("後パーツ「" + Nicknames.getTailPartFor(playerdata.settings.nickname.id3).getOrElse("") + "」をセットしました。")
         } else {
           player.sendMessage("全パーツ合計で8文字以内になるよう設定してください。")
         }
@@ -273,7 +272,7 @@ object OnClickTitleMenu extends Listener {
           } else {
             playerdata.TitleFlags.addOne(Integer.parseInt(itemmeta.getDisplayName))
             playerdata.consumeAchievePoint(20)
-            player.sendMessage("パーツ「" + SeichiAssist.seichiAssistConfig.getTitle1(Integer.parseInt(itemmeta.getDisplayName)) + "」を購入しました。")
+            player.sendMessage("パーツ「" + Nicknames.getHeadPartFor(Integer.parseInt(itemmeta.getDisplayName)).getOrElse("") + "」を購入しました。")
             playerdata.samepageflag = true
             player.openInventory(MenuInventoryData.setTitleShopData(player))
           }
@@ -283,7 +282,7 @@ object OnClickTitleMenu extends Listener {
           } else {
             playerdata.TitleFlags.addOne(Integer.parseInt(itemmeta.getDisplayName))
             playerdata.consumeAchievePoint(35)
-            player.sendMessage("パーツ「" + SeichiAssist.seichiAssistConfig.getTitle2(Integer.parseInt(itemmeta.getDisplayName)) + "」を購入しました。")
+            player.sendMessage("パーツ「" + Nicknames.getMiddlePartFor(Integer.parseInt(itemmeta.getDisplayName)).getOrElse("") + "」を購入しました。")
             playerdata.samepageflag = true
             player.openInventory(MenuInventoryData.setTitleShopData(player))
           }


### PR DESCRIPTION
修正方法が粗いですが、二つ名組み合わせメニューの未Scala-ize部分まで修正が及びそうだったため、一番単純なやり方で修正をかけています。