### PR TITLE
経験値瓶を一つにまとめる

### DIFF
--- a/src/main/scala/com/github/unchama/seichiassist/SeichiAssist.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/SeichiAssist.scala
@@ -36,7 +36,7 @@ import com.github.unchama.seichiassist.task.global.{HalfHourRankingRoutine, Play
 import com.github.unchama.util.{ActionStatus, ClassUtils}
 import org.bukkit.ChatColor._
 import org.bukkit.command.{Command, CommandSender}
-import org.bukkit.entity.Entity
+import org.bukkit.entity.{Entity, ThrownExpBottle}
 import org.bukkit.event.Listener
 import org.bukkit.plugin.java.JavaPlugin
 import org.bukkit.{Bukkit, Material}
@@ -61,6 +61,11 @@ class SeichiAssist extends JavaPlugin() {
   val magicEffectEntityScope: SingleResourceScope[IO, Entity] = {
     import PluginExecutionContexts.asyncShift
     ResourceScope.unsafeCreateSingletonScope
+  }
+
+  val thrownExpBottleScope: ResourceScope[IO, ThrownExpBottle] = {
+    import PluginExecutionContexts.asyncShift
+    ResourceScope.unsafeCreate
   }
 
   /**
@@ -250,7 +255,7 @@ class SeichiAssist extends JavaPlugin() {
     Seq(
       new PlayerJoinListener(),
       new PlayerQuitListener(),
-      new PlayerClickListener(),
+      new PlayerClickListener(thrownExpBottleScope),
       new PlayerBlockBreakListener(),
       new PlayerInventoryListener(),
       new EntityListener(),
@@ -336,6 +341,7 @@ class SeichiAssist extends JavaPlugin() {
     lockedBlockChunkScope.releaseAll.unsafeRunSync()
     arrowSkillProjectileScope.releaseAll.unsafeRunSync()
     magicEffectEntityScope.releaseAll.value.unsafeRunSync()
+    thrownExpBottleScope.releaseAll.unsafeRunSync()
 
     //sqlコネクションチェック
     SeichiAssist.databaseGateway.ensureConnection()

--- a/src/main/scala/com/github/unchama/seichiassist/SeichiAssist.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/SeichiAssist.scala
@@ -255,7 +255,8 @@ class SeichiAssist extends JavaPlugin() {
     Seq(
       new PlayerJoinListener(),
       new PlayerQuitListener(),
-      new PlayerClickListener(thrownExpBottleScope),
+      new PlayerClickListener(),
+      new ExpBottleStackUsageController(thrownExpBottleScope),
       new PlayerBlockBreakListener(),
       new PlayerInventoryListener(),
       new EntityListener(),

--- a/src/main/scala/com/github/unchama/seichiassist/SeichiAssist.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/SeichiAssist.scala
@@ -22,7 +22,6 @@ import com.github.unchama.seichiassist.data.player.PlayerData
 import com.github.unchama.seichiassist.data.{GachaPrize, MineStackGachaData, RankData}
 import com.github.unchama.seichiassist.database.DatabaseGateway
 import com.github.unchama.seichiassist.domain.minecraft.UuidRepository
-import com.github.unchama.seichiassist.expbottlestack.bukkit.listeners.ExpBottleStackUsageController
 import com.github.unchama.seichiassist.infrastructure.ScalikeJDBCConfiguration
 import com.github.unchama.seichiassist.infrastructure.migration.loggers.{PersistedItemsMigrationSlf4jLogger, PlayerItemsMigrationSlf4jLogger, WorldLevelMigrationSlf4jLogger}
 import com.github.unchama.seichiassist.infrastructure.migration.repositories.{PersistedItemsMigrationVersionRepository, PlayerItemsMigrationVersionRepository, WorldLevelItemsMigrationVersionRepository}

--- a/src/main/scala/com/github/unchama/seichiassist/expbottlestack/EntryPoints.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/expbottlestack/EntryPoints.scala
@@ -1,0 +1,20 @@
+package com.github.unchama.seichiassist.expbottlestack
+
+import cats.effect.IO
+import com.github.unchama.generic.effect.ResourceScope
+import com.github.unchama.generic.effect.unsafe.EffectEnvironment
+import com.github.unchama.seichiassist.SubsystemEntryPoints
+import com.github.unchama.seichiassist.expbottlestack.bukkit.listeners.ExpBottleStackUsageController
+import org.bukkit.entity.ThrownExpBottle
+
+object EntryPoints {
+  def wired(implicit managedBottleScope: ResourceScope[IO, ThrownExpBottle],
+            effectEnvironment: EffectEnvironment): SubsystemEntryPoints = {
+    SubsystemEntryPoints(
+      listenersToBeRegistered = Seq(
+        new ExpBottleStackUsageController()
+      ),
+      commandsToBeRegistered = Map()
+    )
+  }
+}

--- a/src/main/scala/com/github/unchama/seichiassist/expbottlestack/bukkit/listeners/ExpBottleStackUsageController.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/expbottlestack/bukkit/listeners/ExpBottleStackUsageController.scala
@@ -35,7 +35,12 @@ class ExpBottleStackUsageController(implicit managedBottleScope: ResourceScope[I
 
   @EventHandler
   def onExpBottleHitBlock(event: ExpBottleEvent): Unit = {
-    managedBottleScope.release(event.getEntity).unsafeRunSync()
+    val bottle = event.getEntity
+
+    if (managedBottleScope.isTracked(bottle).unsafeRunSync()) {
+      event.setExperience(0)
+      managedBottleScope.release(event.getEntity).unsafeRunSync()
+    }
   }
 
   //　経験値瓶を持った状態でのShift右クリック…一括使用

--- a/src/main/scala/com/github/unchama/seichiassist/expbottlestack/bukkit/listeners/ExpBottleStackUsageController.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/expbottlestack/bukkit/listeners/ExpBottleStackUsageController.scala
@@ -1,20 +1,21 @@
-package com.github.unchama.seichiassist.listener
+package com.github.unchama.seichiassist.expbottlestack.bukkit.listeners
 
 import cats.effect.{IO, Resource}
 import com.github.unchama.generic.effect.ResourceScope
 import com.github.unchama.generic.effect.unsafe.EffectEnvironment
-import org.bukkit.{Location, Material}
 import org.bukkit.entity.{ExperienceOrb, ThrownExpBottle}
 import org.bukkit.event.block.Action
 import org.bukkit.event.entity.ExpBottleEvent
 import org.bukkit.event.player.PlayerInteractEvent
 import org.bukkit.event.{EventHandler, Listener}
 import org.bukkit.inventory.ItemStack
+import org.bukkit.{Location, Material}
 
 import scala.util.Random
 
-class ExpBottleStackUsageController(managedBottleScope: ResourceScope[IO, ThrownExpBottle])
-                                   (implicit effectEnvironment: EffectEnvironment) extends Listener {
+class ExpBottleStackUsageController(implicit managedBottleScope: ResourceScope[IO, ThrownExpBottle],
+                                    effectEnvironment: EffectEnvironment) extends Listener {
+
   @EventHandler
   def onExpBottleHitBlock(event: ExpBottleEvent): Unit = {
     managedBottleScope.release(event.getEntity).unsafeRunSync()

--- a/src/main/scala/com/github/unchama/seichiassist/expbottlestack/domain/BottleCount.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/expbottlestack/domain/BottleCount.scala
@@ -1,0 +1,15 @@
+package com.github.unchama.seichiassist.expbottlestack.domain
+
+import cats.effect.Sync
+
+import scala.util.Random
+
+case class BottleCount(amount: Int) extends AnyVal {
+
+  // 経験値瓶一つに付きもたらされる経験値量は3..11。ソースはGamepedia
+  def randomlyGenerateExpAmount[F[_] : Sync]: F[Int] = Sync[F].delay {
+    (1 to amount)
+      .map(_ => Random.nextInt(9 /* Exclusive */) + 3)
+      .sum
+  }
+}

