### PR TITLE
経験値の計算式を1.8以降のものに変更

### DIFF
--- a/src/main/scala/com/github/unchama/buildassist/ExperienceManager.java
+++ b/src/main/scala/com/github/unchama/buildassist/ExperienceManager.java
@@ -259,7 +259,7 @@ public class ExperienceManager implements IExperienceManager {
     @Override
     public int getXpNeededToLevelUp(int level) {
         Validate.isTrue(level >= 0, "Level may not be negative.");
-        return level > 30 ? 112 + (level - 30) * 9 : level >= 16 ? 37 + (level - 15) * 5 : 7 + (level - 1) * 2;
+        return level > 30 ? 112 + (level - 30) * 9 : level >= 16 ? 37 + (level - 15) * 5 : 7 + level * 2;
     }
 
     /**

--- a/src/main/scala/com/github/unchama/buildassist/ExperienceManager.java
+++ b/src/main/scala/com/github/unchama/buildassist/ExperienceManager.java
@@ -74,9 +74,9 @@ public class ExperienceManager implements IExperienceManager {
 
         for (int i = 0; i < xpTotalToReachLevel.length; i++) {
             xpTotalToReachLevel[i] =
-                    i >= 30 ? (int) (3.5 * i * i - 151.5 * i + 2220) :
-                            i >= 16 ? (int) (1.5 * i * i - 29.5 * i + 360) :
-                                    17 * i;
+                    i >= 30 ? (int) (4.5 * i * i - 162.5 * i + 2220) :
+                            i >= 16 ? (int) (2.5 * i * i - 40.5 * i + 360) :
+                                    i * i + 6 * i;
         }
     }
 
@@ -261,7 +261,7 @@ public class ExperienceManager implements IExperienceManager {
     @Override
     public int getXpNeededToLevelUp(int level) {
         Validate.isTrue(level >= 0, "Level may not be negative.");
-        return level > 30 ? 62 + (level - 30) * 7 : level >= 16 ? 17 + (level - 15) * 3 : 17;
+        return level > 30 ? 112 + (level - 30) * 9 : level >= 16 ? 37 + (level - 15) * 5 : 7 + (level - 1) * 2;
     }
 
     /**

--- a/src/main/scala/com/github/unchama/buildassist/ExperienceManager.java
+++ b/src/main/scala/com/github/unchama/buildassist/ExperienceManager.java
@@ -72,11 +72,8 @@ public class ExperienceManager implements IExperienceManager {
     private static void initLookupTables(int maxLevel) {
         xpTotalToReachLevel = new int[maxLevel];
 
-        for (int i = 0; i < xpTotalToReachLevel.length; i++) {
-            xpTotalToReachLevel[i] =
-                    i >= 30 ? (int) (4.5 * i * i - 162.5 * i + 2220) :
-                            i >= 16 ? (int) (2.5 * i * i - 40.5 * i + 360) :
-                                    i * i + 6 * i;
+        for (int i = 1; i < xpTotalToReachLevel.length; i++) {
+            xpTotalToReachLevel[i] = xpTotalToReachLevel[i-1] + getXpNeededToLevelUp(i-1);
         }
     }
 
@@ -93,8 +90,7 @@ public class ExperienceManager implements IExperienceManager {
         int curExp = 7; // level 1
 
         while (curExp <= exp) {
-            level++;
-            curExp += level >= 30 ? 112 + (level - 30) * 9 : level >= 15 ? 37 + (level - 15) * 5 : 7 + level * 2;
+            curExp += getXpNeededToLevelUp(++level);
         }
         return level;
     }
@@ -259,7 +255,7 @@ public class ExperienceManager implements IExperienceManager {
     @Override
     public int getXpNeededToLevelUp(int level) {
         Validate.isTrue(level >= 0, "Level may not be negative.");
-        return level > 30 ? 112 + (level - 30) * 9 : level >= 16 ? 37 + (level - 15) * 5 : 7 + level * 2;
+        return level >= 31 ? 112 + (level - 30) * 9 : level >= 16 ? 37 + (level - 15) * 5 : 7 + level * 2;
     }
 
     /**

--- a/src/main/scala/com/github/unchama/buildassist/ExperienceManager.java
+++ b/src/main/scala/com/github/unchama/buildassist/ExperienceManager.java
@@ -91,12 +91,10 @@ public class ExperienceManager implements IExperienceManager {
     private static int calculateLevelForExp(int exp) {
         int level = 0;
         int curExp = 7; // level 1
-        int incr = 10;
 
         while (curExp <= exp) {
-            curExp += incr;
             level++;
-            incr += (level % 2 == 0) ? 3 : 4;
+            curExp += level >= 30 ? 112 + (level - 30) * 9 : level >= 15 ? 37 + (level - 15) * 5 : 7 + level * 2;
         }
         return level;
     }

--- a/src/main/scala/com/github/unchama/buildassist/ExperienceManager.java
+++ b/src/main/scala/com/github/unchama/buildassist/ExperienceManager.java
@@ -73,7 +73,7 @@ public class ExperienceManager implements IExperienceManager {
         xpTotalToReachLevel = new int[maxLevel];
 
         for (int i = 1; i < xpTotalToReachLevel.length; i++) {
-            xpTotalToReachLevel[i] = xpTotalToReachLevel[i-1] + getXpNeededToLevelUp(i-1);
+            xpTotalToReachLevel[i] = xpTotalToReachLevel[i-1] + calculateXpNeededToLevelUp(i-1);
         }
     }
 
@@ -90,9 +90,19 @@ public class ExperienceManager implements IExperienceManager {
         int curExp = 7; // level 1
 
         while (curExp <= exp) {
-            curExp += getXpNeededToLevelUp(++level);
+            curExp += calculateXpNeededToLevelUp(++level);
         }
         return level;
+    }
+
+    /**
+     * Calculate the amount of XP needed for level up.
+     *
+     * @param level The level to check for.
+     * @return The amount of XP needed for level up.
+     */
+    private static int calculateXpNeededToLevelUp(int level){
+        return level >= 31 ? 112 + (level - 30) * 9 : level >= 16 ? 37 + (level - 15) * 5 : 7 + level * 2;
     }
 
     /**
@@ -255,7 +265,7 @@ public class ExperienceManager implements IExperienceManager {
     @Override
     public int getXpNeededToLevelUp(int level) {
         Validate.isTrue(level >= 0, "Level may not be negative.");
-        return level >= 31 ? 112 + (level - 30) * 9 : level >= 16 ? 37 + (level - 15) * 5 : 7 + level * 2;
+        return calculateXpNeededToLevelUp(level);
     }
 
     /**

--- a/src/main/scala/com/github/unchama/seichiassist/util/exp/ExperienceManager.java
+++ b/src/main/scala/com/github/unchama/seichiassist/util/exp/ExperienceManager.java
@@ -247,7 +247,6 @@ public class ExperienceManager implements IExperienceManager {
      * Return the total XP needed to be the given level.
      *
      * @param level The level to check for.
-     
      * @return The amount of XP needed for the level.
      * @throws IllegalArgumentException if the level is less than 0 or greater than the current hard maximum
      */

--- a/src/main/scala/com/github/unchama/seichiassist/util/exp/ExperienceManager.java
+++ b/src/main/scala/com/github/unchama/seichiassist/util/exp/ExperienceManager.java
@@ -240,7 +240,7 @@ public class ExperienceManager implements IExperienceManager {
     @Override
     public int getXpNeededToLevelUp(int level) {
         Validate.isTrue(level >= 0, "Level may not be negative.");
-        return level > 30 ? 112 + (level - 30) * 9 : level >= 16 ? 37 + (level - 15) * 5 : 7 + (level - 1) * 2;
+        return level > 30 ? 112 + (level - 30) * 9 : level >= 16 ? 37 + (level - 15) * 5 : 7 + level * 2;
     }
 
     /**

--- a/src/main/scala/com/github/unchama/seichiassist/util/exp/ExperienceManager.java
+++ b/src/main/scala/com/github/unchama/seichiassist/util/exp/ExperienceManager.java
@@ -53,11 +53,8 @@ public class ExperienceManager implements IExperienceManager {
     private static void initLookupTables(int maxLevel) {
         xpTotalToReachLevel = new int[maxLevel];
 
-        for (int i = 0; i < xpTotalToReachLevel.length; i++) {
-            xpTotalToReachLevel[i] =
-                    i >= 30 ? (int) (4.5 * i * i - 162.5 * i + 2220) :
-                            i >= 16 ? (int) (2.5 * i * i - 40.5 * i + 360) :
-                                    i * i + 6 * i;
+        for (int i = 1; i < xpTotalToReachLevel.length; i++) {
+            xpTotalToReachLevel[i] = xpTotalToReachLevel[i-1] + getXpNeededToLevelUp(i-1);
         }
     }
 
@@ -74,8 +71,7 @@ public class ExperienceManager implements IExperienceManager {
         int curExp = 7; // level 1
 
         while (curExp <= exp) {
-            level++;
-            curExp += level >= 30 ? 112 + (level - 30) * 9 : level >= 15 ? 37 + (level - 15) * 5 : 7 + level * 2;
+            curExp += getXpNeededToLevelUp(++level);
         }
         return level;
     }
@@ -240,7 +236,7 @@ public class ExperienceManager implements IExperienceManager {
     @Override
     public int getXpNeededToLevelUp(int level) {
         Validate.isTrue(level >= 0, "Level may not be negative.");
-        return level > 30 ? 112 + (level - 30) * 9 : level >= 16 ? 37 + (level - 15) * 5 : 7 + level * 2;
+        return level >= 31 ? 112 + (level - 30) * 9 : level >= 16 ? 37 + (level - 15) * 5 : 7 + level * 2;
     }
 
     /**

--- a/src/main/scala/com/github/unchama/seichiassist/util/exp/ExperienceManager.java
+++ b/src/main/scala/com/github/unchama/seichiassist/util/exp/ExperienceManager.java
@@ -54,7 +54,7 @@ public class ExperienceManager implements IExperienceManager {
         xpTotalToReachLevel = new int[maxLevel];
 
         for (int i = 1; i < xpTotalToReachLevel.length; i++) {
-            xpTotalToReachLevel[i] = xpTotalToReachLevel[i-1] + getXpNeededToLevelUp(i-1);
+            xpTotalToReachLevel[i] = xpTotalToReachLevel[i-1] + calculateXpNeededToLevelUp(i-1);
         }
     }
 
@@ -71,9 +71,19 @@ public class ExperienceManager implements IExperienceManager {
         int curExp = 7; // level 1
 
         while (curExp <= exp) {
-            curExp += getXpNeededToLevelUp(++level);
+            curExp += calculateXpNeededToLevelUp(++level);
         }
         return level;
+    }
+
+    /**
+     * Calculate the amount of XP needed for level up.
+     *
+     * @param level The level to check for.
+     * @return The amount of XP needed for level up.
+     */
+    private static int calculateXpNeededToLevelUp(int level){
+        return level >= 31 ? 112 + (level - 30) * 9 : level >= 16 ? 37 + (level - 15) * 5 : 7 + level * 2;
     }
 
     /**
@@ -236,7 +246,7 @@ public class ExperienceManager implements IExperienceManager {
     @Override
     public int getXpNeededToLevelUp(int level) {
         Validate.isTrue(level >= 0, "Level may not be negative.");
-        return level >= 31 ? 112 + (level - 30) * 9 : level >= 16 ? 37 + (level - 15) * 5 : 7 + level * 2;
+        return calculateXpNeededToLevelUp(level);
     }
 
     /**

--- a/src/main/scala/com/github/unchama/seichiassist/util/exp/ExperienceManager.java
+++ b/src/main/scala/com/github/unchama/seichiassist/util/exp/ExperienceManager.java
@@ -55,9 +55,9 @@ public class ExperienceManager implements IExperienceManager {
 
         for (int i = 0; i < xpTotalToReachLevel.length; i++) {
             xpTotalToReachLevel[i] =
-                    i >= 30 ? (int) (3.5 * i * i - 151.5 * i + 2220) :
-                            i >= 16 ? (int) (1.5 * i * i - 29.5 * i + 360) :
-                                    17 * i;
+                    i >= 30 ? (int) (4.5 * i * i - 162.5 * i + 2220) :
+                            i >= 16 ? (int) (2.5 * i * i - 40.5 * i + 360) :
+                                    i * i + 6 * i;
         }
     }
 
@@ -72,12 +72,10 @@ public class ExperienceManager implements IExperienceManager {
     private static int calculateLevelForExp(int exp) {
         int level = 0;
         int curExp = 7; // level 1
-        int incr = 10;
 
         while (curExp <= exp) {
-            curExp += incr;
             level++;
-            incr += (level % 2 == 0) ? 3 : 4;
+            curExp += level >= 30 ? 112 + (level - 30) * 9 : level >= 15 ? 37 + (level - 15) * 5 : 7 + level * 2;
         }
         return level;
     }
@@ -242,13 +240,14 @@ public class ExperienceManager implements IExperienceManager {
     @Override
     public int getXpNeededToLevelUp(int level) {
         Validate.isTrue(level >= 0, "Level may not be negative.");
-        return level > 30 ? 62 + (level - 30) * 7 : level >= 16 ? 17 + (level - 15) * 3 : 17;
+        return level > 30 ? 112 + (level - 30) * 9 : level >= 16 ? 37 + (level - 15) * 5 : 7 + (level - 1) * 2;
     }
 
     /**
      * Return the total XP needed to be the given level.
      *
      * @param level The level to check for.
+     
      * @return The amount of XP needed for the level.
      * @throws IllegalArgumentException if the level is less than 0 or greater than the current hard maximum
      */


### PR DESCRIPTION
経験値の計算式が1.8より前のものだったので1.8以降のものに変更しました

```
Total experience =
level2 + 6 × level (at levels 0–16)
2.5 × level2 – 40.5 × level + 360 (at levels 17–31)
4.5 × level2 – 162.5 × level + 2220 (at levels 32+)
```

See https://minecraft.gamepedia.com/Experience