### PR TITLE
クリスマスイベント関連アイテムの追加

### DIFF
--- a/src/main/scala/com/github/unchama/seasonalevents/SeasonalEvents.scala
+++ b/src/main/scala/com/github/unchama/seasonalevents/SeasonalEvents.scala
@@ -1,6 +1,7 @@
 package com.github.unchama.seasonalevents
 
 import com.github.unchama.seasonalevents.anniversary.AnniversaryListener
+import com.github.unchama.seasonalevents.christmas.ChristmasItemListener
 import com.github.unchama.seasonalevents.commands.EventCommand
 import com.github.unchama.seasonalevents.halloween.HalloweenItemListener
 import com.github.unchama.seasonalevents.limitedlogin.LimitedLoginBonusGifter
@@ -13,6 +14,7 @@ class SeasonalEvents(instance: SeichiAssist) {
   def onEnable(): Unit = {
     List(
       AnniversaryListener,
+      ChristmasItemListener,
       HalloweenItemListener,
       LimitedLoginBonusGifter,
       SeizonsikiListener,

--- a/src/main/scala/com/github/unchama/seasonalevents/SeasonalEvents.scala
+++ b/src/main/scala/com/github/unchama/seasonalevents/SeasonalEvents.scala
@@ -14,7 +14,7 @@ class SeasonalEvents(instance: SeichiAssist) {
   def onEnable(): Unit = {
     List(
       AnniversaryListener,
-      ChristmasItemListener,
+      new ChristmasItemListener(instance),
       HalloweenItemListener,
       LimitedLoginBonusGifter,
       SeizonsikiListener,

--- a/src/main/scala/com/github/unchama/seasonalevents/christmas/Christmas.scala
+++ b/src/main/scala/com/github/unchama/seasonalevents/christmas/Christmas.scala
@@ -10,6 +10,4 @@ object Christmas {
   val END_DATE: LocalDate = LocalDate.of(EVENT_YEAR, 12, 26)
 
   def isInEvent: Boolean = dateRangeAsSequence(START_DATE, END_DATE).contains(LocalDate.now())
-
-  def isChristmas: Boolean = LocalDate.of(EVENT_YEAR, 12, 25).isEqual(LocalDate.now())
 }

--- a/src/main/scala/com/github/unchama/seasonalevents/christmas/Christmas.scala
+++ b/src/main/scala/com/github/unchama/seasonalevents/christmas/Christmas.scala
@@ -1,0 +1,15 @@
+package com.github.unchama.seasonalevents.christmas
+
+import java.time.LocalDate
+
+import com.github.unchama.seasonalevents.Util.dateRangeAsSequence
+
+object Christmas {
+  val EVENT_YEAR: Int = 2020
+  val START_DATE: LocalDate = LocalDate.of(EVENT_YEAR, 12, 15)
+  val END_DATE: LocalDate = LocalDate.of(EVENT_YEAR, 12, 26)
+
+  def isInEvent: Boolean = dateRangeAsSequence(START_DATE, END_DATE).contains(LocalDate.now())
+
+  def isChristmas: Boolean = LocalDate.of(EVENT_YEAR, 12, 25).isEqual(LocalDate.now())
+}

--- a/src/main/scala/com/github/unchama/seasonalevents/christmas/Christmas.scala
+++ b/src/main/scala/com/github/unchama/seasonalevents/christmas/Christmas.scala
@@ -2,9 +2,10 @@ package com.github.unchama.seasonalevents.christmas
 
 import java.time.LocalDate
 
-import com.github.unchama.seasonalevents.Util.dateRangeAsSequence
+import com.github.unchama.seasonalevents.Util.{dateRangeAsSequence, validateItemDropRate}
 
 object Christmas {
+  val itemDropRate: Double = validateItemDropRate(0.002)
   val EVENT_YEAR: Int = 2020
   val START_DATE: LocalDate = LocalDate.of(EVENT_YEAR, 12, 15)
   val END_DATE: LocalDate = LocalDate.of(EVENT_YEAR, 12, 26)

--- a/src/main/scala/com/github/unchama/seasonalevents/christmas/Christmas.scala
+++ b/src/main/scala/com/github/unchama/seasonalevents/christmas/Christmas.scala
@@ -2,10 +2,11 @@ package com.github.unchama.seasonalevents.christmas
 
 import java.time.LocalDate
 
-import com.github.unchama.seasonalevents.Util.{dateRangeAsSequence, validateItemDropRate}
+import com.github.unchama.seasonalevents.Util.{dateRangeAsSequence, validateItemDropRate, validateUrl}
 
 object Christmas {
   val itemDropRate: Double = validateItemDropRate(0.002)
+  val blogArticleUrl: String = validateUrl("https://www.seichi.network/post/christmas2020")
   val EVENT_YEAR: Int = 2020
   val START_DATE: LocalDate = LocalDate.of(EVENT_YEAR, 12, 15)
   val END_DATE: LocalDate = LocalDate.of(EVENT_YEAR, 12, 26)

--- a/src/main/scala/com/github/unchama/seasonalevents/christmas/ChristmasItemData.scala
+++ b/src/main/scala/com/github/unchama/seasonalevents/christmas/ChristmasItemData.scala
@@ -263,25 +263,9 @@ object ChristmasItemData {
       .pipe(_.getItem)
   }
 
-  def isChristmasPickaxe(itemStack: ItemStack): Boolean =
-    itemStack != null && itemStack.getType != Material.AIR && {
-      new NBTItem(itemStack)
-        .getByte(NBTTagConstants.typeIdTag) == 5
-    }
-
   //endregion
 
-  // SeichiAssistで呼ばれてるだけ
-  def christmasPlayerHead(head: SkullMeta): SkullMeta = {
-    val lore = List(
-      "",
-      s"$GREEN${ITALIC}大切なあなたへ。",
-      s"$YELLOW$UNDERLINE${ITALIC}Merry Christmas $EVENT_YEAR"
-    ).map(str => s"$RESET$str")
-      .asJava
-    head.setLore(lore)
-    head
-  }
+  //region hristmasSock
 
   val christmasSock: ItemStack = {
     val loreList = List(
@@ -309,6 +293,20 @@ object ChristmasItemData {
       setObject(NBTTagConstants.expiryDateTag, END_DATE)
     }
       .pipe(_.getItem)
+  }
+
+  //endregion
+
+  // SeichiAssistで呼ばれてるだけ
+  def christmasPlayerHead(head: SkullMeta): SkullMeta = {
+    val lore = List(
+      "",
+      s"$GREEN${ITALIC}大切なあなたへ。",
+      s"$YELLOW$UNDERLINE${ITALIC}Merry Christmas $EVENT_YEAR"
+    ).map(str => s"$RESET$str")
+      .asJava
+    head.setLore(lore)
+    head
   }
 
   object NBTTagConstants {

--- a/src/main/scala/com/github/unchama/seasonalevents/christmas/ChristmasItemData.scala
+++ b/src/main/scala/com/github/unchama/seasonalevents/christmas/ChristmasItemData.scala
@@ -2,8 +2,9 @@ package com.github.unchama.seasonalevents.christmas
 
 import java.time.LocalDate
 
+import com.github.unchama.seichiassist.util.Util
 import de.tr7zw.itemnbtapi.NBTItem
-import org.bukkit.ChatColor.{AQUA, GRAY, ITALIC, RESET}
+import org.bukkit.ChatColor._
 import org.bukkit.Color.fromRGB
 import org.bukkit.enchantments.Enchantment
 import org.bukkit.entity.EntityType
@@ -28,11 +29,11 @@ object ChristmasItemData {
       val year = LocalDate.now().getYear
       List(
         "",
-        s"${year}クリスマスイベント限定品",
+        s"$GRAY{year}クリスマスイベント限定品",
         "",
-        "一口で食べられます",
-        "食べると不運か幸運がランダムで付与されます"
-      ).map(str => s"$RESET$GRAY$str")
+        s"${YELLOW}一口で食べられます",
+        s"${YELLOW}食べると不運か幸運がランダムで付与されます"
+      ).map(str => s"$RESET$str")
     }.asJava
 
     val itemMeta = Bukkit.getItemFactory.getItemMeta(Material.CAKE).tap { meta =>
@@ -72,10 +73,10 @@ object ChristmasItemData {
       val year = LocalDate.now().getYear
       List(
         "",
-        s"${year}クリスマスイベント限定品",
+        s"$GRAY${year}クリスマスイベント限定品",
         "",
-        "食べると移動速度上昇か低下がランダムで付与されます"
-      ).map(str => s"$RESET$GRAY$str")
+        s"${YELLOW}食べると移動速度上昇か低下がランダムで付与されます"
+      ).map(str => s"$RESET$str")
     }.asJava
 
     val itemMeta = Bukkit.getItemFactory.getItemMeta(Material.COOKED_CHICKEN).tap { meta =>
@@ -118,10 +119,10 @@ object ChristmasItemData {
     val loreList = {
       val year = LocalDate.now().getYear
       List(
-        s"${year}クリスマスイベント限定品",
+        s"$GRAY${year}クリスマスイベント限定品",
         "",
-        "クリスマスを一人で過ごす鯖民たちの涙（血涙）を集めた瓶"
-      ).map(str => s"$RESET$GRAY$str")
+        s"${YELLOW}クリスマスを一人で過ごす鯖民たちの涙（血涙）を集めた瓶"
+      ).map(str => s"$RESET$str")
     }.asJava
 
     val potionMeta = Bukkit.getItemFactory.getItemMeta(Material.POTION).asInstanceOf[PotionMeta].tap { meta =>
@@ -160,18 +161,18 @@ object ChristmasItemData {
     val loreList = {
       val year = LocalDate.now().getYear
       List(
-        "迷彩 I",
+        s"${GRAY}迷彩 I",
         "",
-        s"${year}クリスマスイベント限定品",
+        s"$GRAY${year}クリスマスイベント限定品",
         "",
-        "敵から気づかれにくくなります",
-        "「鮮やかに、キメろ。」"
-      ).map(str => s"$RESET$GRAY$str")
+        s"${WHITE}敵から気づかれにくくなります",
+        s"$WHITE「鮮やかに、キメろ。」"
+      ).map(str => s"$RESET$str")
     }.asJava
 
     val itemMeta = Bukkit.getItemFactory.getItemMeta(Material.DIAMOND_CHESTPLATE).tap { meta =>
       import meta._
-      setDisplayName(s"$AQUA${ITALIC}迷彩服")
+      setDisplayName(s"$AQUA${ITALIC}迷彩服（胴）")
       setLore(loreList)
       enchants.foreach(ench => addEnchant(ench, 1, true))
     }

--- a/src/main/scala/com/github/unchama/seasonalevents/christmas/ChristmasItemData.scala
+++ b/src/main/scala/com/github/unchama/seasonalevents/christmas/ChristmasItemData.scala
@@ -1,7 +1,5 @@
 package com.github.unchama.seasonalevents.christmas
 
-import java.time.LocalDate
-
 import com.github.unchama.seasonalevents.christmas.Christmas.{END_DATE, EVENT_YEAR}
 import com.github.unchama.seichiassist.util.Util
 import de.tr7zw.itemnbtapi.NBTItem
@@ -20,18 +18,16 @@ import scala.util.chaining._
 
 object ChristmasItemData {
 
+  private val christmasItemBaseLore = List(
+    "",
+    s"$RESET$GRAY${EVENT_YEAR}クリスマスイベント限定品",
+    "",
+  )
+
   //region ChristmasCake
 
-  private val christmasCakeBaseLore: List[String] = List(
-    "",
-    s"$GRAY${EVENT_YEAR}クリスマスイベント限定品",
-    "",
-    s"${YELLOW}一口で食べられます",
-    s"${YELLOW}食べると不運か幸運がランダムで付与されます"
-  ).map(str => s"$RESET$str")
-
-  private def christmasCakePieceLore(remainingPieces: Int): List[String] =
-    List(s"$RESET${GRAY}残り摂食可能回数: $remainingPieces")
+  private def christmasCakePieceLore(remainingPieces: Int) =
+    List(s"$RESET${GRAY}残り摂食可能回数: $remainingPieces/${christmasCakeDefaultPieces}回")
 
   val christmasCakeDefaultPieces = 7
 
@@ -40,7 +36,12 @@ object ChristmasItemData {
       ItemFlag.HIDE_ENCHANTS
     )
     val loreList = {
-      christmasCakeBaseLore ::: christmasCakePieceLore(pieces)
+      val cakeBaseLore: List[String] = List(
+        s"${YELLOW}置かずに食べられます",
+        s"${YELLOW}食べると不運か幸運がランダムで付与されます"
+      ).map(str => s"$RESET$str")
+
+      christmasItemBaseLore ::: cakeBaseLore ::: christmasCakePieceLore(pieces)
     }.asJava
 
     val itemMeta = Bukkit.getItemFactory.getItemMeta(Material.CAKE).tap { meta =>
@@ -77,13 +78,11 @@ object ChristmasItemData {
       ItemFlag.HIDE_ENCHANTS
     )
     val loreList = {
-      val year = LocalDate.now().getYear
-      List(
-        "",
-        s"$GRAY${year}クリスマスイベント限定品",
-        "",
-        s"${YELLOW}食べると移動速度上昇か低下がランダムで付与されます"
-      ).map(str => s"$RESET$str")
+      val lore = List(
+        s"$RESET${YELLOW}食べると移動速度上昇か低下がランダムで付与されます"
+      )
+
+      christmasItemBaseLore ::: lore
     }.asJava
 
     val itemMeta = Bukkit.getItemFactory.getItemMeta(Material.COOKED_CHICKEN).tap { meta =>
@@ -124,12 +123,11 @@ object ChristmasItemData {
       new PotionEffect(PotionEffectType.REGENERATION, 20 * 20, 0)
     )
     val loreList = {
-      val year = LocalDate.now().getYear
-      List(
-        s"$GRAY${year}クリスマスイベント限定品",
-        "",
-        s"${YELLOW}クリスマスを一人で過ごす鯖民たちの涙（血涙）を集めた瓶"
-      ).map(str => s"$RESET$str")
+      val lore = List(
+        s"$RESET${YELLOW}クリスマスを一人で過ごす鯖民たちの涙（血涙）を集めた瓶"
+      )
+
+      christmasItemBaseLore ::: lore
     }.asJava
 
     val potionMeta = Bukkit.getItemFactory.getItemMeta(Material.POTION).asInstanceOf[PotionMeta].tap { meta =>
@@ -166,15 +164,13 @@ object ChristmasItemData {
       Enchantment.DURABILITY
     )
     val loreList = {
-      val year = LocalDate.now().getYear
-      List(
-        s"${GRAY}迷彩 I",
-        "",
-        s"$GRAY${year}クリスマスイベント限定品",
-        "",
-        s"${WHITE}敵から気づかれにくくなります",
-        s"$WHITE「鮮やかに、キメろ。」"
-      ).map(str => s"$RESET$str")
+      val lore = List(
+        "特殊エンチャント：迷彩 I",
+        "敵から気づかれにくくなります",
+        "「鮮やかに、キメろ。」"
+      ).map(str => s"$RESET$WHITE$str")
+
+      christmasItemBaseLore ::: lore
     }.asJava
 
     val itemMeta = Bukkit.getItemFactory.getItemMeta(Material.DIAMOND_CHESTPLATE).tap { meta =>
@@ -237,17 +233,14 @@ object ChristmasItemData {
       (Enchantment.LUCK, 1)
     )
     val loreList = {
-      val year = LocalDate.now().getYear
       val enchDescription = enchants
         .map { case (ench, lvl) => s"$RESET$GRAY${Util.getEnchantName(ench.getName, lvl)}" }
         .toList
       val lore = List(
-        "",
-        s"$GRAY${year}クリスマスイベント限定品",
-        "",
-        s"${AQUA}耐久無限"
-      ).map(str => s"$RESET$str")
-      enchDescription ::: lore
+        s"$RESET${AQUA}耐久無限"
+      )
+
+      enchDescription ::: christmasItemBaseLore ::: lore
     }.asJava
 
     val itemMeta = Bukkit.getItemFactory.getItemMeta(Material.DIAMOND_PICKAXE).tap { meta =>

--- a/src/main/scala/com/github/unchama/seasonalevents/christmas/ChristmasItemData.scala
+++ b/src/main/scala/com/github/unchama/seasonalevents/christmas/ChristmasItemData.scala
@@ -6,6 +6,7 @@ import de.tr7zw.itemnbtapi.NBTItem
 import org.bukkit.ChatColor.{AQUA, GRAY, ITALIC, RESET}
 import org.bukkit.Color.fromRGB
 import org.bukkit.enchantments.Enchantment
+import org.bukkit.entity.EntityType
 import org.bukkit.inventory.meta.PotionMeta
 import org.bukkit.inventory.{ItemFlag, ItemStack}
 import org.bukkit.potion.{PotionEffect, PotionEffectType}
@@ -85,10 +86,10 @@ object ChristmasItemData {
       itemFlags.foreach(flg => addItemFlags(flg))
     }
 
-    val cake = new ItemStack(Material.COOKED_CHICKEN, 1)
-    cake.setItemMeta(itemMeta)
+    val turkey = new ItemStack(Material.COOKED_CHICKEN, 1)
+    turkey.setItemMeta(itemMeta)
 
-    new NBTItem(cake).tap { nbtItem =>
+    new NBTItem(turkey).tap { nbtItem =>
       import nbtItem._
       setByte(NBTTagConstants.typeIdTag, 2.toByte)
     }
@@ -149,9 +150,64 @@ object ChristmasItemData {
 
   //endregion
 
+  //region ChristmasChestPlate
+
+  val ChristmasChestPlate: ItemStack = {
+    val enchants = Set(
+      Enchantment.MENDING,
+      Enchantment.DURABILITY
+    )
+    val loreList = {
+      val year = LocalDate.now().getYear
+      List(
+        "迷彩 I",
+        "",
+        s"${year}クリスマスイベント限定品",
+        "",
+        "敵から気づかれにくくなります",
+        "「鮮やかに、キメろ。」"
+      ).map(str => s"$RESET$GRAY$str")
+    }.asJava
+
+    val itemMeta = Bukkit.getItemFactory.getItemMeta(Material.DIAMOND_CHESTPLATE).tap { meta =>
+      import meta._
+      setDisplayName(s"$AQUA${ITALIC}迷彩服")
+      setLore(loreList)
+      enchants.foreach(ench => addEnchant(ench, 1, true))
+    }
+
+    val chestPlate = new ItemStack(Material.DIAMOND_CHESTPLATE, 1)
+    chestPlate.setItemMeta(itemMeta)
+
+    new NBTItem(chestPlate).tap { nbtItem =>
+      import nbtItem._
+      setByte(NBTTagConstants.typeIdTag, 4.toByte)
+      setByte(NBTTagConstants.camouflageEnchLevelTag, 1.toByte)
+    }
+      .pipe(_.getItem)
+  }
+
+  def isChristmasChestPlate(itemStack: ItemStack): Boolean =
+    itemStack != null && itemStack.getType != Material.AIR && {
+      new NBTItem(itemStack)
+        .getByte(NBTTagConstants.typeIdTag) == 4
+    }
+
+  //endregion
+
+  def calculateStandardDistance(enchLevel: Int, enemyType: EntityType): Int = {
+    val isZombie = enemyType == EntityType.ZOMBIE || enemyType == EntityType.ZOMBIE_VILLAGER
+
+    enchLevel match {
+      case 1 => if (isZombie) 20 else 10
+      case _ => if (isZombie) 40 else 20
+    }
+  }
+
   object NBTTagConstants {
     val typeIdTag = "christmasItemTypeId"
     val cakePieceTag = "christmasCakePiece"
+    val camouflageEnchLevelTag = "camouflageEnchLevel"
   }
 
 }

--- a/src/main/scala/com/github/unchama/seasonalevents/christmas/ChristmasItemData.scala
+++ b/src/main/scala/com/github/unchama/seasonalevents/christmas/ChristmasItemData.scala
@@ -2,7 +2,7 @@ package com.github.unchama.seasonalevents.christmas
 
 import java.time.LocalDate
 
-import com.github.unchama.seasonalevents.christmas.Christmas.EVENT_YEAR
+import com.github.unchama.seasonalevents.christmas.Christmas.{END_DATE, EVENT_YEAR}
 import com.github.unchama.seichiassist.util.Util
 import de.tr7zw.itemnbtapi.NBTItem
 import org.bukkit.ChatColor._
@@ -283,10 +283,39 @@ object ChristmasItemData {
     head
   }
 
+  val christmasSock: ItemStack = {
+    val loreList = List(
+      "Merry Christmas!",
+      s"クリスマスをお祝いして$RED${UNDERLINE}靴下${RESET}をどうぞ！",
+      s"$RED${UNDERLINE}アルカディア、エデン、ヴァルハラサーバー メインワールドの",
+      s"$RED${UNDERLINE}スポーン地点にいる村人に欲しい物を詰めてもらおう！"
+    ).map(str => s"$RESET$str")
+      .asJava
+
+    val itemMeta = Bukkit.getItemFactory.getItemMeta(Material.PAPER).tap { meta =>
+      import meta._
+      setDisplayName(s"${AQUA}靴下")
+      setLore(loreList)
+      addEnchant(Enchantment.DIG_SPEED, 1, true)
+      addItemFlags(ItemFlag.HIDE_ENCHANTS)
+    }
+
+    val itemStack = new ItemStack(Material.PAPER, 1)
+    itemStack.setItemMeta(itemMeta)
+
+    new NBTItem(itemStack).tap { item =>
+      import item._
+      setByte(NBTTagConstants.typeIdTag, 6.toByte)
+      setObject(NBTTagConstants.expiryDateTag, END_DATE)
+    }
+      .pipe(_.getItem)
+  }
+
   object NBTTagConstants {
     val typeIdTag = "christmasItemTypeId"
     val cakePieceTag = "christmasCakePiece"
     val camouflageEnchLevelTag = "camouflageEnchLevel"
+    val expiryDateTag = "christmasSockExpiryDate"
   }
 
 }

--- a/src/main/scala/com/github/unchama/seasonalevents/christmas/ChristmasItemData.scala
+++ b/src/main/scala/com/github/unchama/seasonalevents/christmas/ChristmasItemData.scala
@@ -22,19 +22,25 @@ object ChristmasItemData {
 
   //region ChristmasCake
 
-  val ChristmasCake: ItemStack = {
+  private val christmasCakeBaseLore: List[String] = List(
+    "",
+    s"$GRAY${EVENT_YEAR}クリスマスイベント限定品",
+    "",
+    s"${YELLOW}一口で食べられます",
+    s"${YELLOW}食べると不運か幸運がランダムで付与されます"
+  ).map(str => s"$RESET$str")
+
+  private def christmasCakePieceLore(remainingPieces: Int): List[String] =
+    List(s"$RESET${GRAY}残り摂食可能回数: $remainingPieces")
+
+  val christmasCakeDefaultPieces = 7
+
+  def christmasCake(pieces: Int): ItemStack = {
     val itemFlags = Set(
       ItemFlag.HIDE_ENCHANTS
     )
     val loreList = {
-      val year = LocalDate.now().getYear
-      List(
-        "",
-        s"$GRAY{year}クリスマスイベント限定品",
-        "",
-        s"${YELLOW}一口で食べられます",
-        s"${YELLOW}食べると不運か幸運がランダムで付与されます"
-      ).map(str => s"$RESET$str")
+      christmasCakeBaseLore ::: christmasCakePieceLore(pieces)
     }.asJava
 
     val itemMeta = Bukkit.getItemFactory.getItemMeta(Material.CAKE).tap { meta =>
@@ -51,7 +57,7 @@ object ChristmasItemData {
     new NBTItem(cake).tap { nbtItem =>
       import nbtItem._
       setByte(NBTTagConstants.typeIdTag, 1.toByte)
-      setByte(NBTTagConstants.cakePieceTag, 7.toByte)
+      setByte(NBTTagConstants.cakePieceTag, pieces.toByte)
     }
       .pipe(_.getItem)
   }

--- a/src/main/scala/com/github/unchama/seasonalevents/christmas/ChristmasItemData.scala
+++ b/src/main/scala/com/github/unchama/seasonalevents/christmas/ChristmasItemData.scala
@@ -1,0 +1,61 @@
+package com.github.unchama.seasonalevents.christmas
+
+import java.time.LocalDate
+
+import de.tr7zw.itemnbtapi.NBTItem
+import org.bukkit.ChatColor.{AQUA, GRAY, ITALIC, RESET}
+import org.bukkit.enchantments.Enchantment
+import org.bukkit.inventory.{ItemFlag, ItemStack}
+import org.bukkit.{Bukkit, Material}
+
+import scala.jdk.CollectionConverters._
+import scala.util.chaining._
+
+object ChristmasItemData {
+
+  //region ChristmasCake
+
+  val ChristmasCake: ItemStack = {
+    val itemFlags = Set(
+      ItemFlag.HIDE_ENCHANTS
+    )
+    val loreList = {
+      val year = LocalDate.now().getYear
+      List(
+        "",
+        s"${year}クリスマスイベント限定品",
+        "",
+        "一口で食べられます",
+        "食べると不運か幸運がランダムで付与されます"
+      ).map(str => s"$RESET$GRAY$str")
+    }.asJava
+
+    val itemMeta = Bukkit.getItemFactory.getItemMeta(Material.CAKE).tap { meta =>
+      import meta._
+      setDisplayName(s"$AQUA${ITALIC}まいんちゃん特製クリスマスケーキ")
+      addEnchant(Enchantment.MENDING, 1, true)
+      setLore(loreList)
+      itemFlags.foreach(flg => addItemFlags(flg))
+    }
+
+    val cake = new ItemStack(Material.CAKE, 1)
+    cake.setItemMeta(itemMeta)
+
+    new NBTItem(cake)
+      .tap(_.setByte(NBTTagConstants.typeIdTag, 1.toByte))
+      .pipe(_.getItem)
+  }
+
+  def isChristmasCake(itemStack: ItemStack): Boolean =
+    itemStack != null && itemStack.getType != Material.AIR && {
+      new NBTItem(itemStack)
+        .getByte(NBTTagConstants.typeIdTag) == 1
+    }
+
+  //endregion
+
+  private object NBTTagConstants {
+    val typeIdTag = "halloweenItemTypeId"
+  }
+
+}

--- a/src/main/scala/com/github/unchama/seasonalevents/christmas/ChristmasItemData.scala
+++ b/src/main/scala/com/github/unchama/seasonalevents/christmas/ChristmasItemData.scala
@@ -46,7 +46,7 @@ object ChristmasItemData {
 
     val itemMeta = Bukkit.getItemFactory.getItemMeta(Material.CAKE).tap { meta =>
       import meta._
-      setDisplayName(s"$AQUA${ITALIC}まいんちゃん特製クリスマスケーキ")
+      setDisplayName(s"$AQUA${ITALIC}まいんちゃんお手製クリスマスケーキ")
       addEnchant(Enchantment.MENDING, 1, true)
       setLore(loreList)
       itemFlags.foreach(flg => addItemFlags(flg))
@@ -87,7 +87,7 @@ object ChristmasItemData {
 
     val itemMeta = Bukkit.getItemFactory.getItemMeta(Material.COOKED_CHICKEN).tap { meta =>
       import meta._
-      setDisplayName(s"$AQUA${ITALIC}まいんちゃん特製ローストターキー")
+      setDisplayName(s"$AQUA${ITALIC}まいんちゃんお手製ローストターキー")
       addEnchant(Enchantment.MENDING, 1, true)
       setLore(loreList)
       itemFlags.foreach(flg => addItemFlags(flg))

--- a/src/main/scala/com/github/unchama/seasonalevents/christmas/ChristmasItemData.scala
+++ b/src/main/scala/com/github/unchama/seasonalevents/christmas/ChristmasItemData.scala
@@ -37,9 +37,9 @@ object ChristmasItemData {
     )
     val loreList = {
       val cakeBaseLore: List[String] = List(
-        s"${YELLOW}置かずに食べられます",
-        s"${YELLOW}食べると不運か幸運がランダムで付与されます"
-      ).map(str => s"$RESET$str")
+        "置かずに食べられます",
+        "食べると不運か幸運がランダムで付与されます"
+      ).map(str => s"$RESET$YELLOW$str")
 
       christmasItemBaseLore ::: cakeBaseLore ::: christmasCakePieceLore(pieces)
     }.asJava

--- a/src/main/scala/com/github/unchama/seasonalevents/christmas/ChristmasItemData.scala
+++ b/src/main/scala/com/github/unchama/seasonalevents/christmas/ChristmasItemData.scala
@@ -210,6 +210,66 @@ object ChristmasItemData {
 
   //endregion
 
+  //region THANATOSレプリカ
+
+  val ChristmasPickaxe: ItemStack = {
+    val displayName = Seq(
+      "T" -> RED,
+      "H" -> GOLD,
+      "A" -> YELLOW,
+      "N" -> GREEN,
+      "A" -> BLUE,
+      "T" -> DARK_AQUA,
+      "O" -> LIGHT_PURPLE,
+      "S" -> RED,
+      " Replica" -> WHITE
+    ).map { case (c, color) => s"$color$BOLD$ITALIC$c" }
+      .mkString
+    val enchants = Set(
+      (Enchantment.DIG_SPEED, 3),
+      (Enchantment.LUCK, 1)
+    )
+    val loreList = {
+      val year = LocalDate.now().getYear
+      val enchDescription = enchants
+        .map { case (ench, lvl) => s"$RESET$GRAY${Util.getEnchantName(ench.getName, lvl)}" }
+        .toList
+      val lore = List(
+        "",
+        s"$GRAY${year}クリスマスイベント限定品",
+        "",
+        s"${AQUA}耐久無限"
+      ).map(str => s"$RESET$str")
+      enchDescription ::: lore
+    }.asJava
+
+    val itemMeta = Bukkit.getItemFactory.getItemMeta(Material.DIAMOND_PICKAXE).tap { meta =>
+      import meta._
+      setDisplayName(displayName)
+      setLore(loreList)
+      setUnbreakable(true)
+      addItemFlags(ItemFlag.HIDE_ENCHANTS)
+      enchants.foreach { case (ench, lvl) => addEnchant(ench, lvl, true) }
+    }
+
+    val pickaxe = new ItemStack(Material.DIAMOND_PICKAXE, 1)
+    pickaxe.setItemMeta(itemMeta)
+
+    new NBTItem(pickaxe).tap { nbtItem =>
+      import nbtItem._
+      setByte(NBTTagConstants.typeIdTag, 5.toByte)
+    }
+      .pipe(_.getItem)
+  }
+
+  def isChristmasPickaxe(itemStack: ItemStack): Boolean =
+    itemStack != null && itemStack.getType != Material.AIR && {
+      new NBTItem(itemStack)
+        .getByte(NBTTagConstants.typeIdTag) == 5
+    }
+
+  //endregion
+
   object NBTTagConstants {
     val typeIdTag = "christmasItemTypeId"
     val cakePieceTag = "christmasCakePiece"

--- a/src/main/scala/com/github/unchama/seasonalevents/christmas/ChristmasItemData.scala
+++ b/src/main/scala/com/github/unchama/seasonalevents/christmas/ChristmasItemData.scala
@@ -195,13 +195,18 @@ object ChristmasItemData {
 
   //endregion
 
-  def calculateStandardDistance(enchLevel: Int, enemyType: EntityType): Int = {
+  def calculateStandardDistance(enchLevel: Int, enemyType: EntityType): Double = {
+    val rate = enchLevel match {
+      case 1 => 0.9
+      case 2 => 0.8
+      case 3 => 0.5
+      case 4 => 0.3
+      case 5 => 0.1
+      case _ => throw new IllegalArgumentException("不正なエンチャントレベルが指定されました。")
+    }
     val isZombie = enemyType == EntityType.ZOMBIE || enemyType == EntityType.ZOMBIE_VILLAGER
 
-    enchLevel match {
-      case 1 => if (isZombie) 20 else 10
-      case _ => if (isZombie) 40 else 20
-    }
+    (if (isZombie) 40 else 20) * rate
   }
 
   object NBTTagConstants {

--- a/src/main/scala/com/github/unchama/seasonalevents/christmas/ChristmasItemData.scala
+++ b/src/main/scala/com/github/unchama/seasonalevents/christmas/ChristmasItemData.scala
@@ -57,6 +57,48 @@ object ChristmasItemData {
 
   //endregion
 
+  //region ChristmasTurkey
+
+  val ChristmasTurkey: ItemStack = {
+    val itemFlags = Set(
+      ItemFlag.HIDE_ENCHANTS
+    )
+    val loreList = {
+      val year = LocalDate.now().getYear
+      List(
+        "",
+        s"${year}クリスマスイベント限定品",
+        "",
+        "食べると移動速度上昇か低下がランダムで付与されます"
+      ).map(str => s"$RESET$GRAY$str")
+    }.asJava
+
+    val itemMeta = Bukkit.getItemFactory.getItemMeta(Material.COOKED_CHICKEN).tap { meta =>
+      import meta._
+      setDisplayName(s"$AQUA${ITALIC}まいんちゃん特製ローストターキー")
+      addEnchant(Enchantment.MENDING, 1, true)
+      setLore(loreList)
+      itemFlags.foreach(flg => addItemFlags(flg))
+    }
+
+    val cake = new ItemStack(Material.COOKED_CHICKEN, 1)
+    cake.setItemMeta(itemMeta)
+
+    new NBTItem(cake).tap { nbtItem =>
+      import nbtItem._
+      setByte(NBTTagConstants.typeIdTag, 2.toByte)
+    }
+      .pipe(_.getItem)
+  }
+
+  def isChristmasTurkey(itemStack: ItemStack): Boolean =
+    itemStack != null && itemStack.getType != Material.AIR && {
+      new NBTItem(itemStack)
+        .getByte(NBTTagConstants.typeIdTag) == 2
+    }
+
+  //endregion
+
   object NBTTagConstants {
     val typeIdTag = "christmasItemTypeId"
     val cakePieceTag = "christmasCakePiece"

--- a/src/main/scala/com/github/unchama/seasonalevents/christmas/ChristmasItemData.scala
+++ b/src/main/scala/com/github/unchama/seasonalevents/christmas/ChristmasItemData.scala
@@ -193,8 +193,6 @@ object ChristmasItemData {
         .getByte(NBTTagConstants.typeIdTag) == 4
     }
 
-  //endregion
-
   def calculateStandardDistance(enchLevel: Int, enemyType: EntityType): Double = {
     val rate = enchLevel match {
       case 1 => 0.9
@@ -208,6 +206,8 @@ object ChristmasItemData {
 
     (if (isZombie) 40 else 20) * rate
   }
+
+  //endregion
 
   object NBTTagConstants {
     val typeIdTag = "christmasItemTypeId"

--- a/src/main/scala/com/github/unchama/seasonalevents/christmas/ChristmasItemData.scala
+++ b/src/main/scala/com/github/unchama/seasonalevents/christmas/ChristmasItemData.scala
@@ -4,10 +4,14 @@ import java.time.LocalDate
 
 import de.tr7zw.itemnbtapi.NBTItem
 import org.bukkit.ChatColor.{AQUA, GRAY, ITALIC, RESET}
+import org.bukkit.Color.fromRGB
 import org.bukkit.enchantments.Enchantment
+import org.bukkit.inventory.meta.PotionMeta
 import org.bukkit.inventory.{ItemFlag, ItemStack}
+import org.bukkit.potion.{PotionEffect, PotionEffectType}
 import org.bukkit.{Bukkit, Material}
 
+import scala.collection.immutable.{List, Set}
 import scala.jdk.CollectionConverters._
 import scala.util.chaining._
 
@@ -95,6 +99,52 @@ object ChristmasItemData {
     itemStack != null && itemStack.getType != Material.AIR && {
       new NBTItem(itemStack)
         .getByte(NBTTagConstants.typeIdTag) == 2
+    }
+
+  //endregion
+
+  //region ChristmasPotion
+
+  val christmasPotion: ItemStack = {
+    val itemFlags = Set(
+      ItemFlag.HIDE_ENCHANTS,
+      ItemFlag.HIDE_POTION_EFFECTS
+    )
+    val potionEffects = Set(
+      new PotionEffect(PotionEffectType.INCREASE_DAMAGE, 20 * 30, 0),
+      new PotionEffect(PotionEffectType.REGENERATION, 20 * 20, 0)
+    )
+    val loreList = {
+      val year = LocalDate.now().getYear
+      List(
+        s"${year}クリスマスイベント限定品",
+        "",
+        "クリスマスを一人で過ごす鯖民たちの涙（血涙）を集めた瓶"
+      ).map(str => s"$RESET$GRAY$str")
+    }.asJava
+
+    val potionMeta = Bukkit.getItemFactory.getItemMeta(Material.POTION).asInstanceOf[PotionMeta].tap { meta =>
+      import meta._
+      setDisplayName(s"$AQUA${ITALIC}みんなの涙")
+      setColor(fromRGB(215, 0, 58))
+      addEnchant(Enchantment.MENDING, 1, true)
+      setLore(loreList)
+      itemFlags.foreach(flg => addItemFlags(flg))
+      potionEffects.foreach(effect => addCustomEffect(effect, true))
+    }
+
+    val potion = new ItemStack(Material.POTION, 1)
+    potion.setItemMeta(potionMeta)
+
+    new NBTItem(potion)
+      .tap(_.setByte(NBTTagConstants.typeIdTag, 3.toByte))
+      .pipe(_.getItem)
+  }
+
+  def isChristmasPotion(itemStack: ItemStack): Boolean =
+    itemStack != null && itemStack.getType != Material.AIR && {
+      new NBTItem(itemStack)
+        .getByte(NBTTagConstants.typeIdTag) == 3
     }
 
   //endregion

--- a/src/main/scala/com/github/unchama/seasonalevents/christmas/ChristmasItemData.scala
+++ b/src/main/scala/com/github/unchama/seasonalevents/christmas/ChristmasItemData.scala
@@ -72,7 +72,7 @@ object ChristmasItemData {
 
   //region ChristmasTurkey
 
-  val ChristmasTurkey: ItemStack = {
+  val christmasTurkey: ItemStack = {
     val itemFlags = Set(
       ItemFlag.HIDE_ENCHANTS
     )
@@ -160,7 +160,7 @@ object ChristmasItemData {
 
   //region ChristmasChestPlate
 
-  val ChristmasChestPlate: ItemStack = {
+  val christmasChestPlate: ItemStack = {
     val enchants = Set(
       Enchantment.MENDING,
       Enchantment.DURABILITY
@@ -219,7 +219,7 @@ object ChristmasItemData {
 
   //region THANATOSレプリカ
 
-  val ChristmasPickaxe: ItemStack = {
+  val christmasPickaxe: ItemStack = {
     val displayName = Seq(
       "T" -> RED,
       "H" -> GOLD,

--- a/src/main/scala/com/github/unchama/seasonalevents/christmas/ChristmasItemData.scala
+++ b/src/main/scala/com/github/unchama/seasonalevents/christmas/ChristmasItemData.scala
@@ -41,8 +41,11 @@ object ChristmasItemData {
     val cake = new ItemStack(Material.CAKE, 1)
     cake.setItemMeta(itemMeta)
 
-    new NBTItem(cake)
-      .tap(_.setByte(NBTTagConstants.typeIdTag, 1.toByte))
+    new NBTItem(cake).tap { nbtItem =>
+      import nbtItem._
+      setByte(NBTTagConstants.typeIdTag, 1.toByte)
+      setByte(NBTTagConstants.cakePieceTag, 7.toByte)
+    }
       .pipe(_.getItem)
   }
 
@@ -54,8 +57,9 @@ object ChristmasItemData {
 
   //endregion
 
-  private object NBTTagConstants {
-    val typeIdTag = "halloweenItemTypeId"
+  object NBTTagConstants {
+    val typeIdTag = "christmasItemTypeId"
+    val cakePieceTag = "christmasCakePiece"
   }
 
 }

--- a/src/main/scala/com/github/unchama/seasonalevents/christmas/ChristmasItemData.scala
+++ b/src/main/scala/com/github/unchama/seasonalevents/christmas/ChristmasItemData.scala
@@ -2,13 +2,14 @@ package com.github.unchama.seasonalevents.christmas
 
 import java.time.LocalDate
 
+import com.github.unchama.seasonalevents.christmas.Christmas.EVENT_YEAR
 import com.github.unchama.seichiassist.util.Util
 import de.tr7zw.itemnbtapi.NBTItem
 import org.bukkit.ChatColor._
 import org.bukkit.Color.fromRGB
 import org.bukkit.enchantments.Enchantment
 import org.bukkit.entity.EntityType
-import org.bukkit.inventory.meta.PotionMeta
+import org.bukkit.inventory.meta.{PotionMeta, SkullMeta}
 import org.bukkit.inventory.{ItemFlag, ItemStack}
 import org.bukkit.potion.{PotionEffect, PotionEffectType}
 import org.bukkit.{Bukkit, Material}
@@ -269,6 +270,18 @@ object ChristmasItemData {
     }
 
   //endregion
+
+  // SeichiAssistで呼ばれてるだけ
+  def christmasPlayerHead(head: SkullMeta): SkullMeta = {
+    val lore = List(
+      "",
+      s"$GREEN${ITALIC}大切なあなたへ。",
+      s"$YELLOW$UNDERLINE${ITALIC}Merry Christmas $EVENT_YEAR"
+    ).map(str => s"$RESET$str")
+      .asJava
+    head.setLore(lore)
+    head
+  }
 
   object NBTTagConstants {
     val typeIdTag = "christmasItemTypeId"

--- a/src/main/scala/com/github/unchama/seasonalevents/christmas/ChristmasItemData.scala
+++ b/src/main/scala/com/github/unchama/seasonalevents/christmas/ChristmasItemData.scala
@@ -275,7 +275,7 @@ object ChristmasItemData {
     ).map(str => s"$RESET$str")
       .asJava
 
-    val itemMeta = Bukkit.getItemFactory.getItemMeta(Material.PAPER).tap { meta =>
+    val itemMeta = Bukkit.getItemFactory.getItemMeta(Material.LEATHER_BOOTS).tap { meta =>
       import meta._
       setDisplayName(s"${AQUA}靴下")
       setLore(loreList)
@@ -283,7 +283,7 @@ object ChristmasItemData {
       addItemFlags(ItemFlag.HIDE_ENCHANTS)
     }
 
-    val itemStack = new ItemStack(Material.PAPER, 1)
+    val itemStack = new ItemStack(Material.LEATHER_BOOTS, 1)
     itemStack.setItemMeta(itemMeta)
 
     new NBTItem(itemStack).tap { nbtItem =>

--- a/src/main/scala/com/github/unchama/seasonalevents/christmas/ChristmasItemData.scala
+++ b/src/main/scala/com/github/unchama/seasonalevents/christmas/ChristmasItemData.scala
@@ -286,8 +286,8 @@ object ChristmasItemData {
     val itemStack = new ItemStack(Material.PAPER, 1)
     itemStack.setItemMeta(itemMeta)
 
-    new NBTItem(itemStack).tap { item =>
-      import item._
+    new NBTItem(itemStack).tap { nbtItem =>
+      import nbtItem._
       setByte(NBTTagConstants.typeIdTag, 6.toByte)
       setObject(NBTTagConstants.expiryDateTag, END_DATE)
     }

--- a/src/main/scala/com/github/unchama/seasonalevents/christmas/ChristmasItemData.scala
+++ b/src/main/scala/com/github/unchama/seasonalevents/christmas/ChristmasItemData.scala
@@ -303,6 +303,11 @@ object ChristmasItemData {
 
   //endregion
 
+  val christmasMebiusLore: List[String] = List(
+    "",
+    s"$RESET${WHITE}Merry Christmas! あなたに特別なMebiusを"
+  )
+
   // SeichiAssistで呼ばれてるだけ
   def christmasPlayerHead(head: SkullMeta): SkullMeta = {
     val lore = List(

--- a/src/main/scala/com/github/unchama/seasonalevents/christmas/ChristmasItemListener.scala
+++ b/src/main/scala/com/github/unchama/seasonalevents/christmas/ChristmasItemListener.scala
@@ -160,9 +160,8 @@ class ChristmasItemListener(instance: SeichiAssist) extends Listener {
     if (!isInEvent) return
 
     event.getEntity match {
-      case entity: LivingEntity =>
-        if (entity.getType == EntityType.STRAY && entity.getKiller != null)
-          Util.randomlyDropItemAt(entity, christmasSock, itemDropRate)
+      case entity: LivingEntity if entity.getType == EntityType.STRAY && entity.getKiller != null =>
+        Util.randomlyDropItemAt(entity, christmasSock, itemDropRate)
       case _ =>
     }
   }

--- a/src/main/scala/com/github/unchama/seasonalevents/christmas/ChristmasItemListener.scala
+++ b/src/main/scala/com/github/unchama/seasonalevents/christmas/ChristmasItemListener.scala
@@ -19,8 +19,6 @@ import org.bukkit.inventory.EquipmentSlot
 import org.bukkit.potion.{PotionEffect, PotionEffectType}
 import org.bukkit.{Bukkit, Sound}
 
-import scala.util.chaining._
-
 class ChristmasItemListener(instance: SeichiAssist) extends Listener {
   @EventHandler
   def onPlayerConsumeChristmasCake(event: PlayerInteractEvent): Unit = {
@@ -42,10 +40,7 @@ class ChristmasItemListener(instance: SeichiAssist) extends Listener {
 
     val remainingPiece = new NBTItem(item).getByte(NBTTagConstants.cakePieceTag).toInt
     if (remainingPiece != 0) {
-      val newItem = new NBTItem(item)
-        // TODO Pieceの説明文も減らす
-        .tap(_.setByte(NBTTagConstants.cakePieceTag, (remainingPiece - 1).toByte))
-        .pipe(_.getItem)
+      val newItem = christmasCake(remainingPiece - 1)
       addItem(player, newItem)
     }
   }

--- a/src/main/scala/com/github/unchama/seasonalevents/christmas/ChristmasItemListener.scala
+++ b/src/main/scala/com/github/unchama/seasonalevents/christmas/ChristmasItemListener.scala
@@ -6,7 +6,7 @@ import com.github.unchama.seasonalevents.christmas.ChristmasItemData._
 import com.github.unchama.seichiassist.util.Util.{addItem, removeItemfromPlayerInventory}
 import de.tr7zw.itemnbtapi.NBTItem
 import org.bukkit.event.block.Action
-import org.bukkit.event.player.PlayerInteractEvent
+import org.bukkit.event.player.{PlayerInteractEvent, PlayerItemConsumeEvent}
 import org.bukkit.event.{EventHandler, Listener}
 import org.bukkit.inventory.EquipmentSlot
 import org.bukkit.potion.{PotionEffect, PotionEffectType}
@@ -39,5 +39,14 @@ object ChristmasItemListener extends Listener {
         .pipe(_.getItem)
       addItem(player, newItem)
     }
+  }
+
+  @EventHandler
+  def onPlayerConsumeChristmasTurkey(event: PlayerItemConsumeEvent): Unit = {
+    if (!isChristmasTurkey(event.getItem)) return
+
+    val rand = new Random().nextDouble()
+    val potionEffectType = if (rand > 0.5) PotionEffectType.SPEED else PotionEffectType.SLOW
+    event.getPlayer.addPotionEffect(new PotionEffect(potionEffectType, 20 * 30, 0), true)
   }
 }

--- a/src/main/scala/com/github/unchama/seasonalevents/christmas/ChristmasItemListener.scala
+++ b/src/main/scala/com/github/unchama/seasonalevents/christmas/ChristmasItemListener.scala
@@ -2,6 +2,7 @@ package com.github.unchama.seasonalevents.christmas
 
 import java.util.Random
 
+import com.github.unchama.seasonalevents.Util
 import com.github.unchama.seasonalevents.christmas.Christmas.{isInEvent, itemDropRate}
 import com.github.unchama.seasonalevents.christmas.ChristmasItemData._
 import com.github.unchama.seichiassist.util.Util.{addItem, dropItem, isPlayerInventoryFull, removeItemfromPlayerInventory}
@@ -9,9 +10,9 @@ import com.github.unchama.seichiassist.{ManagedWorld, SeichiAssist}
 import de.tr7zw.itemnbtapi.NBTItem
 import org.bukkit.ChatColor.{AQUA, RED}
 import org.bukkit.entity.EntityType._
-import org.bukkit.entity.Player
+import org.bukkit.entity.{EntityType, LivingEntity, Player}
 import org.bukkit.event.block.{Action, BlockBreakEvent}
-import org.bukkit.event.entity.EntityTargetLivingEntityEvent
+import org.bukkit.event.entity.{EntityDeathEvent, EntityTargetLivingEntityEvent}
 import org.bukkit.event.player.{PlayerInteractEvent, PlayerItemConsumeEvent}
 import org.bukkit.event.{EventHandler, Listener}
 import org.bukkit.inventory.EquipmentSlot
@@ -143,6 +144,15 @@ class ChristmasItemListener(instance: SeichiAssist) extends Listener {
         player.sendMessage(s"$AQUA「靴下」を見つけたよ！")
       }
       player.playSound(player.getLocation, Sound.BLOCK_NOTE_HARP, 3.0f, 1.0f)
+    }
+  }
+
+  @EventHandler
+  def onStrayDeath(event: EntityDeathEvent): Unit = {
+    event.getEntity match {
+      case entity: LivingEntity =>
+        if (entity.getType == EntityType.STRAY && entity.getKiller != null)
+          Util.randomlyDropItemAt(entity, christmasSock, itemDropRate)
     }
   }
 

--- a/src/main/scala/com/github/unchama/seasonalevents/christmas/ChristmasItemListener.scala
+++ b/src/main/scala/com/github/unchama/seasonalevents/christmas/ChristmasItemListener.scala
@@ -153,6 +153,7 @@ class ChristmasItemListener(instance: SeichiAssist) extends Listener {
       case entity: LivingEntity =>
         if (entity.getType == EntityType.STRAY && entity.getKiller != null)
           Util.randomlyDropItemAt(entity, christmasSock, itemDropRate)
+      case _ =>
     }
   }
 

--- a/src/main/scala/com/github/unchama/seasonalevents/christmas/ChristmasItemListener.scala
+++ b/src/main/scala/com/github/unchama/seasonalevents/christmas/ChristmasItemListener.scala
@@ -3,23 +3,36 @@ package com.github.unchama.seasonalevents.christmas
 import java.util.Random
 
 import com.github.unchama.seasonalevents.Util
-import com.github.unchama.seasonalevents.christmas.Christmas.{isInEvent, itemDropRate}
+import com.github.unchama.seasonalevents.christmas.Christmas.{END_DATE, blogArticleUrl, isInEvent, itemDropRate}
 import com.github.unchama.seasonalevents.christmas.ChristmasItemData._
 import com.github.unchama.seichiassist.util.Util.{addItem, dropItem, isPlayerInventoryFull, removeItemfromPlayerInventory}
 import com.github.unchama.seichiassist.{ManagedWorld, SeichiAssist}
 import de.tr7zw.itemnbtapi.NBTItem
-import org.bukkit.ChatColor.{AQUA, RED}
+import org.bukkit.ChatColor._
 import org.bukkit.entity.EntityType._
 import org.bukkit.entity.{EntityType, LivingEntity, Player}
 import org.bukkit.event.block.{Action, BlockBreakEvent}
 import org.bukkit.event.entity.{EntityDeathEvent, EntityTargetLivingEntityEvent}
-import org.bukkit.event.player.{PlayerInteractEvent, PlayerItemConsumeEvent}
+import org.bukkit.event.player.{PlayerInteractEvent, PlayerItemConsumeEvent, PlayerJoinEvent}
 import org.bukkit.event.{EventHandler, Listener}
 import org.bukkit.inventory.EquipmentSlot
 import org.bukkit.potion.{PotionEffect, PotionEffectType}
 import org.bukkit.{Bukkit, Sound}
 
 class ChristmasItemListener(instance: SeichiAssist) extends Listener {
+  @EventHandler
+  def onPlayerJoin(event: PlayerJoinEvent): Unit = {
+    if (isInEvent) {
+      Seq(
+        s"$LIGHT_PURPLE${END_DATE}までの期間限定で、クリスマスイベントを開催しています。",
+        "詳しくは下記URLのサイトをご覧ください。",
+        s"$DARK_GREEN$UNDERLINE$blogArticleUrl"
+      ).foreach(
+        event.getPlayer.sendMessage(_)
+      )
+    }
+  }
+
   @EventHandler
   def onPlayerConsumeChristmasCake(event: PlayerInteractEvent): Unit = {
     val item = event.getItem

--- a/src/main/scala/com/github/unchama/seasonalevents/christmas/ChristmasItemListener.scala
+++ b/src/main/scala/com/github/unchama/seasonalevents/christmas/ChristmasItemListener.scala
@@ -3,6 +3,7 @@ package com.github.unchama.seasonalevents.christmas
 import java.util.Random
 
 import com.github.unchama.seasonalevents.christmas.ChristmasItemData._
+import com.github.unchama.seichiassist.SeichiAssist
 import com.github.unchama.seichiassist.util.Util.{addItem, removeItemfromPlayerInventory}
 import de.tr7zw.itemnbtapi.NBTItem
 import org.bukkit.event.block.Action
@@ -10,10 +11,11 @@ import org.bukkit.event.player.{PlayerInteractEvent, PlayerItemConsumeEvent}
 import org.bukkit.event.{EventHandler, Listener}
 import org.bukkit.inventory.EquipmentSlot
 import org.bukkit.potion.{PotionEffect, PotionEffectType}
+import org.bukkit.{Bukkit, Sound}
 
 import scala.util.chaining._
 
-object ChristmasItemListener extends Listener {
+class ChristmasItemListener(instance: SeichiAssist) extends Listener {
   @EventHandler
   def onPlayerConsumeChristmasCake(event: PlayerInteractEvent): Unit = {
     val item = event.getItem
@@ -49,4 +51,32 @@ object ChristmasItemListener extends Listener {
     val potionEffectType = if (rand > 0.5) PotionEffectType.SPEED else PotionEffectType.SLOW
     event.getPlayer.addPotionEffect(new PotionEffect(potionEffectType, 20 * 30, 0), true)
   }
+
+  @EventHandler
+  def onPlayerConsumeChristmasPotion(event: PlayerItemConsumeEvent): Unit = {
+    if (!isChristmasPotion(event.getItem)) return
+
+    val player = event.getPlayer
+    val playerUuid = player.getUniqueId
+
+    for (i <- 1 to 5) {
+      Bukkit.getServer.getScheduler.runTaskLater(instance, new Runnable {
+        override def run(): Unit = {
+          // この条件分岐がfalseになる可能性は通常ない（ログインしている限りplayerMapにはそのMCIDのデータが有るはずだ）が、なっている事例があるので念の為
+          // 参照：https://github.com/GiganticMinecraft/SeichiAssist/issues/707
+          if (SeichiAssist.playermap.contains(playerUuid)) {
+            val playerData = SeichiAssist.playermap(playerUuid)
+            val manaState = playerData.manaState
+            val maxMana = manaState.calcMaxManaOnly(player, playerData.level)
+            // マナを15%回復する
+            manaState.increase(maxMana * 0.15, player, playerData.level)
+            player.playSound(player.getLocation, Sound.ENTITY_WITCH_DRINK, 1.0F, 1.2F)
+          } else {
+            Bukkit.getServer.getLogger.info(s"${player.getName}によって「みんなの涙」が使用されましたが、プレイヤーデータが存在しなかったため、マナ回復が行われませんでした。")
+          }
+        }
+      }, (20 * 60 * i).toLong)
+    }
+  }
+
 }

--- a/src/main/scala/com/github/unchama/seasonalevents/christmas/ChristmasItemListener.scala
+++ b/src/main/scala/com/github/unchama/seasonalevents/christmas/ChristmasItemListener.scala
@@ -149,6 +149,8 @@ class ChristmasItemListener(instance: SeichiAssist) extends Listener {
 
   @EventHandler
   def onStrayDeath(event: EntityDeathEvent): Unit = {
+    if (!isInEvent) return
+
     event.getEntity match {
       case entity: LivingEntity =>
         if (entity.getType == EntityType.STRAY && entity.getKiller != null)

--- a/src/main/scala/com/github/unchama/seasonalevents/christmas/ChristmasItemListener.scala
+++ b/src/main/scala/com/github/unchama/seasonalevents/christmas/ChristmasItemListener.scala
@@ -1,0 +1,43 @@
+package com.github.unchama.seasonalevents.christmas
+
+import java.util.Random
+
+import com.github.unchama.seasonalevents.christmas.ChristmasItemData._
+import com.github.unchama.seichiassist.util.Util.{addItem, removeItemfromPlayerInventory}
+import de.tr7zw.itemnbtapi.NBTItem
+import org.bukkit.event.block.Action
+import org.bukkit.event.player.PlayerInteractEvent
+import org.bukkit.event.{EventHandler, Listener}
+import org.bukkit.inventory.EquipmentSlot
+import org.bukkit.potion.{PotionEffect, PotionEffectType}
+
+import scala.util.chaining._
+
+object ChristmasItemListener extends Listener {
+  @EventHandler
+  def onPlayerConsumeChristmasCake(event: PlayerInteractEvent): Unit = {
+    val item = event.getItem
+    if (!isChristmasCake(item)) return
+
+    if (event.getHand == EquipmentSlot.OFF_HAND) return
+    if (event.getAction != Action.RIGHT_CLICK_AIR && event.getAction != Action.LEFT_CLICK_BLOCK) return
+
+    event.setCancelled(true)
+
+    val player = event.getPlayer
+
+    val rand = new Random().nextDouble()
+    val potionEffectType = if (rand > 0.5) PotionEffectType.LUCK else PotionEffectType.UNLUCK
+    player.addPotionEffect(new PotionEffect(potionEffectType, 20 * 30, 0), true)
+
+    removeItemfromPlayerInventory(player.getInventory, item, 1)
+
+    val remainingPiece = new NBTItem(item).getByte(NBTTagConstants.cakePieceTag).toInt
+    if (remainingPiece != 0) {
+      val newItem = new NBTItem(item)
+        .tap(_.setByte(NBTTagConstants.cakePieceTag, (remainingPiece - 1).toByte))
+        .pipe(_.getItem)
+      addItem(player, newItem)
+    }
+  }
+}

--- a/src/main/scala/com/github/unchama/seasonalevents/christmas/ChristmasItemListener.scala
+++ b/src/main/scala/com/github/unchama/seasonalevents/christmas/ChristmasItemListener.scala
@@ -109,9 +109,14 @@ class ChristmasItemListener(instance: SeichiAssist) extends Listener {
         val distance = entityLocation.distance(playerLocation)
         val enchantLevel = new NBTItem(chestPlate).getByte(NBTTagConstants.camouflageEnchLevelTag).toInt
         // ここの数字に敵からの索敵距離を下げる
-        val standard = calculateStandardDistance(enchantLevel, entity.getType)
-
-        if (distance > standard) event.setCancelled(true)
+        try {
+          val standard = calculateStandardDistance(enchantLevel, entity.getType)
+          if (distance > standard) event.setCancelled(true)
+        } catch {
+          case err: IllegalArgumentException =>
+            Bukkit.getServer.getLogger.info(s"${player.getName}によって、「迷彩」エンチャントのついたアイテムが使用されましたが、設定されているエンチャントレベルが不正なものでした。")
+            err.printStackTrace()
+        }
       case _ =>
     }
   }

--- a/src/main/scala/com/github/unchama/seasonalevents/christmas/ChristmasItemListener.scala
+++ b/src/main/scala/com/github/unchama/seasonalevents/christmas/ChristmasItemListener.scala
@@ -2,13 +2,15 @@ package com.github.unchama.seasonalevents.christmas
 
 import java.util.Random
 
+import com.github.unchama.seasonalevents.christmas.Christmas.{isInEvent, itemDropRate}
 import com.github.unchama.seasonalevents.christmas.ChristmasItemData._
-import com.github.unchama.seichiassist.SeichiAssist
-import com.github.unchama.seichiassist.util.Util.{addItem, removeItemfromPlayerInventory}
+import com.github.unchama.seichiassist.util.Util.{addItem, dropItem, isPlayerInventoryFull, removeItemfromPlayerInventory}
+import com.github.unchama.seichiassist.{ManagedWorld, SeichiAssist}
 import de.tr7zw.itemnbtapi.NBTItem
+import org.bukkit.ChatColor.{AQUA, RED}
 import org.bukkit.entity.EntityType._
 import org.bukkit.entity.Player
-import org.bukkit.event.block.Action
+import org.bukkit.event.block.{Action, BlockBreakEvent}
 import org.bukkit.event.entity.EntityTargetLivingEntityEvent
 import org.bukkit.event.player.{PlayerInteractEvent, PlayerItemConsumeEvent}
 import org.bukkit.event.{EventHandler, Listener}
@@ -118,6 +120,29 @@ class ChristmasItemListener(instance: SeichiAssist) extends Listener {
             err.printStackTrace()
         }
       case _ =>
+    }
+  }
+
+  @EventHandler
+  def onChristmasSockPopped(event: BlockBreakEvent): Unit = {
+    if (!isInEvent) return
+    if (event.isCancelled) return
+
+    val player = event.getPlayer
+    val block = event.getBlock
+    if (block == null) return
+    if (!ManagedWorld.WorldOps(player.getWorld).isSeichi) return
+
+    val rand = new Random().nextDouble()
+    if (rand < itemDropRate) {
+      if (isPlayerInventoryFull(player)) {
+        dropItem(player, christmasSock)
+        player.sendMessage(s"${RED}インベントリに空きがなかったため、「靴下」は地面にドロップしました。")
+      } else {
+        addItem(player, christmasSock)
+        player.sendMessage(s"$AQUA「靴下」を見つけたよ！")
+      }
+      player.playSound(player.getLocation, Sound.BLOCK_NOTE_HARP, 3.0f, 1.0f)
     }
   }
 

--- a/src/main/scala/com/github/unchama/seasonalevents/commands/EventCommand.scala
+++ b/src/main/scala/com/github/unchama/seasonalevents/commands/EventCommand.scala
@@ -1,8 +1,9 @@
 package com.github.unchama.seasonalevents.commands
 
 import cats.effect.IO
-import com.github.unchama.seasonalevents.halloween.HalloweenItemData
-import com.github.unchama.seasonalevents.newyear.NewYearItemData
+import com.github.unchama.seasonalevents.christmas.ChristmasItemData._
+import com.github.unchama.seasonalevents.halloween.HalloweenItemData._
+import com.github.unchama.seasonalevents.newyear.NewYearItemData._
 import com.github.unchama.seichiassist.commands.contextual.builder.BuilderTemplates.playerCommandBuilder
 import com.github.unchama.seichiassist.util.Util
 import com.github.unchama.targetedeffect.TargetedEffect._
@@ -13,21 +14,32 @@ object EventCommand {
 
   import com.github.unchama.targetedeffect._
 
+  val christsmasGrantEffect: TargetedEffect[Player] =
+    Util.grantItemStacksEffect(
+      christmasCake(christmasCakeDefaultPieces),
+      christmasTurkey,
+      christmasPotion,
+      christmasChestPlate,
+      christmasPickaxe,
+      christmasSock
+    )
+
   val newYearGrantEffect: TargetedEffect[Player] =
     Util.grantItemStacksEffect(
-      NewYearItemData.newYearApple,
-      NewYearItemData.newYearBag
+      newYearApple,
+      newYearBag
     )
 
   val halloweenGrantEffect: TargetedEffect[Player] =
     Util.grantItemStacksEffect(
-      HalloweenItemData.halloweenPotion,
-      HalloweenItemData.halloweenHoe
+      halloweenPotion,
+      halloweenHoe
     )
 
   val executor: TabExecutor = playerCommandBuilder
     .execution { context =>
       val effect = context.args.yetToBeParsed match {
+        case "christmas" :: _ => christsmasGrantEffect
         case "newyear" :: _ => newYearGrantEffect
         case "halloween" :: _ => halloweenGrantEffect
         case _ => emptyEffect

--- a/src/main/scala/com/github/unchama/seasonalevents/valentine/ValentineItemData.scala
+++ b/src/main/scala/com/github/unchama/seasonalevents/valentine/ValentineItemData.scala
@@ -3,7 +3,7 @@ package com.github.unchama.seasonalevents.valentine
 import java.time.LocalDate
 import java.util.UUID
 
-import com.github.unchama.seasonalevents.valentine.Valentine.{END_DATE, isInEvent}
+import com.github.unchama.seasonalevents.valentine.Valentine.END_DATE
 import de.tr7zw.itemnbtapi.NBTItem
 import org.bukkit.ChatColor._
 import org.bukkit.entity.Player
@@ -125,16 +125,14 @@ object ValentineItemData {
 
   // SeichiAssistで呼ばれてるだけ
   def valentinePlayerHead(head: SkullMeta): SkullMeta = {
-    if (isInEvent) {
-      val year: String = END_DATE.getYear.toString
-      val lore = List(
-        "",
-        s"$GREEN${ITALIC}大切なあなたへ。",
-        s"$UNDERLINE$YELLOW${ITALIC}Happy Valentine $year"
-      ).map(str => s"$RESET$str")
-        .asJava
-      head.setLore(lore)
-    }
+    val year: String = END_DATE.getYear.toString
+    val lore = List(
+      "",
+      s"$GREEN${ITALIC}大切なあなたへ。",
+      s"$YELLOW$UNDERLINE${ITALIC}Happy Valentine $year"
+    ).map(str => s"$RESET$str")
+      .asJava
+    head.setLore(lore)
     head
   }
 

--- a/src/main/scala/com/github/unchama/seichiassist/menus/stickmenu/SecondPage.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/menus/stickmenu/SecondPage.scala
@@ -6,7 +6,10 @@ import com.github.unchama.menuinventory
 import com.github.unchama.menuinventory._
 import com.github.unchama.menuinventory.slot.button.action.{ClickEventFilter, FilteredButtonEffect, LeftClickButtonEffect}
 import com.github.unchama.menuinventory.slot.button.{Button, RecomputedButton, action}
-import com.github.unchama.seasonalevents.valentine.ValentineItemData
+import com.github.unchama.seasonalevents.christmas.Christmas
+import com.github.unchama.seasonalevents.christmas.ChristmasItemData.christmasPlayerHead
+import com.github.unchama.seasonalevents.valentine.Valentine
+import com.github.unchama.seasonalevents.valentine.ValentineItemData.valentinePlayerHead
 import com.github.unchama.seichiassist.concurrent.PluginExecutionContexts
 import com.github.unchama.seichiassist.data.player.settings.BroadcastMutingSettings.{MuteMessageAndSound, ReceiveMessageAndSound, ReceiveMessageOnly}
 import com.github.unchama.seichiassist.menus.CommonButtons
@@ -100,9 +103,12 @@ object SecondPage extends Menu {
             import scala.util.chaining._
             val skullToGive = new SkullItemStackBuilder(getUniqueId).build().tap { stack =>
               import stack._
-              //バレンタイン中(イベント中かどうかの判断はSeasonalEvent側で行う)
-              setItemMeta {
-                ValentineItemData.valentinePlayerHead(getItemMeta.asInstanceOf[SkullMeta])
+              // 季節イベント中の特殊lore
+              if (Valentine.isInEvent) setItemMeta {
+                valentinePlayerHead(getItemMeta.asInstanceOf[SkullMeta])
+              }
+              else if (Christmas.isInEvent) setItemMeta {
+                christmasPlayerHead(getItemMeta.asInstanceOf[SkullMeta])
               }
             }
 

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/mebius/bukkit/codec/BukkitMebiusItemStackCodec.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/mebius/bukkit/codec/BukkitMebiusItemStackCodec.scala
@@ -1,5 +1,6 @@
 package com.github.unchama.seichiassist.subsystems.mebius.bukkit.codec
 
+import com.github.unchama.seasonalevents.christmas.{Christmas, ChristmasItemData}
 import com.github.unchama.seichiassist.subsystems.mebius.domain.property.{MebiusEnchantmentLevels, MebiusLevel, MebiusProperty}
 import com.github.unchama.seichiassist.subsystems.mebius.domain.resources.MebiusTalks
 import de.tr7zw.itemnbtapi.NBTItem
@@ -105,6 +106,9 @@ object BukkitMebiusItemStackCodec {
             .concat {
               if (property.level.isMaximum) List(unbreakableLoreRow) else Nil
             }
+            .concat {
+              if (Christmas.isInEvent) ChristmasItemData.christmasMebiusLore else Nil
+            }
             .asJava
         }
       }
@@ -133,7 +137,8 @@ object BukkitMebiusItemStackCodec {
   def displayNameOfMaterializedItem(property: MebiusProperty): String = {
     import LoreConstants._
 
-    mebiusNameDisplayPrefix + property.mebiusName
+    if (Christmas.isInEvent) s"$RESET$WHITE$BOLD" + property.mebiusName + " Christmas Ver."
+    else mebiusNameDisplayPrefix + property.mebiusName
   }
 
   def ownershipMatches(player: Player)(property: MebiusProperty): Boolean =


### PR DESCRIPTION
* クリスマスケーキ
	* 食べると幸運か不運のどちらかのバフがつく（50%で切り替わる）
	* 設置することはできず、右クリックで勝手に食べられる（7回）
* 七面鳥
	* 食べると移動速度上昇か低下のどちらかのバフがつく（50%で切り替わる）
* 鯖民の涙
	* 飲むと攻撃力上昇、再生能力のバフがつく
	* 1分おきに計5回マナを15%回復する
* THANATOS レプリカ
	* 効率強化と幸運エンチャント、耐久無限
* 自分の頭を出すときに特別な説明がつく
* 期間中にストレイを倒すまたはブロックを整地ワールドで破壊すると、「靴下」をドロップ
* 期間中は名前が白くなって特殊なloreがついた限定メビウスが出現する