--- a/src/main/scala/com/github/unchama/seichiassist/listener/ExpBottleStackUsageController.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/listener/ExpBottleStackUsageController.scala
@@ -1,0 +1,69 @@
+package com.github.unchama.seichiassist.listener
+
+import cats.effect.{IO, Resource}
+import com.github.unchama.generic.effect.ResourceScope
+import com.github.unchama.generic.effect.unsafe.EffectEnvironment
+import org.bukkit.{Location, Material}
+import org.bukkit.entity.{ExperienceOrb, ThrownExpBottle}
+import org.bukkit.event.block.Action
+import org.bukkit.event.entity.ExpBottleEvent
+import org.bukkit.event.player.PlayerInteractEvent
+import org.bukkit.event.{EventHandler, Listener}
+import org.bukkit.inventory.ItemStack
+
+import scala.util.Random
+
+class ExpBottleStackUsageController(managedBottleScope: ResourceScope[IO, ThrownExpBottle])
+                                   (implicit effectEnvironment: EffectEnvironment) extends Listener {
+  @EventHandler
+  def onExpBottleHitBlock(event: ExpBottleEvent): Unit = {
+    managedBottleScope.release(event.getEntity).unsafeRunSync()
+  }
+
+  //　経験値瓶を持った状態でのShift右クリック…一括使用
+  @EventHandler
+  def onPlayerRightClickExpBottleEvent(event: PlayerInteractEvent): Unit = {
+    val player = event.getPlayer
+    val playerInventory = player.getInventory
+    val action = event.getAction
+
+    // 経験値瓶を持った状態でShift右クリックをした場合
+    if (player.isSneaking
+      && playerInventory.getItemInMainHand != null
+      && playerInventory.getItemInMainHand.getType == Material.EXP_BOTTLE
+      && (action == Action.RIGHT_CLICK_AIR || action == Action.RIGHT_CLICK_BLOCK)) {
+
+      // 一つに付きもたらされる経験値量は3..11。ソースはGamepedia
+      val exp = {
+        val expBottleAmount = playerInventory.getItemInMainHand.getAmount
+        (0 until expBottleAmount).map(_ => Random.nextInt(9 /* Exclusive */) + 3).sum
+      }
+
+      def spawnOrbAt(location: Location): IO[Unit] = IO {
+        val orb = location.getWorld.spawn(
+          location,
+          classOf[ExperienceOrb]
+        )
+        orb.setExperience(exp)
+      }
+
+      def bottleResourceSpawningAt(loc: Location): Resource[IO, ThrownExpBottle] = {
+        import cats.implicits._
+        Resource
+          .make(
+            IO(loc.getWorld.spawn(loc, classOf[ThrownExpBottle]))
+          ) { e =>
+            spawnOrbAt(e.getLocation) >> IO(e.remove())
+          }
+      }
+
+      effectEnvironment.runEffectAsync(
+        "経験値瓶の消費を待つ",
+        managedBottleScope.useTracked(bottleResourceSpawningAt(player.getLocation)) { _ => IO.never }
+      )
+
+      playerInventory.setItemInMainHand(new ItemStack(Material.AIR))
+      event.setCancelled(true)
+    }
+  }
+}

