### PR TITLE
Open stdin in Docker container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,6 +36,7 @@ services:
         sed -i -e 's/host: .*/host: db/' /spigot/plugins/SeichiAssist/config.yml &&
         sed -i -e 's/pw: .*/pw: unchamaisgod/' /spigot/plugins/SeichiAssist/config.yml &&
         java -jar /spigot/spigot*.jar nogui"
+    stdin_open: true
   spigotb:
     build:
       context: .
@@ -58,6 +59,7 @@ services:
         sed -i -e 's/host: .*/host: db/' /spigot/plugins/SeichiAssist/config.yml &&
         sed -i -e 's/pw: .*/pw: unchamaisgod/' /spigot/plugins/SeichiAssist/config.yml &&
         java -jar /spigot/spigot*.jar nogui"
+    stdin_open: true
   bungeecord:
     build: ./docker/bungeecord
     ports:
@@ -67,6 +69,7 @@ services:
     depends_on:
       - spigota
       - spigotb
+    stdin_open: true
 
 
   phpmyadmin:


### PR DESCRIPTION
Resolves #453

Spigotは標準入力が空いていないとCPU使用率が高くなってしまうようなのでコンテナ内でも標準入力を開けてあげるようにしました。詳細は調査していませんが、多分閉じているとコンソールからコマンド受け取るスレッドがループで暴走しているんだと思います。

あと地味にデバッグのためコンソール使いたいときにattachしやすくて便利だと思うのでまとめてBungeeCordでも標準入力を開けました。

以下の環境でstdin_open無しだとCPU使用率が常に高く、stdin_open: trueにすると落ち着くのを確認しました。
```
Server: Docker Engine - Community
 Engine:
  Version:          18.09.6
  API version:      1.39 (minimum version 1.12)
  Go version:       go1.10.8
  Git commit:       481bc77
  Built:            Sat May  4 01:59:36 2019
  OS/Arch:          linux/amd64
  Experimental:     false
```