### PR TITLE
整地レベルアップ時のガチャ券配布はLv.50まで

### DIFF
--- a/src/main/scala/com/github/unchama/seichiassist/listener/PlayerSeichiLevelUpListener.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/listener/PlayerSeichiLevelUpListener.scala
@@ -17,7 +17,8 @@ object PlayerSeichiLevelUpListener extends Listener {
 
     val level = event.getLevelAfterLevelUp
 
-    giveItem("ガチャ券を付与する", level * 5, GachaSkullData.gachaForSeichiLevelUp)
+    if (level <= 50)
+      giveItem("ガチャ券を付与する", level * 5, GachaSkullData.gachaForSeichiLevelUp)
 
     level match {
       case 10 =>


### PR DESCRIPTION
題名通り。参照： #16 