--- a/src/main/scala/com/github/unchama/seichiassist/listener/PlayerClickListener.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/listener/PlayerClickListener.scala
@@ -45,8 +45,10 @@ class PlayerClickListener(implicit effectEnvironment: EffectEnvironment) extends
   private val gachaDataList = SeichiAssist.gachadatalist
   
   // TODO: ビンはいくつなげても一つなのでSingletonでよい (?)
+  import com.github.unchama.generic.effect.ResourceScope
+  import com.github.unchama.generic.effect.ResourceScope.SingleResourceScope
   private val bottleScope: SingleResourceScope[IO, ThrownExpBottle] = {
-    import PluginExecutionContexts.asyncShift
+    import com.github.unchama.seichiassist.concurrent.PluginExecutionContexts.asyncShift
     ResourceScope.unsafeCreateSingletonScope
   }
   //アクティブスキル処理
@@ -436,7 +438,7 @@ class PlayerClickListener(implicit effectEnvironment: EffectEnvironment) extends
 
       def resource[E <: Entity](loc: Location, runtimeClass: Class[E], onRelease: (E) => Unit): Resource[IO, E] = {
             Resource.make(
-              IO(spawnLocation.getWorld.spawn(loc, runtimeClass))
+              IO(loc.getWorld.spawn(loc, runtimeClass))
             )(e =>
               IO(onRelease(e))
             )

--- a/src/main/scala/com/github/unchama/seichiassist/listener/PlayerClickListener.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/listener/PlayerClickListener.scala
@@ -1,5 +1,7 @@
 package com.github.unchama.seichiassist.listener
 
+import java.util.function.Consumer
+
 import cats.effect.IO
 import com.github.unchama.generic.effect.TryableFiber
 import com.github.unchama.generic.effect.unsafe.EffectEnvironment
@@ -18,14 +20,16 @@ import com.github.unchama.util.bukkit.ItemStackUtil
 import com.github.unchama.util.external.ExternalPlugins
 import net.md_5.bungee.api.chat.{HoverEvent, TextComponent}
 import org.bukkit.ChatColor._
-import org.bukkit.entity.ThrownExpBottle
+import org.bukkit.entity.{ExperienceOrb, ThrownExpBottle}
 import org.bukkit.event.block.Action
 import org.bukkit.event.player.PlayerInteractEvent
 import org.bukkit.event.{EventHandler, Listener}
 import org.bukkit.inventory.{EquipmentSlot, ItemStack}
+import org.bukkit.metadata.{FixedMetadataValue, MetadataValue}
 import org.bukkit.{GameMode, Material, Sound}
 
 import scala.collection.mutable
+import scala.util.Random
 
 class PlayerClickListener(implicit effectEnvironment: EffectEnvironment) extends Listener {
 
@@ -427,8 +431,13 @@ class PlayerClickListener(implicit effectEnvironment: EffectEnvironment) extends
 
       val count = playerInventory.getItemInMainHand.getAmount
 
-      (0 until count).foreach { _ => player.launchProjectile(classOf[ThrownExpBottle]) }
+      // TODO: ThrownExpBottleには経験値の量を操作するAPIが付随していない
+      // val proj = player.launchProjectile(classOf[ThrownExpBottle])
+      // 一つに付きもたらされる経験値量は3..11。ソースはGamepedia
+      val exp = (0 until count).map(_ => Random.nextInt(8) + 3).sum
 
+      // とりあえず経験値オーブをスポーンさせておく
+      player.getWorld.spawn(player.getLocation, classOf[ExperienceOrb], { (_: ExperienceOrb).setExperience(exp) })
       playerInventory.setItemInMainHand(new ItemStack(Material.AIR))
       event.setCancelled(true)
     }

--- a/src/main/scala/com/github/unchama/seichiassist/listener/PlayerClickListener.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/listener/PlayerClickListener.scala
@@ -434,7 +434,7 @@ class PlayerClickListener(implicit effectEnvironment: EffectEnvironment) extends
       // TODO: ThrownExpBottleには経験値の量を操作するAPIが付随していない
       // val proj = player.launchProjectile(classOf[ThrownExpBottle])
       // 一つに付きもたらされる経験値量は3..11。ソースはGamepedia
-      val exp = (0 until count).map(_ => Random.nextInt(8) + 3).sum
+      val exp = (0 until count).map(_ => Random.nextInt(9 /* Exclusive */) + 3).sum
 
       // とりあえず経験値オーブをスポーンさせておく
       player.getWorld.spawn(player.getLocation, classOf[ExperienceOrb], { (_: ExperienceOrb).setExperience(exp) })

--- a/src/main/scala/com/github/unchama/seichiassist/listener/PlayerClickListener.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/listener/PlayerClickListener.scala
@@ -436,9 +436,9 @@ class PlayerClickListener(implicit effectEnvironment: EffectEnvironment) extends
 
       def resource[E <: Entity](loc: Location, runtimeClass: Class[E], onRelease: (E) => Unit): Resource[IO, E] = {
             Resource.make(
-              IO(spawnLocation.getWorld.spawn(spawnLocation, tag))
+              IO(spawnLocation.getWorld.spawn(loc, runtimeClass))
             )(e =>
-              IO(e.remove())
+              IO(onRelease(e))
             )
       }
       // 一つに付きもたらされる経験値量は3..11。ソースはGamepedia

--- a/src/main/scala/com/github/unchama/seichiassist/listener/PlayerClickListener.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/listener/PlayerClickListener.scala
@@ -1,8 +1,8 @@
 package com.github.unchama.seichiassist.listener
 
-import cats.effect.{IO, Resource}
+import cats.effect.IO
+import com.github.unchama.generic.effect.TryableFiber
 import com.github.unchama.generic.effect.unsafe.EffectEnvironment
-import com.github.unchama.generic.effect.{ResourceScope, TryableFiber}
 import com.github.unchama.seichiassist.data.GachaPrize
 import com.github.unchama.seichiassist.effects.player.CommonSoundEffects
 import com.github.unchama.seichiassist.menus.stickmenu.StickMenu
@@ -18,19 +18,15 @@ import com.github.unchama.util.bukkit.ItemStackUtil
 import com.github.unchama.util.external.ExternalPlugins
 import net.md_5.bungee.api.chat.{HoverEvent, TextComponent}
 import org.bukkit.ChatColor._
-import org.bukkit.entity.{ExperienceOrb, ThrownExpBottle}
 import org.bukkit.event.block.Action
-import org.bukkit.event.entity.ExpBottleEvent
 import org.bukkit.event.player.PlayerInteractEvent
 import org.bukkit.event.{EventHandler, Listener}
-import org.bukkit.inventory.{EquipmentSlot, ItemStack}
-import org.bukkit.{GameMode, Location, Material, Sound}
+import org.bukkit.inventory.EquipmentSlot
+import org.bukkit.{GameMode, Material, Sound}
 
 import scala.collection.mutable
-import scala.util.Random
 
-class PlayerClickListener(managedBottleScope: ResourceScope[IO, ThrownExpBottle])
-                         (implicit effectEnvironment: EffectEnvironment) extends Listener {
+class PlayerClickListener(implicit effectEnvironment: EffectEnvironment) extends Listener {
 
   import com.github.unchama.seichiassist.concurrent.PluginExecutionContexts.{syncShift, timer}
   import com.github.unchama.targetedeffect._
@@ -412,58 +408,6 @@ class PlayerClickListener(managedBottleScope: ResourceScope[IO, ThrownExpBottle]
         //インベントリを開く
         player.openInventory(playerdata.pocketInventory)
       }
-    }
-  }
-
-  @EventHandler
-  def onExpBottleHitBlock(event: ExpBottleEvent): Unit = {
-    managedBottleScope.release(event.getEntity).unsafeRunSync()
-  }
-
-  //　経験値瓶を持った状態でのShift右クリック…一括使用
-  @EventHandler
-  def onPlayerRightClickExpBottleEvent(event: PlayerInteractEvent): Unit = {
-    val player = event.getPlayer
-    val playerInventory = player.getInventory
-    val action = event.getAction
-
-    // 経験値瓶を持った状態でShift右クリックをした場合
-    if (player.isSneaking
-      && playerInventory.getItemInMainHand != null
-      && playerInventory.getItemInMainHand.getType == Material.EXP_BOTTLE
-      && (action == Action.RIGHT_CLICK_AIR || action == Action.RIGHT_CLICK_BLOCK)) {
-
-      // 一つに付きもたらされる経験値量は3..11。ソースはGamepedia
-      val exp = {
-        val expBottleAmount = playerInventory.getItemInMainHand.getAmount
-        (0 until expBottleAmount).map(_ => Random.nextInt(9 /* Exclusive */) + 3).sum
-      }
-
-      def spawnOrbAt(location: Location): IO[Unit] = IO {
-        val orb = location.getWorld.spawn(
-          location,
-          classOf[ExperienceOrb]
-        )
-        orb.setExperience(exp)
-      }
-
-      def bottleResourceSpawningAt(loc: Location): Resource[IO, ThrownExpBottle] = {
-        import cats.implicits._
-        Resource
-          .make(
-            IO(loc.getWorld.spawn(loc, classOf[ThrownExpBottle]))
-          ) { e =>
-            spawnOrbAt(e.getLocation) >> IO(e.remove())
-          }
-      }
-
-      effectEnvironment.runEffectAsync(
-        "経験値瓶の消費を待つ",
-        managedBottleScope.useTracked(bottleResourceSpawningAt(player.getLocation)) { _ => IO.never }
-      )
-
-      playerInventory.setItemInMainHand(new ItemStack(Material.AIR))
-      event.setCancelled(true)
     }
   }
 

--- a/src/main/scala/com/github/unchama/seichiassist/listener/PlayerClickListener.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/listener/PlayerClickListener.scala
@@ -1,7 +1,5 @@
 package com.github.unchama.seichiassist.listener
 
-import java.util.function.Consumer
-
 import cats.effect.IO
 import com.github.unchama.generic.effect.TryableFiber
 import com.github.unchama.generic.effect.unsafe.EffectEnvironment
@@ -452,10 +450,6 @@ class PlayerClickListener(implicit effectEnvironment: EffectEnvironment) extends
           waitForCollision
       }
       
