### PR TITLE
スポーンで投擲物の発射がキャンセルされた場合にインベントリに存在するアイテムを消費しないようにする

### DIFF
--- a/src/main/scala/com/github/unchama/seichiassist/listener/SpawnRegionProjectileInterceptor.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/listener/SpawnRegionProjectileInterceptor.scala
@@ -10,7 +10,7 @@ import scala.jdk.CollectionConverters._
 
 object SpawnRegionProjectileInterceptor extends Listener {
   @EventHandler
-  def onProjectileLaunched(event: PlayerInteractEvent): Unit = {
+  def beforeProjectileLaunch(event: PlayerInteractEvent): Unit = {
     val player = event.getPlayer
     val inventory = player.getInventory
     val action = event.getAction

--- a/src/main/scala/com/github/unchama/seichiassist/listener/SpawnRegionProjectileInterceptor.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/listener/SpawnRegionProjectileInterceptor.scala
@@ -21,15 +21,14 @@ object SpawnRegionProjectileInterceptor extends Listener {
   @EventHandler
   def beforeProjectileLaunch(event: PlayerInteractEvent): Unit = {
     val player = event.getPlayer
-    val inventory = player.getInventory
     val action = event.getAction
     val projectiles = Set(
       BOW, EGG, LINGERING_POTION, SPLASH_POTION, ENDER_PEARL, EYE_OF_ENDER, SNOW_BALL, EXP_BOTTLE
     )
 
     // Projectileを持った状態で右クリックし、playerがいる保護がspawn保護の中であった場合はイベントをキャンセルする
-    if (inventory.getItemInMainHand != null
-      && projectiles.contains(inventory.getItemInMainHand.getType)
+    if (event.hasItem
+      && projectiles.contains(event.getItem.getType)
       && (action == Action.RIGHT_CLICK_AIR || action == Action.RIGHT_CLICK_BLOCK)
       && getRegions(player.getLocation).asScala.map(_.getId).exists(spawnRegions.contains)) {
       event.setCancelled(true)

--- a/src/main/scala/com/github/unchama/seichiassist/listener/SpawnRegionProjectileInterceptor.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/listener/SpawnRegionProjectileInterceptor.scala
@@ -24,7 +24,7 @@ object SpawnRegionProjectileInterceptor extends Listener {
     val inventory = player.getInventory
     val action = event.getAction
     val projectiles = Set(
-      BOW, EGG, LINGERING_POTION, SPLASH_POTION, ENDER_PEARL, EYE_OF_ENDER, FIREBALL, SNOW_BALL, EXP_BOTTLE
+      BOW, EGG, LINGERING_POTION, SPLASH_POTION, ENDER_PEARL, EYE_OF_ENDER, SNOW_BALL, EXP_BOTTLE
     )
 
     // Projectileを持った状態で右クリックし、playerがいる保護がspawn保護の中であった場合はイベントをキャンセルする

--- a/src/main/scala/com/github/unchama/seichiassist/listener/SpawnRegionProjectileInterceptor.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/listener/SpawnRegionProjectileInterceptor.scala
@@ -17,14 +17,14 @@ object SpawnRegionProjectileInterceptor extends Listener {
     // 公共施設サーバーのスポーン地点名
     "world-spawn"
   )
+  val projectiles = Set(
+    BOW, EGG, LINGERING_POTION, SPLASH_POTION, ENDER_PEARL, EYE_OF_ENDER, SNOW_BALL, EXP_BOTTLE
+  )
 
   @EventHandler
   def beforeProjectileLaunch(event: PlayerInteractEvent): Unit = {
     val player = event.getPlayer
     val action = event.getAction
-    val projectiles = Set(
-      BOW, EGG, LINGERING_POTION, SPLASH_POTION, ENDER_PEARL, EYE_OF_ENDER, SNOW_BALL, EXP_BOTTLE
-    )
 
     // Projectileを持った状態で右クリックし、playerがいる保護がspawn保護の中であった場合はイベントをキャンセルする
     if (event.hasItem

--- a/src/main/scala/com/github/unchama/seichiassist/listener/SpawnRegionProjectileInterceptor.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/listener/SpawnRegionProjectileInterceptor.scala
@@ -9,6 +9,15 @@ import org.bukkit.event.{EventHandler, Listener}
 import scala.jdk.CollectionConverters._
 
 object SpawnRegionProjectileInterceptor extends Listener {
+  val spawnRegions = Set(
+    // 基本の保護名
+    "spawn",
+    // メインワールドにおいて、スポーン地点を保護している保護名
+    "spawn-center",
+    // 公共施設サーバーのスポーン地点名
+    "world-spawn"
+  )
+
   @EventHandler
   def beforeProjectileLaunch(event: PlayerInteractEvent): Unit = {
     val player = event.getPlayer
@@ -16,14 +25,6 @@ object SpawnRegionProjectileInterceptor extends Listener {
     val action = event.getAction
     val projectiles = Set(
       BOW, EGG, LINGERING_POTION, SPLASH_POTION, ENDER_PEARL, EYE_OF_ENDER, FIREBALL, SNOW_BALL, EXP_BOTTLE
-    )
-    val spawnRegions = Set(
-      // 基本の保護名
-      "spawn",
-      // メインワールドにおいて、スポーン地点を保護している保護名
-      "spawn-center",
-      // 公共施設サーバーのスポーン地点名
-      "world-spawn"
     )
 
     // Projectileを持った状態で右クリックし、playerがいる保護がspawn保護の中であった場合はイベントをキャンセルする

--- a/src/main/scala/com/github/unchama/seichiassist/listener/SpawnRegionProjectileInterceptor.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/listener/SpawnRegionProjectileInterceptor.scala
@@ -1,18 +1,22 @@
 package com.github.unchama.seichiassist.listener
 
-import com.github.unchama.util.external.WorldGuardWrapper.{getOneRegion, getRegions}
-import org.bukkit.entity.Player
-import org.bukkit.event.entity.ProjectileLaunchEvent
+import com.github.unchama.util.external.WorldGuardWrapper.getRegions
+import org.bukkit.Material._
+import org.bukkit.event.block.Action
+import org.bukkit.event.player.PlayerInteractEvent
 import org.bukkit.event.{EventHandler, Listener}
 
 import scala.jdk.CollectionConverters._
 
 object SpawnRegionProjectileInterceptor extends Listener {
   @EventHandler
-  def onProjectileLaunch(event: ProjectileLaunchEvent): Unit = {
-    val projectile = event.getEntity
-    if (projectile == null) return
-
+  def onProjectileLaunched(event: PlayerInteractEvent): Unit = {
+    val player = event.getPlayer
+    val inventory = player.getInventory
+    val action = event.getAction
+    val projectiles = Set(
+      BOW, EGG, LINGERING_POTION, SPLASH_POTION, ENDER_PEARL, EYE_OF_ENDER, FIREBALL, SNOW_BALL, EXP_BOTTLE
+    )
     val spawnRegions = Set(
       // 基本の保護名
       "spawn",
@@ -22,10 +26,12 @@ object SpawnRegionProjectileInterceptor extends Listener {
       "world-spawn"
     )
 
-    projectile.getShooter match {
-      case player: Player =>
-        if (getRegions(player.getLocation).asScala.map(_.getId).exists(spawnRegions.contains)) event.setCancelled(true)
-      case _ =>
+    // Projectileを持った状態で右クリックし、playerがいる保護がspawn保護の中であった場合はイベントをキャンセルする
+    if (inventory.getItemInMainHand != null
+      && projectiles.contains(inventory.getItemInMainHand.getType)
+      && (action == Action.RIGHT_CLICK_AIR || action == Action.RIGHT_CLICK_BLOCK)
+      && getRegions(player.getLocation).asScala.map(_.getId).exists(spawnRegions.contains)) {
+      event.setCancelled(true)
     }
   }
 }


### PR DESCRIPTION
This closes #851