### PR TITLE
[ADD]追加し忘れた、整地スキルで壊せる対象ブロックの追加

### DIFF
--- a/src/main/scala/com/github/unchama/seichiassist/MaterialSets.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/MaterialSets.scala
@@ -23,7 +23,8 @@ object MaterialSets {
     Material.PUMPKIN, Material.MELON_BLOCK, Material.STONE_SLAB2, Material.SPONGE, Material.SOIL, Material.GRASS_PATH,
     Material.MOB_SPAWNER, Material.WORKBENCH, Material.FURNACE, Material.QUARTZ_BLOCK, Material.CHEST,
     Material.TRAPPED_CHEST, Material.NETHER_FENCE, Material.NETHER_BRICK_STAIRS, Material.CAULDRON, Material.END_ROD,
-    Material.PURPUR_STAIRS, Material.END_BRICKS, Material.PURPUR_SLAB, Material.ENDER_CHEST, Material.PURPUR_SLAB, Material.STEP
+    Material.PURPUR_STAIRS, Material.END_BRICKS, Material.PURPUR_SLAB, Material.ENDER_CHEST, Material.PURPUR_SLAB, Material.STEP,
+    Material.DOUBLE_STEP,Material.ENDER_PORTAL_FRAME,Material.ENDER_PORTAL
   )
 
   val luckMaterials: Set[Material] = Set(

--- a/src/main/scala/com/github/unchama/seichiassist/data/player/PlayerData.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/data/player/PlayerData.scala
@@ -878,6 +878,7 @@ object PlayerData {
   val exclude: Set[Material] = Set(
     Material.GRASS_PATH,
     Material.SOIL, Material.MOB_SPAWNER,
-    Material.CAULDRON, Material.ENDER_CHEST
+    Material.CAULDRON, Material.ENDER_CHEST,
+    Material.ENDER_PORTAL_FRAME,Material.ENDER_PORTAL
   )
 }

--- a/src/main/scala/com/github/unchama/seichiassist/util/BreakUtil.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/util/BreakUtil.scala
@@ -237,9 +237,7 @@ object BreakUtil {
 
     blockMaterial match {
       case Material.GRASS_PATH | Material.SOIL => return Some(new ItemStack(Material.DIRT))
-      case Material.MOB_SPAWNER => return None
-      case Material.ENDER_PORTAL_FRAME => return None
-      case Material.ENDER_PORTAL => return None
+      case Material.MOB_SPAWNER | Material.ENDER_PORTAL_FRAME | Material.ENDER_PORTAL => return None
       case _ =>
     }
 

--- a/src/main/scala/com/github/unchama/seichiassist/util/BreakUtil.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/util/BreakUtil.scala
@@ -136,7 +136,7 @@ object BreakUtil {
             case others@_ => others
           }
           .filter {
-            case Material.GRASS_PATH | Material.SOIL | Material.MOB_SPAWNER => false
+            case Material.GRASS_PATH | Material.SOIL | Material.MOB_SPAWNER | Material.ENDER_PORTAL_FRAME | Material.ENDER_PORTAL => false
             case _ => true
           }
           .foreach(player.incrementStatistic(Statistic.MINE_BLOCK, _))
@@ -238,6 +238,8 @@ object BreakUtil {
     blockMaterial match {
       case Material.GRASS_PATH | Material.SOIL => return Some(new ItemStack(Material.DIRT))
       case Material.MOB_SPAWNER => return None
+      case Material.ENDER_PORTAL_FRAME => return None
+      case Material.ENDER_PORTAL => return None
       case _ =>
     }
 


### PR DESCRIPTION
This PR will close #388 

以下の点を変更しました。
・重なったハーフブロック、エンダーポータルフレーム、エンダーポータルを整地スキルの対象に含める
・エンダーポータルフレーム、エンダーポータルはプレイヤーの統計に引っかからず、壊してもドロップしない(モンスタースポナーと同じ挙動をする)