-
-      // とりあえず経験値オーブをスポーンさせておく
-      player.getWorld.spawn(player.getLocation, classOf[ExperienceOrb], { (_: ExperienceOrb).setExperience(exp) })
-      player.getWorld.playSound(player.getLocation, Sound.BLOCK_GLASS_BREAK, 1.0F, 1.0F)
       playerInventory.setItemInMainHand(new ItemStack(Material.AIR))
 
       event.setCancelled(true)

--- a/src/main/scala/com/github/unchama/seichiassist/listener/PlayerClickListener.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/listener/PlayerClickListener.scala
@@ -18,13 +18,13 @@ import com.github.unchama.util.bukkit.ItemStackUtil
 import com.github.unchama.util.external.ExternalPlugins
 import net.md_5.bungee.api.chat.{HoverEvent, TextComponent}
 import org.bukkit.ChatColor._
-import org.bukkit.entity.{ExperienceOrb, ThrownExpBottle}
+import org.bukkit.entity.{ExperienceOrb, ThrownExpBottle, Entity}
 import org.bukkit.event.block.Action
 import org.bukkit.event.player.PlayerInteractEvent
 import org.bukkit.event.{EventHandler, Listener}
 import org.bukkit.inventory.{EquipmentSlot, ItemStack}
 import org.bukkit.metadata.{FixedMetadataValue, MetadataValue}
