### PR TITLE
ハロウィンイベントに伴う限定アイテムの追加及びその処理

### DIFF
--- a/src/main/scala/com/github/unchama/seichiassist/SeichiAssist.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/SeichiAssist.scala
@@ -24,7 +24,6 @@ import com.github.unchama.seichiassist.data.{GachaPrize, MineStackGachaData, Ran
 import com.github.unchama.seichiassist.database.DatabaseGateway
 import com.github.unchama.seichiassist.infrastructure.ScalikeJDBCConfiguration
 import com.github.unchama.seichiassist.listener._
-import com.github.unchama.seichiassist.listener.HalloweenItemListener
 import com.github.unchama.seichiassist.listener.new_year_event.NewYearsEvent
 import com.github.unchama.seichiassist.meta.subsystem.StatefulSubsystem
 import com.github.unchama.seichiassist.minestack.{MineStackObj, MineStackObjectCategory}

--- a/src/main/scala/com/github/unchama/seichiassist/SeichiAssist.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/SeichiAssist.scala
@@ -24,6 +24,7 @@ import com.github.unchama.seichiassist.data.{GachaPrize, MineStackGachaData, Ran
 import com.github.unchama.seichiassist.database.DatabaseGateway
 import com.github.unchama.seichiassist.infrastructure.ScalikeJDBCConfiguration
 import com.github.unchama.seichiassist.listener._
+import com.github.unchama.seichiassist.listener.HalloweenItemListener
 import com.github.unchama.seichiassist.listener.new_year_event.NewYearsEvent
 import com.github.unchama.seichiassist.meta.subsystem.StatefulSubsystem
 import com.github.unchama.seichiassist.minestack.{MineStackObj, MineStackObjectCategory}
@@ -286,7 +287,8 @@ class SeichiAssist extends JavaPlugin() {
       new RegionInventoryListener(),
       new WorldRegenListener(),
       new ChatInterceptor(List(globalChatInterceptionScope)),
-      new MenuHandler()
+      new MenuHandler(),
+      new HalloweenItemListener()
     )
       .concat(repositories)
       .concat(subsystems.flatMap(_.listeners))

--- a/src/main/scala/com/github/unchama/seichiassist/commands/EventCommand.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/commands/EventCommand.scala
@@ -2,6 +2,7 @@ package com.github.unchama.seichiassist.commands
 
 import cats.effect.IO
 import com.github.unchama.seichiassist.commands.contextual.builder.BuilderTemplates.playerCommandBuilder
+import com.github.unchama.seichiassist.data.HalloweenItemData
 import com.github.unchama.seichiassist.listener.new_year_event.{NewYearBagListener, NewYearItemListener}
 import com.github.unchama.seichiassist.util.Util
 import com.github.unchama.targetedeffect.TargetedEffect._
@@ -11,17 +12,23 @@ import org.bukkit.entity.Player
 object EventCommand {
   import com.github.unchama.targetedeffect._
 
-  val grantEffect: TargetedEffect[Player] =
+  val newYearGrantEffect: TargetedEffect[Player] =
     Util.grantItemStacksEffect(
       NewYearBagListener.getNewYearBag,
       NewYearItemListener.getNewYearApple
     )
 
+  val halloweenGrantEffect: TargetedEffect[Player] =
+    Util.grantItemStacksEffect(
+      HalloweenItemData.getHalloweenPotion
+    )
+
   val executor: TabExecutor = playerCommandBuilder
     .execution { context =>
       val effect = context.args.yetToBeParsed match {
-        case "get" :: _ => emptyEffect
-        case _ => grantEffect
+        case "newyear" :: _ => newYearGrantEffect
+        case "halloween" :: _ => halloweenGrantEffect
+        case _ => emptyEffect
       }
 
       IO.pure(effect)

--- a/src/main/scala/com/github/unchama/seichiassist/data/HalloweenItemData.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/data/HalloweenItemData.scala
@@ -4,6 +4,8 @@ import scala.collection.immutable.{List, Set}
 import scala.jdk.CollectionConverters._
 import scala.util.chaining._
 import java.util._
+
+import de.tr7zw.itemnbtapi.NBTItem
 import org.bukkit.Bukkit
 import org.bukkit.ChatColor
 import org.bukkit.Color.fromRGB
@@ -33,7 +35,10 @@ object HalloweenItemData {
 
     val potion = new ItemStack(Material.POTION, 1)
     potion.setItemMeta(potionMeta)
-    potion
+
+    val nbtItem = new NBTItem(potion)
+    nbtItem.setByte(NBTTagConstants.typeIdTag, 1.toByte)
+    nbtItem.getItem
   }
 
   private val halloweenPotionItemFlags = Set(
@@ -57,4 +62,16 @@ object HalloweenItemData {
       s"${ChatColor.RESET}${ChatColor.GRAY}MEBIUS育成中の時などにご利用ください"
     )
   }.asJava
+
+  private object NBTTagConstants {
+    val typeIdTag = "halloweenPotionTypeId"
+  }
+
+  def isHalloweenPotion(itemStack: ItemStack): Boolean = {
+    if (itemStack != null && itemStack.getType != Material.AIR) {
+      new NBTItem(itemStack).getByte(NBTTagConstants.typeIdTag) != 0
+    } else {
+      false
+    }
+  }
 }

--- a/src/main/scala/com/github/unchama/seichiassist/data/HalloweenItemData.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/data/HalloweenItemData.scala
@@ -1,0 +1,54 @@
+package com.github.unchama.seichiassist.data
+
+import scala.collection.mutable
+import scala.jdk.CollectionConverters._
+import java.util._
+import org.bukkit.Bukkit
+import org.bukkit.ChatColor
+import org.bukkit.Color.fromRGB
+import org.bukkit.enchantments.Enchantment
+import org.bukkit.Material
+import org.bukkit.inventory.{ItemFlag, ItemStack}
+import org.bukkit.inventory.meta.{ItemMeta, PotionMeta}
+import org.bukkit.potion.{PotionEffect, PotionEffectType}
+
+object HalloweenItemData {
+  def getHalloweenPotion: ItemStack = {
+    val potion: ItemStack = new ItemStack(Material.POTION, 1)
+    val potionMeta: PotionMeta = Bukkit.getItemFactory.getItemMeta(Material.POTION).asInstanceOf[PotionMeta]
+    potionMeta.setDisplayName(s"${ChatColor.AQUA}${ChatColor.ITALIC}うんちゃまの汗")
+    potionMeta.setColor(fromRGB(1, 93, 178))
+    potionMeta.addEnchant(Enchantment.MENDING, 1, true)
+    potionMeta.setLore(halloweenPotionLoreList())
+    halloweenPotionItemFlags.foreach {
+      potionMeta.addItemFlags(_)
+    }
+    halloweenPotionEffects.foreach {
+      potionMeta.addCustomEffect(_, true)
+    }
+    potion.setItemMeta(potionMeta)
+    potion
+  }
+
+  private val halloweenPotionItemFlags = Seq(
+    ItemFlag.HIDE_ENCHANTS,
+    ItemFlag.HIDE_POTION_EFFECTS
+  )
+
+  private val halloweenPotionEffects = Seq(
+    new PotionEffect(PotionEffectType.REGENERATION, 200, 3),
+    new PotionEffect(PotionEffectType.DAMAGE_RESISTANCE, 400, 2),
+    new PotionEffect(PotionEffectType.NIGHT_VISION, 12000, 0),
+    new PotionEffect(PotionEffectType.LUCK, 6000, 0)
+  )
+
+  private def halloweenPotionLoreList() = {
+    val loreList = mutable.ListBuffer[String]()
+    loreList += ""
+    val year = Calendar.getInstance().get(Calendar.YEAR)
+    loreList += s"${ChatColor.RESET}${ChatColor.GRAY}${year}ハロウィンイベント限定品"
+    loreList += s"${ChatColor.RESET}${ChatColor.GRAY}敵に囲まれてピンチの時や"
+    loreList += s"${ChatColor.RESET}${ChatColor.GRAY}MEBIUS育成中の時などにご利用ください"
+    loreList.toList
+  }.asJava
+}

--- a/src/main/scala/com/github/unchama/seichiassist/data/HalloweenItemData.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/data/HalloweenItemData.scala
@@ -30,7 +30,7 @@ object HalloweenItemData {
     potion
   }
 
-  private val halloweenPotionItemFlags = Seq(
+  private val halloweenPotionItemFlags = Set(
     ItemFlag.HIDE_ENCHANTS,
     ItemFlag.HIDE_POTION_EFFECTS
   )
@@ -43,12 +43,12 @@ object HalloweenItemData {
   )
 
   private def halloweenPotionLoreList() = {
-    val loreList = mutable.ListBuffer[String]()
-    loreList += ""
     val year = Calendar.getInstance().get(Calendar.YEAR)
-    loreList += s"${ChatColor.RESET}${ChatColor.GRAY}${year}ハロウィンイベント限定品"
-    loreList += s"${ChatColor.RESET}${ChatColor.GRAY}敵に囲まれてピンチの時や"
-    loreList += s"${ChatColor.RESET}${ChatColor.GRAY}MEBIUS育成中の時などにご利用ください"
-    loreList.toList
+    List(
+      "",
+      s"${ChatColor.RESET}${ChatColor.GRAY}${year}ハロウィンイベント限定品",
+      s"${ChatColor.RESET}${ChatColor.GRAY}敵に囲まれてピンチの時や",
+      s"${ChatColor.RESET}${ChatColor.GRAY}MEBIUS育成中の時などにご利用ください"
+    )
   }.asJava
 }

--- a/src/main/scala/com/github/unchama/seichiassist/data/HalloweenItemData.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/data/HalloweenItemData.scala
@@ -35,11 +35,11 @@ object HalloweenItemData {
     ItemFlag.HIDE_POTION_EFFECTS
   )
 
-  private val halloweenPotionEffects = Seq(
-    new PotionEffect(PotionEffectType.REGENERATION, 200, 3),
-    new PotionEffect(PotionEffectType.DAMAGE_RESISTANCE, 400, 2),
-    new PotionEffect(PotionEffectType.NIGHT_VISION, 12000, 0),
-    new PotionEffect(PotionEffectType.LUCK, 6000, 0)
+  private val halloweenPotionEffects = Set(
+    new PotionEffect(PotionEffectType.REGENERATION, 20 * 10, 3),
+    new PotionEffect(PotionEffectType.DAMAGE_RESISTANCE, 20 * 20, 2),
+    new PotionEffect(PotionEffectType.NIGHT_VISION, 20 * 60 * 10, 0),
+    new PotionEffect(PotionEffectType.LUCK, 20 * 60 * 5, 0)
   )
 
   private def halloweenPotionLoreList() = {

--- a/src/main/scala/com/github/unchama/seichiassist/data/HalloweenItemData.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/data/HalloweenItemData.scala
@@ -1,7 +1,8 @@
 package com.github.unchama.seichiassist.data
 
-import scala.collection.mutable
+import scala.collection.immutable.{List, Set}
 import scala.jdk.CollectionConverters._
+import scala.util.chaining._
 import java.util._
 import org.bukkit.Bukkit
 import org.bukkit.ChatColor
@@ -14,18 +15,23 @@ import org.bukkit.potion.{PotionEffect, PotionEffectType}
 
 object HalloweenItemData {
   def getHalloweenPotion(): ItemStack = {
-    val potion = new ItemStack(Material.POTION, 1)
     val potionMeta: PotionMeta = Bukkit.getItemFactory.getItemMeta(Material.POTION).asInstanceOf[PotionMeta]
-    potionMeta.setDisplayName(s"${ChatColor.AQUA}${ChatColor.ITALIC}うんちゃまの汗")
-    potionMeta.setColor(fromRGB(1, 93, 178))
-    potionMeta.addEnchant(Enchantment.MENDING, 1, true)
-    potionMeta.setLore(halloweenPotionLoreList())
-    halloweenPotionItemFlags.foreach {
-      potionMeta.addItemFlags(_)
-    }
-    halloweenPotionEffects.foreach {
-      potionMeta.addCustomEffect(_, true)
-    }
+      .tap(_.setDisplayName(s"${ChatColor.AQUA}${ChatColor.ITALIC}うんちゃまの汗"))
+      .tap(_.setColor(fromRGB(1, 93, 178)))
+      .tap(_.addEnchant(Enchantment.MENDING, 1, true))
+      .tap(_.setLore(halloweenPotionLoreList()))
+      .tap(meta =>
+        halloweenPotionItemFlags.foreach(flg =>
+          meta.addItemFlags(flg)
+        )
+      )
+      .tap(meta =>
+        halloweenPotionEffects.foreach (ef =>
+          meta.addCustomEffect(ef, true)
+        )
+      )
+
+    val potion = new ItemStack(Material.POTION, 1)
     potion.setItemMeta(potionMeta)
     potion
   }

--- a/src/main/scala/com/github/unchama/seichiassist/data/HalloweenItemData.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/data/HalloweenItemData.scala
@@ -13,8 +13,8 @@ import org.bukkit.inventory.meta.{ItemMeta, PotionMeta}
 import org.bukkit.potion.{PotionEffect, PotionEffectType}
 
 object HalloweenItemData {
-  def getHalloweenPotion: ItemStack = {
-    val potion: ItemStack = new ItemStack(Material.POTION, 1)
+  def getHalloweenPotion(): ItemStack = {
+    val potion = new ItemStack(Material.POTION, 1)
     val potionMeta: PotionMeta = Bukkit.getItemFactory.getItemMeta(Material.POTION).asInstanceOf[PotionMeta]
     potionMeta.setDisplayName(s"${ChatColor.AQUA}${ChatColor.ITALIC}うんちゃまの汗")
     potionMeta.setColor(fromRGB(1, 93, 178))

--- a/src/main/scala/com/github/unchama/seichiassist/listener/HalloweenItemListener.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/listener/HalloweenItemListener.scala
@@ -1,12 +1,8 @@
 package com.github.unchama.seichiassist.listener
 
-import org.bukkit.entity.Player
-import org.bukkit.event.player.{PlayerItemConsumeEvent, PlayerJoinEvent}
+import org.bukkit.event.player.PlayerItemConsumeEvent
 import org.bukkit.event.{EventHandler, Listener}
-import org.bukkit.inventory.meta.PotionMeta
 import com.github.unchama.seichiassist.data.HalloweenItemData.isHalloweenPotion
-import com.github.unchama.seichiassist.util.Util
-import org.bukkit.Bukkit
 import org.bukkit.potion.{PotionEffect, PotionEffectType}
 
 class HalloweenItemListener extends Listener {

--- a/src/main/scala/com/github/unchama/seichiassist/listener/HalloweenItemListener.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/listener/HalloweenItemListener.scala
@@ -4,7 +4,7 @@ import org.bukkit.entity.Player
 import org.bukkit.event.player.{PlayerItemConsumeEvent, PlayerJoinEvent}
 import org.bukkit.event.{EventHandler, Listener}
 import org.bukkit.inventory.meta.PotionMeta
-import com.github.unchama.seichiassist.data.HalloweenItemData
+import com.github.unchama.seichiassist.data.HalloweenItemData.isHalloweenPotion
 import com.github.unchama.seichiassist.util.Util
 import org.bukkit.Bukkit
 import org.bukkit.potion.{PotionEffect, PotionEffectType}
@@ -19,9 +19,7 @@ class HalloweenItemListener extends Listener {
 
     if (!item.hasItemMeta || !itemMeta.hasLore || !itemMeta.isInstanceOf[PotionMeta]) return
 
-    val hwPotionMeta = HalloweenItemData.getHalloweenPotion().getItemMeta
-
-    if (itemMeta.getLore == hwPotionMeta.getLore && itemMeta.getDisplayName == hwPotionMeta.getDisplayName) {
+    if (isHalloweenPotion(item)) {
       // 1.12.2では、Saturationのポーションは効果がないので、PotionEffectとして直接Playerに付与する
       // 10分
       player.addPotionEffect(new PotionEffect(PotionEffectType.SATURATION, 20 * 60 * 10, 0), true)

--- a/src/main/scala/com/github/unchama/seichiassist/listener/HalloweenItemListener.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/listener/HalloweenItemListener.scala
@@ -22,7 +22,9 @@ class HalloweenItemListener extends Listener {
     val hwPotionMeta = HalloweenItemData.getHalloweenPotion().getItemMeta
 
     if (itemMeta.getLore == hwPotionMeta.getLore && itemMeta.getDisplayName == hwPotionMeta.getDisplayName) {
-      player.addPotionEffect(new PotionEffect(PotionEffectType.SATURATION, 12000, 0), true)
+      // 1.12.2では、Saturationのポーションは効果がないので、PotionEffectとして直接Playerに付与する
+      // 10分
+      player.addPotionEffect(new PotionEffect(PotionEffectType.SATURATION, 20 * 60 * 10, 0), true)
     }
   }
 }

--- a/src/main/scala/com/github/unchama/seichiassist/listener/HalloweenItemListener.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/listener/HalloweenItemListener.scala
@@ -1,0 +1,28 @@
+package com.github.unchama.seichiassist.listener
+
+import org.bukkit.entity.Player
+import org.bukkit.event.player.{PlayerItemConsumeEvent, PlayerJoinEvent}
+import org.bukkit.event.{EventHandler, Listener}
+import org.bukkit.inventory.meta.PotionMeta
+import com.github.unchama.seichiassist.data.HalloweenItemData
+import com.github.unchama.seichiassist.util.Util
+import org.bukkit.Bukkit
+import org.bukkit.potion.{PotionEffect, PotionEffectType}
+
+class HalloweenItemListener extends Listener {
+
+  @EventHandler
+  def onPlayerConsumeHalloweenPotion(event: PlayerItemConsumeEvent): Unit = {
+    val player = event.getPlayer
+    val item = event.getItem
+    val itemMeta = item.getItemMeta
+
+    if (!item.hasItemMeta || !itemMeta.hasLore || !itemMeta.isInstanceOf[PotionMeta]) return
+
+    val hwPotionMeta = HalloweenItemData.getHalloweenPotion().getItemMeta
+
+    if (itemMeta.getLore == hwPotionMeta.getLore && itemMeta.getDisplayName == hwPotionMeta.getDisplayName) {
+      player.addPotionEffect(new PotionEffect(PotionEffectType.SATURATION, 12000, 0), true)
+    }
+  }
+}

--- a/src/main/scala/com/github/unchama/seichiassist/listener/HalloweenItemListener.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/listener/HalloweenItemListener.scala
@@ -13,16 +13,10 @@ class HalloweenItemListener extends Listener {
 
   @EventHandler
   def onPlayerConsumeHalloweenPotion(event: PlayerItemConsumeEvent): Unit = {
-    val player = event.getPlayer
-    val item = event.getItem
-    val itemMeta = item.getItemMeta
-
-    if (!item.hasItemMeta || !itemMeta.hasLore || !itemMeta.isInstanceOf[PotionMeta]) return
-
-    if (isHalloweenPotion(item)) {
+    if (isHalloweenPotion(event.getItem)) {
       // 1.12.2では、Saturationのポーションは効果がないので、PotionEffectとして直接Playerに付与する
       // 10分
-      player.addPotionEffect(new PotionEffect(PotionEffectType.SATURATION, 20 * 60 * 10, 0), true)
+      event.getPlayer.addPotionEffect(new PotionEffect(PotionEffectType.SATURATION, 20 * 60 * 10, 0), true)
     }
   }
 }


### PR DESCRIPTION
参照：https://red.minecraftserver.jp/issues/8420

チケットでは「満腹度回復や多少のエンチャントのついたカボチャ」となっているが、そうしなかった理由を以下で挙げておく。
* チケットのままだとあまり使われなさそうな未来になる（APOLLOかぶれないし）
* かぼちゃをつけたりはずしたりの検知がCustomEnchantmentsを見る限り難しそうだった

したがって、「APOLLOの少し弱い補助的なポーション」という体で今回の実装にした。