### PR TITLE
金床使用時にMebiusかどうかの判定が正しく作動しないのを修正

### DIFF
--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/mebius/bukkit/codec/BukkitMebiusItemStackCodec.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/mebius/bukkit/codec/BukkitMebiusItemStackCodec.scala
@@ -41,13 +41,10 @@ object BukkitMebiusItemStackCodec {
     val nameTag = "mebiusName"
   }
 
-  def isMebius(itemStack: ItemStack): Boolean = {
-    if (itemStack != null && itemStack.getType != Material.AIR) {
-      new NBTItem(itemStack).getByte(NBTTagConstants.typeIdTag) != 0
-    } else {
-      false
+  def isMebius(itemStack: ItemStack): Boolean =
+    itemStack != null && itemStack.getType != Material.AIR && {
+      new NBTItem(itemStack).getByte(NBTTagConstants.typeIdTag) == 1
     }
-  }
 
   /**
    * (必ずしも有効な`MebiusProperty`を持つとは限らない)実体から `ItemStack` をデコードする。


### PR DESCRIPTION
This closes #654 .
数字キーを使って移動させたときにキャンセルするのはちょっとわからなかったので、それ以外の部分を直しました。