-import org.bukkit.{GameMode, Material, Sound}
+import org.bukkit.{GameMode, Material, Sound, Location}
 
 import scala.collection.mutable
 import scala.util.Random

--- a/src/main/scala/com/github/unchama/seichiassist/listener/PlayerClickListener.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/listener/PlayerClickListener.scala
@@ -438,7 +438,9 @@ class PlayerClickListener(implicit effectEnvironment: EffectEnvironment) extends
 
       // とりあえず経験値オーブをスポーンさせておく
       player.getWorld.spawn(player.getLocation, classOf[ExperienceOrb], { (_: ExperienceOrb).setExperience(exp) })
+      player.getWorld.playSound(player.getLocation, Sound.BLOCK_GLASS_BREAK, 1.0F, 1.0F)
       playerInventory.setItemInMainHand(new ItemStack(Material.AIR))
+
       event.setCancelled(true)
     }
   }

--- a/src/main/scala/com/github/unchama/seichiassist/listener/PlayerClickListener.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/listener/PlayerClickListener.scala
@@ -446,7 +446,10 @@ class PlayerClickListener(implicit effectEnvironment: EffectEnvironment) extends
       
       val waitForCollision = IO.sleep(100.ticks)(IO.timer(ExecutionContext.global))
       // TODO: これちゃんと解放される？
