### PR TITLE
SeasonalEvents下で、不要なNBTタグの書き込みをやめたり、イベント開催中であることを通知したりする

### DIFF
--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/seasonalevents/christmas/ChristmasItemData.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/seasonalevents/christmas/ChristmasItemData.scala
@@ -277,7 +277,7 @@ object ChristmasItemData {
 
     val itemMeta = Bukkit.getItemFactory.getItemMeta(Material.INK_SACK).tap { meta =>
       import meta._
-      setDisplayName(s"${AQUA}靴下")
+      setDisplayName(s"${AQUA}靴下(${EVENT_YEAR}年)")
       setLore(loreList)
       addEnchant(Enchantment.DIG_SPEED, 1, true)
       addItemFlags(ItemFlag.HIDE_ENCHANTS)
@@ -293,7 +293,6 @@ object ChristmasItemData {
     new NBTItem(itemStack).tap { nbtItem =>
       import nbtItem._
       setByte(NBTTagConstants.typeIdTag, 6.toByte)
-      setObject(NBTTagConstants.expiryDateTag, END_DATE)
     }
       .pipe(_.getItem)
   }
@@ -321,7 +320,6 @@ object ChristmasItemData {
     val typeIdTag = "christmasItemTypeId"
     val cakePieceTag = "christmasCakePiece"
     val camouflageEnchLevelTag = "camouflageEnchLevel"
-    val expiryDateTag = "christmasSockExpiryDate"
   }
 
 }

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/seasonalevents/halloween/Halloween.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/seasonalevents/halloween/Halloween.scala
@@ -1,0 +1,14 @@
+package com.github.unchama.seichiassist.subsystems.seasonalevents.halloween
+
+import java.time.LocalDate
+
+import com.github.unchama.seichiassist.subsystems.seasonalevents.Util.{dateRangeAsSequence, validateUrl}
+
+object Halloween {
+  val blogArticleUrl: String = validateUrl("https://www.seichi.network/post/halloween2020")
+  val EVENT_YEAR: Int = 2020
+  val START_DATE: LocalDate = LocalDate.of(EVENT_YEAR, 10, 15)
+  val END_DATE: LocalDate = LocalDate.of(EVENT_YEAR, 10, 31)
+
+  def isInEvent: Boolean = dateRangeAsSequence(START_DATE, END_DATE).contains(LocalDate.now())
+}

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/seasonalevents/halloween/HalloweenItemListener.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/seasonalevents/halloween/HalloweenItemListener.scala
@@ -1,17 +1,31 @@
 package com.github.unchama.seichiassist.subsystems.seasonalevents.halloween
 
+import com.github.unchama.seichiassist.subsystems.seasonalevents.halloween.Halloween.{blogArticleUrl, END_DATE, isInEvent}
 import com.github.unchama.seichiassist.subsystems.seasonalevents.halloween.HalloweenItemData.{isHalloweenHoe, isHalloweenPotion}
 import com.github.unchama.util.external.WorldGuardWrapper.isRegionMember
+import org.bukkit.ChatColor.{DARK_GREEN, LIGHT_PURPLE, UNDERLINE}
 import org.bukkit.Material
 import org.bukkit.block.Block
 import org.bukkit.entity.Player
 import org.bukkit.event.block.Action
-import org.bukkit.event.player.{PlayerInteractEvent, PlayerItemConsumeEvent}
+import org.bukkit.event.player.{PlayerInteractEvent, PlayerItemConsumeEvent, PlayerJoinEvent}
 import org.bukkit.event.{EventHandler, Listener}
 import org.bukkit.inventory.EquipmentSlot
 import org.bukkit.potion.{PotionEffect, PotionEffectType}
 
 object HalloweenItemListener extends Listener {
+  @EventHandler
+  def onPlayerJoin(event: PlayerJoinEvent): Unit = {
+    if (isInEvent) {
+      Seq(
+        s"$LIGHT_PURPLE${END_DATE}までの期間限定で、ハロウィンイベントを開催しています。",
+        "詳しくは下記URLのサイトをご覧ください。",
+        s"$DARK_GREEN$UNDERLINE$blogArticleUrl"
+      ).foreach(
+        event.getPlayer.sendMessage(_)
+      )
+    }
+  }
 
   @EventHandler
   def onPlayerConsumeHalloweenPotion(event: PlayerItemConsumeEvent): Unit = {

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/seasonalevents/newyear/NewYear.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/seasonalevents/newyear/NewYear.scala
@@ -1,11 +1,11 @@
 package com.github.unchama.seichiassist.subsystems.seasonalevents.newyear
 
-import com.github.unchama.seichiassist.subsystems.seasonalevents.Util.{dateRangeAsSequence, validateItemDropRate}
-
+import com.github.unchama.seichiassist.subsystems.seasonalevents.Util.{dateRangeAsSequence, validateItemDropRate, validateUrl}
 import java.time.LocalDate
 
 object NewYear {
   val itemDropRate: Double = validateItemDropRate(0.002)
+  val blogArticleUrl: String = validateUrl("https://www.seichi.network/post/newyear2021")
   // 新年が何年かを西暦で入力しておくと、自動的に他の日付が設定される
   val EVENT_YEAR: Int = 2021
   val START_DATE: LocalDate = LocalDate.of(EVENT_YEAR, 1, 1)

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/seasonalevents/newyear/NewYearItemData.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/seasonalevents/newyear/NewYearItemData.scala
@@ -1,7 +1,7 @@
 package com.github.unchama.seichiassist.subsystems.seasonalevents.newyear
 
 import com.github.unchama.itemstackbuilder.{SkullItemStackBuilder, SkullOwnerTextureValue}
-import com.github.unchama.seichiassist.subsystems.seasonalevents.newyear.NewYear.{DISTRIBUTED_SOBA_DATE, END_DATE}
+import com.github.unchama.seichiassist.subsystems.seasonalevents.newyear.NewYear.{DISTRIBUTED_SOBA_DATE, END_DATE, EVENT_YEAR}
 import de.tr7zw.itemnbtapi.NBTItem
 import org.bukkit.ChatColor._
 import org.bukkit.enchantments.Enchantment
@@ -61,7 +61,7 @@ object NewYearItemData {
 
     val itemMeta = Bukkit.getItemFactory.getItemMeta(Material.PAPER).tap { meta =>
       import meta._
-      setDisplayName(s"${AQUA}お年玉袋")
+      setDisplayName(s"${AQUA}お年玉袋(${EVENT_YEAR}年)")
       setLore(loreList)
       addEnchant(Enchantment.DIG_SPEED, 1, true)
       addItemFlags(ItemFlag.HIDE_ENCHANTS)
@@ -69,13 +69,7 @@ object NewYearItemData {
 
     val itemStack = new ItemStack(Material.PAPER, 1)
     itemStack.setItemMeta(itemMeta)
-
-    new NBTItem(itemStack).tap { item =>
-      import item._
-      setByte(NBTTagConstants.typeIdTag, 2.toByte)
-      setObject(NBTTagConstants.expiryDateTag, END_DATE)
-    }
-      .pipe(_.getItem)
+    itemStack
   }
 
   // https://minecraft-heads.com/custom-heads/food-drinks/413-bowl-of-noodles
@@ -92,7 +86,6 @@ object NewYearItemData {
   object NBTTagConstants {
     val typeIdTag = "newYearItemTypeId"
     val expiryDateTag = "newYearAppleExpiryDate"
-    val eventYearTag = "newYearEventYear"
   }
 
 }

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/seasonalevents/newyear/NewYearListener.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/seasonalevents/newyear/NewYearListener.scala
@@ -1,7 +1,7 @@
 package com.github.unchama.seichiassist.subsystems.seasonalevents.newyear
 
 import com.github.unchama.seichiassist.data.player.PlayerData
-import com.github.unchama.seichiassist.subsystems.seasonalevents.newyear.NewYear.{isInEvent, itemDropRate}
+import com.github.unchama.seichiassist.subsystems.seasonalevents.newyear.NewYear._
 import com.github.unchama.seichiassist.subsystems.seasonalevents.newyear.NewYearItemData._
 import com.github.unchama.seichiassist.util.Util.{addItem, dropItem, isPlayerInventoryFull}
 import com.github.unchama.seichiassist.{ManagedWorld, SeichiAssist}
@@ -20,25 +20,33 @@ import java.util.Random
 object NewYearListener extends Listener {
   @EventHandler
   def giveSobaToPlayer(event: PlayerJoinEvent): Unit = {
-    if (!isInEvent) return
-
     val player: Player = event.getPlayer
 
-    val playerData: PlayerData = SeichiAssist.playermap(player.getUniqueId)
-    if (playerData.hasNewYearSobaGive) return
+    if (sobaWillBeDistributed) {
+      val playerData: PlayerData = SeichiAssist.playermap(player.getUniqueId)
+      if (playerData.hasNewYearSobaGive) return
 
-    if (isPlayerInventoryFull(player)) {
+      if (isPlayerInventoryFull(player)) {
+        List(
+          "インベントリに空きがなかったため、アイテムを配布できませんでした。",
+          "インベントリに空きを作ってから、再度サーバーに参加してください。"
+        ).map(str => s"$RED$UNDERLINE$str")
+          .foreach(player.sendMessage)
+      } else {
+        addItem(player, sobaHead)
+        playerData.hasNewYearSobaGive = true
+        player.sendMessage(s"${BLUE}大晦日ログインボーナスとして記念品を入手しました。")
+      }
+      player.playSound(player.getLocation, Sound.BLOCK_ANVIL_PLACE, 1.0f, 1.0f)
+    } else if (isInEvent) {
       List(
-        "インベントリに空きがなかったため、アイテムを配布できませんでした。",
-        "インベントリに空きを作ってから、再度サーバーに参加してください。"
-      ).map(str => s"$RED$UNDERLINE$str")
-        .foreach(player.sendMessage)
-    } else {
-      addItem(player, sobaHead)
-      playerData.hasNewYearSobaGive = true
-      player.sendMessage(s"${BLUE}大晦日ログインボーナスとして記念品を入手しました。")
+        s"$LIGHT_PURPLE${END_DATE}までの期間限定で、新年イベントを開催しています。",
+        "詳しくは下記URLのサイトをご覧ください。",
+        s"$DARK_GREEN$UNDERLINE$blogArticleUrl"
+      ).foreach(
+        player.sendMessage(_)
+      )
     }
-    player.playSound(player.getLocation, Sound.BLOCK_ANVIL_PLACE, 1.0f, 1.0f)
   }
 
   @EventHandler

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/seasonalevents/seizonsiki/Seizonsiki.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/seasonalevents/seizonsiki/Seizonsiki.scala
@@ -1,14 +1,14 @@
 package com.github.unchama.seichiassist.subsystems.seasonalevents.seizonsiki
 
-import com.github.unchama.seichiassist.subsystems.seasonalevents.Util.{validateItemDropRate, validateUrl}
-
+import com.github.unchama.seichiassist.subsystems.seasonalevents.Util.{dateRangeAsSequence, validateItemDropRate, validateUrl}
 import java.time.LocalDate
 
 object Seizonsiki {
-  def isInEvent: Boolean = LocalDate.now().isBefore(END_DATE)
-
-  // イベントが実際に終了する日。
-  val END_DATE: LocalDate = LocalDate.of(2017, 1, 22)
   val itemDropRate: Double = validateItemDropRate(0.3)
   val blogArticleUrl: String = validateUrl("https://www.seichi.network/post/seizonsiki2020")
+  val EVENT_YEAR: Int = 2021
+  val START_DATE: LocalDate = LocalDate.of(EVENT_YEAR, 1, 9)
+  val END_DATE: LocalDate = LocalDate.of(EVENT_YEAR, 1, 22)
+
+  def isInEvent: Boolean = dateRangeAsSequence(START_DATE, END_DATE).contains(LocalDate.now())
 }

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/seasonalevents/seizonsiki/SeizonsikiListener.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/seasonalevents/seizonsiki/SeizonsikiListener.scala
@@ -31,7 +31,7 @@ object SeizonsikiListener extends Listener {
   def onPlayerJoinEvent(event: PlayerJoinEvent): Unit = {
     if (isInEvent) {
       List(
-        s"$LIGHT_PURPLE${END_DATE}までの期間限定で、限定イベント『チャラゾンビたちの成ゾン式！』を開催しています。",
+        s"$LIGHT_PURPLE${END_DATE}までの期間限定で、イベント『チャラゾンビたちの成ゾン式！』を開催しています。",
         "詳しくは下記URLのサイトをご覧ください。",
         s"$DARK_GREEN$UNDERLINE$blogArticleUrl"
       ).foreach(

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/seasonalevents/valentine/Valentine.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/seasonalevents/valentine/Valentine.scala
@@ -1,14 +1,14 @@
 package com.github.unchama.seichiassist.subsystems.seasonalevents.valentine
 
-import com.github.unchama.seichiassist.subsystems.seasonalevents.Util.{validateItemDropRate, validateUrl}
-
+import com.github.unchama.seichiassist.subsystems.seasonalevents.Util.{dateRangeAsSequence, validateItemDropRate, validateUrl}
 import java.time.LocalDate
 
 object Valentine {
-  def isInEvent: Boolean = LocalDate.now().isBefore(END_DATE)
-
-  // イベントが実際に終了する日
-  val END_DATE: LocalDate = LocalDate.of(2018, 2, 27)
   val itemDropRate: Double = validateItemDropRate(0.3)
   val blogArticleUrl: String = validateUrl("https://www.seichi.network/post/valentine2020")
+  val EVENT_YEAR: Int = 2021
+  val START_DATE: LocalDate = LocalDate.of(EVENT_YEAR, 2, 13)
+  val END_DATE: LocalDate = LocalDate.of(EVENT_YEAR, 2, 27)
+
+  def isInEvent: Boolean = dateRangeAsSequence(START_DATE, END_DATE).contains(LocalDate.now())
 }

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/seasonalevents/valentine/ValentineItemData.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/seasonalevents/valentine/ValentineItemData.scala
@@ -1,6 +1,6 @@
 package com.github.unchama.seichiassist.subsystems.seasonalevents.valentine
 
-import com.github.unchama.seichiassist.subsystems.seasonalevents.valentine.Valentine.END_DATE
+import com.github.unchama.seichiassist.subsystems.seasonalevents.valentine.Valentine.{END_DATE, EVENT_YEAR}
 import de.tr7zw.itemnbtapi.NBTItem
 import org.bukkit.ChatColor._
 import org.bukkit.entity.Player
@@ -124,11 +124,10 @@ object ValentineItemData {
 
   // SeichiAssistで呼ばれてるだけ
   def valentinePlayerHead(head: SkullMeta): SkullMeta = {
-    val year: String = END_DATE.getYear.toString
     val lore = List(
       "",
       s"$GREEN${ITALIC}大切なあなたへ。",
-      s"$YELLOW$UNDERLINE${ITALIC}Happy Valentine $year"
+      s"$YELLOW$UNDERLINE${ITALIC}Happy Valentine $EVENT_YEAR"
     ).map(str => s"$RESET$str")
       .asJava
     head.setLore(lore)

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/seasonalevents/valentine/ValentineListener.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/seasonalevents/valentine/ValentineListener.scala
@@ -55,7 +55,7 @@ object ValentineListener extends Listener {
   def onPlayerJoinEvent(event: PlayerJoinEvent): Unit = {
     if (isInEvent) {
       Seq(
-        s"$LIGHT_PURPLE${END_DATE}までの期間限定で、限定イベント『＜ブラックバレンタイン＞リア充 vs 整地民！』を開催しています。",
+        s"$LIGHT_PURPLE${END_DATE}までの期間限定で、イベント『＜ブラックバレンタイン＞リア充 vs 整地民！』を開催しています。",
         "詳しくは下記URLのサイトをご覧ください。",
         s"$DARK_GREEN$UNDERLINE$blogArticleUrl"
       ).foreach(


### PR DESCRIPTION
This closes #837

ただし、現在開催中のクリスマスイベントにも関連する変更であるため、何もイベントが開催されていない期間にこのPRが本番環境で適用される必要がある。