-      bottleScope.useTracked(location, classOf[ThrownExpBottle], e => resource(location, classOf[ExperienceOrb], orb => orb.setExperience(exp))) { proj => 
+      bottleScope.useTracked(location, classOf[ThrownExpBottle], e => { 
+        e.remove
+        resource(location, classOf[ExperienceOrb], orb => orb.setExperience(exp))
+      }) { proj => 
           waitForCollision
       }
       

--- a/src/main/scala/com/github/unchama/seichiassist/listener/PlayerClickListener.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/listener/PlayerClickListener.scala
@@ -449,11 +449,9 @@ class PlayerClickListener(implicit effectEnvironment: EffectEnvironment) extends
       val waitForCollision = IO.sleep(100.ticks)(IO.timer(ExecutionContext.global))
       // TODO: これちゃんと解放される？
       val location = player.getLocation
-      bottleScope.useTracked(location, classOf[ThrownExpBottle], e => { 
+      bottleScope.useTracked(location, classOf[ThrownExpBottle]) { e => 
         e.remove
-        resource(location, classOf[ExperienceOrb], orb => orb.setExperience(exp))
-      }) { proj => 
-          waitForCollision
+        resource(location, classOf[ExperienceOrb]) {orb => orb.setExperience(exp)}
       }
       
       playerInventory.setItemInMainHand(new ItemStack(Material.AIR))

--- a/src/main/scala/com/github/unchama/seichiassist/listener/PlayerClickListener.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/listener/PlayerClickListener.scala
@@ -435,7 +435,7 @@ class PlayerClickListener(implicit effectEnvironment: EffectEnvironment) extends
       && (action == Action.RIGHT_CLICK_AIR || action == Action.RIGHT_CLICK_BLOCK)) {
 
       val count = playerInventory.getItemInMainHand.getAmount
-
+      import cats.effect.{IO, Resource}
       def resource[E <: Entity](loc: Location, runtimeClass: Class[E], onRelease: (E) => Unit): Resource[IO, E] = {
             Resource.make(
               IO(loc.getWorld.spawn(loc, runtimeClass))
@@ -449,8 +449,7 @@ class PlayerClickListener(implicit effectEnvironment: EffectEnvironment) extends
       val waitForCollision = IO.sleep(100.ticks)(IO.timer(ExecutionContext.global))
       // TODO: これちゃんと解放される？
       val location = player.getLocation
-      bottleScope.useTracked(location, classOf[ThrownExpBottle]) { e => 
-        e.remove
+      bottleScope.useTracked(BukkitResources.vanishingEntityResource(location, classOf[ThrownExpBottle])) { e => 
         resource(location, classOf[ExperienceOrb]) {orb => orb.setExperience(exp)}
       }
       

--- a/src/main/scala/com/github/unchama/seichiassist/listener/PlayerClickListener.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/listener/PlayerClickListener.scala
@@ -446,6 +446,7 @@ class PlayerClickListener(implicit effectEnvironment: EffectEnvironment) extends
       
       val waitForCollision = IO.sleep(100.ticks)(IO.timer(ExecutionContext.global))
       // TODO: これちゃんと解放される？
+      val location = player.getLocation
       bottleScope.useTracked(location, classOf[ThrownExpBottle], e => { 
         e.remove
         resource(location, classOf[ExperienceOrb], orb => orb.setExperience(exp))


### PR DESCRIPTION
close #541 
経験値の量をいじるメソッドがAPIに生えてなかったので瓶のスポーンを削除する代わりにオーブのスポーンを追加
なお、既存の装置に影響が出ることを避けるために、EntitySpawnEventをリッスンして瓶のスポーンをキャンセルするようなことは行わない