### PR TITLE
メニューインベントリからの依存関係を整理できる機構を導入する

### DIFF
--- a/src/main/scala/com/github/unchama/buildassist/PlayerInventoryListener.scala
+++ b/src/main/scala/com/github/unchama/buildassist/PlayerInventoryListener.scala
@@ -1,11 +1,10 @@
 package com.github.unchama.buildassist
 
-import cats.effect.{IO, SyncIO}
+import cats.effect.IO
 import com.github.unchama.buildassist.menu.BuildMainMenu
 import com.github.unchama.generic.effect.unsafe.EffectEnvironment
+import com.github.unchama.menuinventory.router.CanOpen
 import com.github.unchama.seichiassist.effects.player.CommonSoundEffects
-import com.github.unchama.seichiassist.meta.subsystem.StatefulSubsystem
-import com.github.unchama.seichiassist.subsystems
 import net.md_5.bungee.api.ChatColor._
 import org.bukkit.entity.{EntityType, Player}
 import org.bukkit.event.inventory.{InventoryClickEvent, InventoryType}
@@ -13,7 +12,8 @@ import org.bukkit.event.{EventHandler, Listener}
 import org.bukkit.{Material, Sound}
 
 class PlayerInventoryListener(implicit effectEnvironment: EffectEnvironment,
-                              flySystem: StatefulSubsystem[IO, subsystems.managedfly.InternalState[SyncIO]]) extends Listener {
+                              ioCanOpenBuildMainMenu: IO CanOpen BuildMainMenu.type) extends Listener {
+
   import com.github.unchama.targetedeffect._
   import com.github.unchama.util.syntax.Nullability.NullabilityExtensionReceiver
 
@@ -62,12 +62,11 @@ class PlayerInventoryListener(implicit effectEnvironment: EffectEnvironment,
 			 */
       if (itemstackcurrent.getType == Material.SKULL_ITEM) {
         //ホームメニューへ帰還
-        import com.github.unchama.seichiassist.concurrent.PluginExecutionContexts.{layoutPreparationContext, syncShift}
 
         effectEnvironment.runAsyncTargetedEffect(player)(
           SequentialEffect(
             CommonSoundEffects.menuTransitionFenceSound,
-            new BuildMainMenu().open
+            ioCanOpenBuildMainMenu.open(BuildMainMenu)
           ),
           "BuildMainMenuを開く"
         )

--- a/src/main/scala/com/github/unchama/buildassist/listener/BuildMainMenuOpener.scala
+++ b/src/main/scala/com/github/unchama/buildassist/listener/BuildMainMenuOpener.scala
@@ -1,19 +1,18 @@
 package com.github.unchama.buildassist.listener
 
-import cats.effect.{IO, SyncIO}
+import cats.effect.IO
 import com.github.unchama.buildassist.menu.BuildMainMenu
 import com.github.unchama.generic.effect.unsafe.EffectEnvironment
+import com.github.unchama.menuinventory.router.CanOpen
 import com.github.unchama.seichiassist.effects.player.CommonSoundEffects
-import com.github.unchama.seichiassist.meta.subsystem.StatefulSubsystem
-import com.github.unchama.seichiassist.subsystems
 import org.bukkit.Material
 import org.bukkit.event.block.Action
 import org.bukkit.event.player.PlayerInteractEvent
 import org.bukkit.event.{EventHandler, Listener}
 import org.bukkit.inventory.EquipmentSlot
 
-class PlayerLeftClickListener(implicit effectEnvironment: EffectEnvironment,
-                              flySystem: StatefulSubsystem[IO, subsystems.managedfly.InternalState[SyncIO]]) extends Listener {
+class BuildMainMenuOpener(implicit effectEnvironment: EffectEnvironment,
+                          ioCanOpenBuildMainMenu: IO CanOpen BuildMainMenu.type) extends Listener {
 
   import com.github.unchama.targetedeffect._
 
@@ -33,12 +32,10 @@ class PlayerLeftClickListener(implicit effectEnvironment: EffectEnvironment,
       if (!hasStickOnMainHand || !actionWasOnMainHand) return
     }
 
-    import com.github.unchama.seichiassist.concurrent.PluginExecutionContexts.{layoutPreparationContext, syncShift}
-
     effectEnvironment.runAsyncTargetedEffect(player)(
       SequentialEffect(
         CommonSoundEffects.menuTransitionFenceSound,
-        new BuildMainMenu().open
+        ioCanOpenBuildMainMenu.open(BuildMainMenu)
       ),
       "BuildMainMenuを開く"
     )

--- a/src/main/scala/com/github/unchama/buildassist/menu/BlockPlacementSkillMenu.scala
+++ b/src/main/scala/com/github/unchama/buildassist/menu/BlockPlacementSkillMenu.scala
@@ -3,11 +3,11 @@ package com.github.unchama.buildassist.menu
 import cats.effect.{IO, SyncIO}
 import com.github.unchama.buildassist.{BuildAssist, TemporaryMutableBuildAssistPlayerData}
 import com.github.unchama.itemstackbuilder.{IconItemStackBuilder, SkullItemStackBuilder}
+import com.github.unchama.menuinventory.router.CanOpen
 import com.github.unchama.menuinventory.slot.button.action.LeftClickButtonEffect
 import com.github.unchama.menuinventory.slot.button.{Button, RecomputedButton}
 import com.github.unchama.menuinventory.{Menu, MenuFrame, MenuSlotLayout}
 import com.github.unchama.seichiassist.effects.player.CommonSoundEffects
-import com.github.unchama.seichiassist.meta.subsystem.StatefulSubsystem
 import com.github.unchama.seichiassist.subsystems
 import com.github.unchama.targetedeffect.commandsender.MessageEffect
 import com.github.unchama.targetedeffect.player.FocusedSoundEffect
@@ -17,9 +17,9 @@ import org.bukkit.ChatColor._
 import org.bukkit.entity.Player
 import org.bukkit.{Material, Sound}
 
-class BlockPlacementSkillMenu(implicit flySystem: StatefulSubsystem[IO, subsystems.managedfly.InternalState[SyncIO]]) extends Menu {
+object BlockPlacementSkillMenu extends Menu {
 
-  import com.github.unchama.seichiassist.concurrent.PluginExecutionContexts.{layoutPreparationContext, syncShift}
+  import com.github.unchama.seichiassist.concurrent.PluginExecutionContexts.syncShift
   import menuinventory.syntax._
 
   class Environment(implicit
@@ -29,7 +29,7 @@ class BlockPlacementSkillMenu(implicit flySystem: StatefulSubsystem[IO, subsyste
   override val frame: MenuFrame =
     MenuFrame(4.chestRows, s"$DARK_PURPLE$BOLD「範囲設置スキル」設定画面")
 
-  def buttonToOpenPreviousPage(): Button = {
+  def buttonToOpenPreviousPage(implicit environment: Environment): Button = {
     val iconItemStack = new IconItemStackBuilder(Material.BARRIER)
       .title(s"$YELLOW$UNDERLINE${BOLD}元のページへ")
       .lore(s"$RESET$DARK_RED${UNDERLINE}クリックで移動")
@@ -39,15 +39,19 @@ class BlockPlacementSkillMenu(implicit flySystem: StatefulSubsystem[IO, subsyste
       iconItemStack,
       LeftClickButtonEffect(
         CommonSoundEffects.menuTransitionFenceSound,
-        new BuildMainMenu().open
+        environment.canOpenMainMenu.open(BuildMainMenu)
       )
     )
   }
 
-  private case class ButtonComputations(player: Player) {
+  private case class ButtonComputations(player: Player)(implicit environment: Environment) {
 
     import com.github.unchama.seichiassist.concurrent.PluginExecutionContexts.layoutPreparationContext
     import player._
+
+    implicit class PlayerDataOps(val playerData: TemporaryMutableBuildAssistPlayerData) {
+      def computeCurrentSkillRange(): Int = playerData.AREAint * 2 + 1
+    }
 
     def computeButtonToToggleDirtPlacement(): IO[Button] = RecomputedButton {
       IO {
@@ -305,7 +309,7 @@ class BlockPlacementSkillMenu(implicit flySystem: StatefulSubsystem[IO, subsyste
     }
   }
 
-  override def computeMenuLayout(player: Player): IO[MenuSlotLayout] = {
+  override def computeMenuLayout(player: Player)(implicit environment: Environment): IO[MenuSlotLayout] = {
     val computations = ButtonComputations(player)
     import computations._
 
@@ -333,12 +337,4 @@ class BlockPlacementSkillMenu(implicit flySystem: StatefulSubsystem[IO, subsyste
       dynamicPart <- dynamicPartComputation
     } yield menuinventory.MenuSlotLayout(constantPart ++ dynamicPart)
   }
-}
-
-object BlockPlacementSkillMenu {
-
-  implicit class PlayerDataOps(val playerData: TemporaryMutableBuildAssistPlayerData) extends AnyVal {
-    def computeCurrentSkillRange(): Int = playerData.AREAint * 2 + 1
-  }
-
 }

--- a/src/main/scala/com/github/unchama/buildassist/menu/BlockPlacementSkillMenu.scala
+++ b/src/main/scala/com/github/unchama/buildassist/menu/BlockPlacementSkillMenu.scala
@@ -22,6 +22,10 @@ class BlockPlacementSkillMenu(implicit flySystem: StatefulSubsystem[IO, subsyste
   import com.github.unchama.seichiassist.concurrent.PluginExecutionContexts.{layoutPreparationContext, syncShift}
   import menuinventory.syntax._
 
+  class Environment(implicit
+                    val canOpenMainMenu: CanOpen[IO, BuildMainMenu.type],
+                    val flyState: subsystems.managedfly.InternalState[SyncIO])
+
   override val frame: MenuFrame =
     MenuFrame(4.chestRows, s"$DARK_PURPLE$BOLD「範囲設置スキル」設定画面")
 
@@ -42,7 +46,6 @@ class BlockPlacementSkillMenu(implicit flySystem: StatefulSubsystem[IO, subsyste
 
   private case class ButtonComputations(player: Player) {
 
-    import BlockPlacementSkillMenu._
     import com.github.unchama.seichiassist.concurrent.PluginExecutionContexts.layoutPreparationContext
     import player._
 

--- a/src/main/scala/com/github/unchama/buildassist/menu/BuildAssistMenuRouter.scala
+++ b/src/main/scala/com/github/unchama/buildassist/menu/BuildAssistMenuRouter.scala
@@ -1,0 +1,38 @@
+package com.github.unchama.buildassist.menu
+
+import cats.effect.{IO, SyncIO}
+import com.github.unchama.menuinventory.LayoutPreparationContext
+import com.github.unchama.menuinventory.router.CanOpen
+import com.github.unchama.minecraft.actions.MinecraftServerThreadShift
+import com.github.unchama.seichiassist.subsystems
+
+trait BuildAssistMenuRouter[F[_]] {
+  implicit val canOpenBlockPlacementSkillMenu: F CanOpen BlockPlacementSkillMenu.type
+  implicit val canOpenBuildMainMenu: F CanOpen BuildMainMenu.type
+  implicit val canOpenMineStackMassCraftMenu: F CanOpen MineStackMassCraftMenu
+}
+
+object BuildAssistMenuRouter {
+
+  def apply(implicit
+            flyState: subsystems.managedfly.InternalState[SyncIO],
+            layoutPreparationContext: LayoutPreparationContext,
+            syncShift: MinecraftServerThreadShift[IO]): BuildAssistMenuRouter[IO] = {
+    new BuildAssistMenuRouter[IO] {
+      implicit lazy val blockPlacementSkillMenuEnvironment: BlockPlacementSkillMenu.Environment =
+        new BlockPlacementSkillMenu.Environment
+      implicit lazy val buildMainMenuEnvironment: BuildMainMenu.Environment =
+        new BuildMainMenu.Environment
+      implicit lazy val mineStackMassCraftMenuEnvironment: MineStackMassCraftMenu.Environment =
+        new MineStackMassCraftMenu.Environment
+
+      override implicit lazy val canOpenBlockPlacementSkillMenu: CanOpen[IO, BlockPlacementSkillMenu.type] =
+        _.open
+      override implicit lazy val canOpenBuildMainMenu: CanOpen[IO, BuildMainMenu.type] =
+        _.open
+      override implicit lazy val canOpenMineStackMassCraftMenu: CanOpen[IO, MineStackMassCraftMenu] =
+        _.open
+    }
+  }
+
+}

--- a/src/main/scala/com/github/unchama/buildassist/menu/MineStackMassCraftMenu.scala
+++ b/src/main/scala/com/github/unchama/buildassist/menu/MineStackMassCraftMenu.scala
@@ -1,18 +1,18 @@
 package com.github.unchama.buildassist.menu
 
 import cats.data.{Kleisli, NonEmptyList}
-import cats.effect.{IO, SyncIO}
+import cats.effect.IO
 import com.github.unchama.buildassist.BuildAssist
 import com.github.unchama.itemstackbuilder.{SkullItemStackBuilder, SkullOwnerReference}
+import com.github.unchama.menuinventory.router.CanOpen
 import com.github.unchama.menuinventory.slot.Slot
 import com.github.unchama.menuinventory.slot.button.action.LeftClickButtonEffect
 import com.github.unchama.menuinventory.slot.button.{Button, ReloadingButton}
 import com.github.unchama.menuinventory.{ChestSlotRef, Menu, MenuFrame, MenuSlotLayout}
 import com.github.unchama.seichiassist.menus.{ColorScheme, CommonButtons}
-import com.github.unchama.seichiassist.meta.subsystem.StatefulSubsystem
 import com.github.unchama.seichiassist.minestack.MineStackObj
 import com.github.unchama.seichiassist.util.Util
-import com.github.unchama.seichiassist.{SeichiAssist, SkullOwners, subsystems}
+import com.github.unchama.seichiassist.{SeichiAssist, SkullOwners}
 import com.github.unchama.targetedeffect.commandsender.MessageEffect
 import com.github.unchama.targetedeffect.player.FocusedSoundEffect
 import org.bukkit.ChatColor._
@@ -28,6 +28,10 @@ object MineStackMassCraftMenu {
 
   type MineStackItemId = String
 
+  class Environment(implicit
+                    val canOpenBuildMainMenu: CanOpen[IO, BuildMainMenu.type],
+                    val canOpenItself: CanOpen[IO, MineStackMassCraftMenu])
+
   case class MassCraftRecipe(ingredients: NonEmptyList[(MineStackItemId, Int)],
                              products: NonEmptyList[(MineStackItemId, Int)]) {
     /**
@@ -35,7 +39,9 @@ object MineStackMassCraftMenu {
      */
     def scaleBy(scale: Int): MassCraftRecipe = {
       def scaleChunk(chunk: (MineStackItemId, Int)): (MineStackItemId, Int) =
-        chunk match { case (id, amount) => (id, amount * scale) }
+        chunk match {
+          case (id, amount) => (id, amount * scale)
+        }
 
       MassCraftRecipe(ingredients.map(scaleChunk), products.map(scaleChunk))
     }
@@ -50,7 +56,7 @@ object MineStackMassCraftMenu {
      * @param menuPageNumber         このボタンが表示される一括クラフト画面のページ番号
      */
     def computeButton(player: Player, requiredMassCraftLevel: Int, menuPageNumber: Int)
-                     (implicit flySystem: StatefulSubsystem[IO, subsystems.managedfly.InternalState[SyncIO]]): IO[Button] = {
+                     (implicit environment: Environment): IO[Button] = {
       import cats.implicits._
 
       def queryAmountOf(mineStackObj: MineStackObj): IO[Long] = IO {
@@ -120,7 +126,7 @@ object MineStackMassCraftMenu {
 
       }
 
-    val buttonEffect = LeftClickButtonEffect(
+      val buttonEffect = LeftClickButtonEffect(
         Kleisli { player =>
           for {
             buildLevel <- BuildAssist.instance.buildAmountDataRepository(player).read.toIO
@@ -176,7 +182,7 @@ object MineStackMassCraftMenu {
 
   case class MassCraftRecipeBlock(recipe: MassCraftRecipe, recipeScales: List[Int], requiredBuildLevel: Int) {
     def toLayout(player: Player, beginIndex: Int, pageNumber: Int)
-                (implicit flySystem: StatefulSubsystem[IO, subsystems.managedfly.InternalState[SyncIO]]): IO[List[(Int, Slot)]] = {
+                (implicit environment: Environment): IO[List[(Int, Slot)]] = {
       import cats.implicits._
 
       recipeScales.zipWithIndex
@@ -490,65 +496,64 @@ object MineStackMassCraftMenu {
       )
     )
   }
+}
 
-  def apply(pageNumber: Int = 1)
-           (implicit flySystem: StatefulSubsystem[IO, subsystems.managedfly.InternalState[SyncIO]]): Menu = {
-    import eu.timepit.refined.auto._
+case class MineStackMassCraftMenu(pageNumber: Int = 1) extends Menu {
+  override type Environment = MineStackMassCraftMenu.Environment
 
-    val menuFrame = {
-      import com.github.unchama.menuinventory.syntax._
-      MenuFrame(6.chestRows, ColorScheme.purpleBold(s"MineStackブロック一括クラフト$pageNumber"))
-    }
+  override val frame: MenuFrame = {
+    import com.github.unchama.menuinventory.syntax._
+    MenuFrame(6.chestRows, ColorScheme.purpleBold(s"MineStackブロック一括クラフト$pageNumber"))
+  }
 
-    new Menu {
-      override val frame: MenuFrame = menuFrame
+  import eu.timepit.refined.auto._
 
-      override def computeMenuLayout(player: Player): IO[MenuSlotLayout] = {
-        def buttonToTransferTo(newPageNumber: Int, skullOwnerReference: SkullOwnerReference): Button =
-          CommonButtons.transferButton(
-            new SkullItemStackBuilder(skullOwnerReference),
-            s"${newPageNumber}ページ目へ",
-            MineStackMassCraftMenu(newPageNumber)
-          )
+  override def computeMenuLayout(player: Player)(implicit environment: Environment): IO[MenuSlotLayout] = {
+    import environment._
 
-        val previousPageButtonSection =
-          if (pageNumber > 1) {
-            Map(ChestSlotRef(5, 7) -> buttonToTransferTo(pageNumber - 1, SkullOwners.MHF_ArrowUp))
-          } else {
-            Map()
-          }
+    def buttonToTransferTo(newPageNumber: Int, skullOwnerReference: SkullOwnerReference): Button =
+      CommonButtons.transferButton(
+        new SkullItemStackBuilder(skullOwnerReference),
+        s"${newPageNumber}ページ目へ",
+        MineStackMassCraftMenu(newPageNumber)
+      )
 
-        val nextPageButtonSection =
-          if (recipeBlocks.isDefinedAt(pageNumber)) {
-            Map(ChestSlotRef(5, 8) -> buttonToTransferTo(pageNumber + 1, SkullOwners.MHF_ArrowDown))
-          } else {
-            Map()
-          }
-
-        val backToMenuButtonSection =
-          Map(
-            ChestSlotRef(5, 0) -> CommonButtons.transferButton(
-              new SkullItemStackBuilder(SkullOwners.MHF_ArrowLeft),
-              "ホームへ", new BuildMainMenu()
-            )
-          )
-
-        import cats.implicits._
-
-        for {
-          recipeSectionBlocks <-
-            recipeBlocks(pageNumber - 1)
-              .traverse { case (beginIndex, recipeBlock) =>
-                recipeBlock.toLayout(player, beginIndex, pageNumber)
-              }
-
-          recipeSection = recipeSectionBlocks.flatten.toMap
-        } yield {
-          MenuSlotLayout(
-            recipeSection ++ previousPageButtonSection ++ nextPageButtonSection ++ backToMenuButtonSection
-          )
-        }
+    val previousPageButtonSection =
+      if (pageNumber > 1) {
+        Map(ChestSlotRef(5, 7) -> buttonToTransferTo(pageNumber - 1, SkullOwners.MHF_ArrowUp))
+      } else {
+        Map()
       }
+
+    val nextPageButtonSection =
+      if (MineStackMassCraftMenu.recipeBlocks.isDefinedAt(pageNumber)) {
+        Map(ChestSlotRef(5, 8) -> buttonToTransferTo(pageNumber + 1, SkullOwners.MHF_ArrowDown))
+      } else {
+        Map()
+      }
+
+    val backToMenuButtonSection =
+      Map(
+        ChestSlotRef(5, 0) -> CommonButtons.transferButton(
+          new SkullItemStackBuilder(SkullOwners.MHF_ArrowLeft),
+          "ホームへ", BuildMainMenu
+        )
+      )
+
+    import cats.implicits._
+
+    for {
+      recipeSectionBlocks <-
+        MineStackMassCraftMenu.recipeBlocks(pageNumber - 1)
+          .traverse { case (beginIndex, recipeBlock) =>
+            recipeBlock.toLayout(player, beginIndex, pageNumber)
+          }
+
+      recipeSection = recipeSectionBlocks.flatten.toMap
+    } yield {
+      MenuSlotLayout(
+        recipeSection ++ previousPageButtonSection ++ nextPageButtonSection ++ backToMenuButtonSection
+      )
     }
   }
 }

--- a/src/main/scala/com/github/unchama/menuinventory/Menu.scala
+++ b/src/main/scala/com/github/unchama/menuinventory/Menu.scala
@@ -29,7 +29,7 @@ trait Menu {
    */
   def open(implicit ctx: LayoutPreparationContext, syncCtx: MinecraftServerThreadShift[IO]): TargetedEffect[Player] = data.Kleisli { player =>
     for {
-      session <- frame.createNewSession()
+      session <- MenuSession.createNewSessionWith[IO](frame)
       _ <- session.openInventory.run(player)
       layout <- computeMenuLayout(player)
       _ <- session.overwriteViewWith(layout)

--- a/src/main/scala/com/github/unchama/menuinventory/Menu.scala
+++ b/src/main/scala/com/github/unchama/menuinventory/Menu.scala
@@ -15,6 +15,12 @@ import org.bukkit.entity.Player
 trait Menu {
 
   /**
+   * メニューを開く操作に必要な環境情報の型。
+   * 例えば、メニューが利用するAPIなどをここを通して渡すことができる。
+   */
+  type Environment
+
+  /**
    * メニューのサイズとタイトルに関する情報
    */
   val frame: MenuFrame
@@ -22,12 +28,14 @@ trait Menu {
   /**
    * @return `player`からメニューの[[MenuSlotLayout]]を計算する[[IO]]
    */
-  def computeMenuLayout(player: Player): IO[MenuSlotLayout]
+  def computeMenuLayout(player: Player)(implicit environment: Environment): IO[MenuSlotLayout]
 
   /**
    * メニューを[Player]に開かせる[TargetedEffect].
    */
-  def open(implicit ctx: LayoutPreparationContext, syncCtx: MinecraftServerThreadShift[IO]): TargetedEffect[Player] = data.Kleisli { player =>
+  def open(implicit environment: Environment,
+           ctx: LayoutPreparationContext,
+           syncCtx: MinecraftServerThreadShift[IO]): TargetedEffect[Player] = data.Kleisli { player =>
     for {
       session <- MenuSession.createNewSessionWith[IO](frame)
       _ <- session.openInventory.run(player)

--- a/src/main/scala/com/github/unchama/menuinventory/MenuFrame.scala
+++ b/src/main/scala/com/github/unchama/menuinventory/MenuFrame.scala
@@ -1,6 +1,5 @@
 package com.github.unchama.menuinventory
 
-import cats.effect.IO
 import com.github.unchama.menuinventory.InventoryRowSize.InventorySize
 import com.github.unchama.util.InventoryUtil._
 import org.bukkit.inventory.{Inventory, InventoryHolder}
@@ -10,8 +9,6 @@ import org.bukkit.inventory.{Inventory, InventoryHolder}
  * @param title インベントリのタイトル
  */
 case class MenuFrame(size: InventorySize, title: String) {
-  def createNewSession(): IO[MenuSession] = IO(new MenuSession(this))
-
   private[menuinventory] def createConfiguredInventory(holder: InventoryHolder): Inventory =
     createInventory(Some(holder), size, Some(title))
 }

--- a/src/main/scala/com/github/unchama/menuinventory/MenuSession.scala
+++ b/src/main/scala/com/github/unchama/menuinventory/MenuSession.scala
@@ -2,7 +2,7 @@ package com.github.unchama.menuinventory
 
 import cats.Eq
 import cats.effect.concurrent.Ref
-import cats.effect.{ContextShift, IO}
+import cats.effect.{ContextShift, IO, Sync}
 import com.github.unchama.menuinventory.slot.Slot
 import com.github.unchama.minecraft.actions.MinecraftServerThreadShift
 import com.github.unchama.targetedeffect.TargetedEffect
@@ -14,7 +14,7 @@ import org.bukkit.inventory.{Inventory, InventoryHolder, ItemStack}
 /**
  * 共有された[sessionInventory]を作用付きの「メニュー」として扱うインベントリを保持するためのセッション.
  */
-class MenuSession private[menuinventory](private val frame: MenuFrame) extends InventoryHolder {
+class MenuSession private(private val frame: MenuFrame) extends InventoryHolder {
 
   val currentLayout: Ref[IO, MenuSlotLayout] = Ref.unsafe(MenuSlotLayout())
 
@@ -86,5 +86,11 @@ class MenuSession private[menuinventory](private val frame: MenuFrame) extends I
   }
 
   override def getInventory: Inventory = sessionInventory
+
+}
+
+object MenuSession {
+
+  def createNewSessionWith[F[_] : Sync](frame: MenuFrame): F[MenuSession] = Sync[F].delay(new MenuSession(frame))
 
 }

--- a/src/main/scala/com/github/unchama/menuinventory/router/CanOpen.scala
+++ b/src/main/scala/com/github/unchama/menuinventory/router/CanOpen.scala
@@ -1,0 +1,14 @@
+package com.github.unchama.menuinventory.router
+
+import cats.data.Kleisli
+import com.github.unchama.menuinventory.Menu
+import org.bukkit.entity.Player
+
+/**
+ * `F` の文脈で `M` をプレーヤーに開かせる作用を提供するtrait。
+ */
+trait CanOpen[F[_], M <: Menu] {
+
+  def open(menu: M): Kleisli[F, Player, Unit]
+
+}

--- a/src/main/scala/com/github/unchama/menuinventory/slot/button/ReloadingButton.scala
+++ b/src/main/scala/com/github/unchama/menuinventory/slot/button/ReloadingButton.scala
@@ -9,7 +9,10 @@ object ReloadingButton {
   /**
    * クリックされるたびに[buttonComputation]に基づいてスロット自体が更新される[Button]を作成する.
    */
-  def apply(menu: Menu)(button: Button)(implicit ctx: LayoutPreparationContext): Button = {
+  def apply[M <: Menu](menu: M)(button: Button)
+                      (implicit
+                       environment: menu.Environment,
+                       ctx: LayoutPreparationContext): Button = {
     button.withAnotherEffect(
       ButtonEffect(scope => {
         val clicker = scope.event.getWhoClicked.asInstanceOf[Player]

--- a/src/main/scala/com/github/unchama/seichiassist/SeichiAssist.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/SeichiAssist.scala
@@ -27,6 +27,7 @@ import com.github.unchama.seichiassist.infrastructure.akka.ConfiguredActorSystem
 import com.github.unchama.seichiassist.infrastructure.logging.jul.NamedJULLogger
 import com.github.unchama.seichiassist.infrastructure.scalikejdbc.ScalikeJDBCConfiguration
 import com.github.unchama.seichiassist.listener._
+import com.github.unchama.seichiassist.menus.TopLevelRouter
 import com.github.unchama.seichiassist.meta.subsystem.{StatefulSubsystem, Subsystem}
 import com.github.unchama.seichiassist.minestack.{MineStackObj, MineStackObjectCategory}
 import com.github.unchama.seichiassist.subsystems._
@@ -313,6 +314,9 @@ class SeichiAssist extends JavaPlugin() {
     }
 
     import PluginExecutionContexts._
+
+    val menuRouter = TopLevelRouter.apply
+    import menuRouter.canOpenStickMenu
 
     MineStackObjectList.minestackGachaPrizes ++= SeichiAssist.generateGachaPrizes()
 

--- a/src/main/scala/com/github/unchama/seichiassist/commands/StickMenuCommand.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/commands/StickMenuCommand.scala
@@ -1,9 +1,9 @@
 package com.github.unchama.seichiassist.commands
 
 import cats.effect.IO
+import com.github.unchama.menuinventory.router.CanOpen
 import com.github.unchama.seichiassist.commands.contextual.builder.BuilderTemplates.playerCommandBuilder
-import com.github.unchama.seichiassist.concurrent.PluginExecutionContexts.{layoutPreparationContext, syncShift}
-import com.github.unchama.seichiassist.menus.stickmenu.StickMenu
+import com.github.unchama.seichiassist.menus.stickmenu.{FirstPage, StickMenu}
 import org.bukkit.command.TabExecutor
 
 /*
@@ -11,9 +11,8 @@ import org.bukkit.command.TabExecutor
 * @author KisaragiEffective
 */
 object StickMenuCommand {
-  val effect = StickMenu.firstPage.open
-  val executor: TabExecutor = playerCommandBuilder
-    .execution { _ => IO.pure(effect) }
+  def executor(implicit ioCanOpenStickMenuFirstPage: IO CanOpen FirstPage.type): TabExecutor = playerCommandBuilder
+    .execution { _ => IO.pure(ioCanOpenStickMenuFirstPage.open(StickMenu.firstPage)) }
     .build()
     .asNonBlockingTabExecutor()
 }

--- a/src/main/scala/com/github/unchama/seichiassist/listener/PlayerClickListener.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/listener/PlayerClickListener.scala
@@ -3,9 +3,10 @@ package com.github.unchama.seichiassist.listener
 import cats.effect.IO
 import com.github.unchama.generic.effect.TryableFiber
 import com.github.unchama.generic.effect.unsafe.EffectEnvironment
+import com.github.unchama.menuinventory.router.CanOpen
 import com.github.unchama.seichiassist.data.GachaPrize
 import com.github.unchama.seichiassist.effects.player.CommonSoundEffects
-import com.github.unchama.seichiassist.menus.stickmenu.StickMenu
+import com.github.unchama.seichiassist.menus.stickmenu.{FirstPage, StickMenu}
 import com.github.unchama.seichiassist.seichiskill.ActiveSkill
 import com.github.unchama.seichiassist.seichiskill.ActiveSkillRange.RemoteArea
 import com.github.unchama.seichiassist.seichiskill.SeichiSkillUsageMode.Disabled
@@ -28,7 +29,8 @@ import org.bukkit.{GameMode, Material, Sound}
 
 import scala.collection.mutable
 
-class PlayerClickListener(implicit effectEnvironment: EffectEnvironment) extends Listener {
+class PlayerClickListener(implicit effectEnvironment: EffectEnvironment,
+                          ioCanOpenStickMenu: IO CanOpen FirstPage.type) extends Listener {
 
   import com.github.unchama.generic.ContextCoercion._
   import com.github.unchama.seichiassist.concurrent.PluginExecutionContexts.{syncShift, timer}
@@ -380,12 +382,10 @@ class PlayerClickListener(implicit effectEnvironment: EffectEnvironment) extends
     if (event.getHand == EquipmentSlot.OFF_HAND) return
     event.setCancelled(true)
 
-    import com.github.unchama.seichiassist.concurrent.PluginExecutionContexts.layoutPreparationContext
-
     effectEnvironment.runAsyncTargetedEffect(player)(
       SequentialEffect(
         CommonSoundEffects.menuTransitionFenceSound,
-        StickMenu.firstPage.open
+        ioCanOpenStickMenu.open(StickMenu.firstPage)
       ),
       "棒メニューの1ページ目を開く"
     )

--- a/src/main/scala/com/github/unchama/seichiassist/listener/PlayerInventoryListener.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/listener/PlayerInventoryListener.scala
@@ -1,12 +1,14 @@
 package com.github.unchama.seichiassist.listener
 
+import cats.effect.IO
 import com.github.unchama.generic.effect.unsafe.EffectEnvironment
+import com.github.unchama.menuinventory.router.CanOpen
 import com.github.unchama.seichiassist._
 import com.github.unchama.seichiassist.data.player.GiganticBerserk
 import com.github.unchama.seichiassist.data.{GachaSkullData, ItemData, MenuInventoryData}
 import com.github.unchama.seichiassist.effects.player.CommonSoundEffects
 import com.github.unchama.seichiassist.listener.invlistener.OnClickTitleMenu
-import com.github.unchama.seichiassist.menus.stickmenu.StickMenu
+import com.github.unchama.seichiassist.menus.stickmenu.{FirstPage, StickMenu}
 import com.github.unchama.seichiassist.task.VotingFairyTask
 import com.github.unchama.seichiassist.util.{StaticGachaPrizeFactory, Util}
 import com.github.unchama.targetedeffect.commandsender.MessageEffect
@@ -22,9 +24,9 @@ import org.bukkit.{Bukkit, Material, Sound}
 
 import scala.collection.mutable.ArrayBuffer
 
-class PlayerInventoryListener(implicit effectEnvironment: EffectEnvironment) extends Listener {
+class PlayerInventoryListener(implicit effectEnvironment: EffectEnvironment,
+                              ioCanOpenStickMenu: IO CanOpen FirstPage.type) extends Listener {
 
-  import com.github.unchama.seichiassist.concurrent.PluginExecutionContexts.syncShift
   import com.github.unchama.targetedeffect._
   import com.github.unchama.util.InventoryUtil._
   import com.github.unchama.util.syntax._
@@ -79,12 +81,12 @@ class PlayerInventoryListener(implicit effectEnvironment: EffectEnvironment) ext
         val name = skullMeta.getDisplayName
         skullMeta.getOwner match {
           case "MHF_ArrowLeft" =>
-            import com.github.unchama.seichiassist.concurrent.PluginExecutionContexts.layoutPreparationContext
+
 
             effectEnvironment.runAsyncTargetedEffect(player)(
               SequentialEffect(
                 CommonSoundEffects.menuTransitionFenceSound,
-                StickMenu.firstPage.open
+                ioCanOpenStickMenu.open(StickMenu.firstPage)
               ),
               "棒メニューの1ページ目を開く"
             )
@@ -156,12 +158,10 @@ class PlayerInventoryListener(implicit effectEnvironment: EffectEnvironment) ext
 			 */
       //ページ変更処理
       if (isSkull && itemstackcurrent.getItemMeta.asInstanceOf[SkullMeta].getOwner == "MHF_ArrowLeft") {
-        import com.github.unchama.seichiassist.concurrent.PluginExecutionContexts.layoutPreparationContext
-
         effectEnvironment.runAsyncTargetedEffect(player)(
           SequentialEffect(
             CommonSoundEffects.menuTransitionFenceSound,
-            StickMenu.firstPage.open
+            ioCanOpenStickMenu.open(StickMenu.firstPage)
           ),
           "棒メニューの1ページ目を開く"
         )
@@ -231,12 +231,12 @@ class PlayerInventoryListener(implicit effectEnvironment: EffectEnvironment) ext
         val skullMeta = itemstackcurrent.getItemMeta.asInstanceOf[SkullMeta]
         skullMeta.getOwner match {
           case "MHF_ArrowLeft" =>
-            import com.github.unchama.seichiassist.concurrent.PluginExecutionContexts.{layoutPreparationContext, syncShift}
+
 
             effectEnvironment.runAsyncTargetedEffect(player)(
               SequentialEffect(
                 CommonSoundEffects.menuTransitionFenceSound,
-                StickMenu.firstPage.open
+                ioCanOpenStickMenu.open(StickMenu.firstPage)
               ),
               "棒メニューの1ページ目を開く"
             )
@@ -734,12 +734,11 @@ class PlayerInventoryListener(implicit effectEnvironment: EffectEnvironment) ext
         player.playSound(player.getLocation, Sound.BLOCK_STONE_BUTTON_CLICK_ON, 1f, 1f)
         player.closeInventory()
       } else if (isSkull && itemstackcurrent.getItemMeta.asInstanceOf[SkullMeta].getOwner == "MHF_ArrowLeft") {
-        import com.github.unchama.seichiassist.concurrent.PluginExecutionContexts.layoutPreparationContext
 
         effectEnvironment.runAsyncTargetedEffect(player)(
           SequentialEffect(
             CommonSoundEffects.menuTransitionFenceSound,
-            StickMenu.firstPage.open
+            ioCanOpenStickMenu.open(StickMenu.firstPage)
           ),
           "棒メニューの1ページ目を開く"
         )

--- a/src/main/scala/com/github/unchama/seichiassist/menus/HomeMenu.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/menus/HomeMenu.scala
@@ -2,6 +2,7 @@ package com.github.unchama.seichiassist.menus
 
 import cats.effect.IO
 import com.github.unchama.itemstackbuilder.IconItemStackBuilder
+import com.github.unchama.menuinventory.router.CanOpen
 import com.github.unchama.menuinventory.slot.button.Button
 import com.github.unchama.menuinventory.slot.button.action.LeftClickButtonEffect
 import com.github.unchama.menuinventory.{ChestSlotRef, Menu, MenuFrame, MenuSlotLayout}
@@ -21,8 +22,10 @@ import org.bukkit.{Material, Sound}
 object HomeMenu extends Menu {
 
   import com.github.unchama.menuinventory.syntax._
-  import com.github.unchama.seichiassist.concurrent.PluginExecutionContexts.{layoutPreparationContext, syncShift}
+  import com.github.unchama.seichiassist.concurrent.PluginExecutionContexts.syncShift
   import eu.timepit.refined.auto._
+
+  class Environment(implicit val ioCanOpenConfirmationMenu: IO CanOpen ConfirmationMenu)
 
   /**
    * メニューのサイズとタイトルに関する情報
@@ -32,7 +35,7 @@ object HomeMenu extends Menu {
   /**
    * @return `player`からメニューの[[MenuSlotLayout]]を計算する[[IO]]
    */
-  override def computeMenuLayout(player: Player): IO[MenuSlotLayout] = {
+  override def computeMenuLayout(player: Player)(implicit environment: Environment): IO[MenuSlotLayout] = {
     import eu.timepit.refined._
     import eu.timepit.refined.auto._
     import eu.timepit.refined.numeric._
@@ -94,7 +97,7 @@ object HomeMenu extends Menu {
       )
     }
 
-    val setHomeButtonButton: Button = {
+    def setHomeButtonButton(implicit environment: Environment): Button = {
       Button(
         new IconItemStackBuilder(Material.BED)
           .title(s"$YELLOW$UNDERLINE${BOLD}ホームポイントを設定")
@@ -106,7 +109,7 @@ object HomeMenu extends Menu {
           .build(),
         LeftClickButtonEffect {
           FocusedSoundEffect(Sound.BLOCK_STONE_BUTTON_CLICK_ON, 1f, 1f)
-          ConfirmationMenu(None).open
+          environment.ioCanOpenConfirmationMenu.open(ConfirmationMenu(None))
         }
       )
     }
@@ -129,7 +132,7 @@ object HomeMenu extends Menu {
         }
       )
 
-    def setSubHomeButton(subHomeNumber: Int): Button =
+    def setSubHomeButton(subHomeNumber: Int)(implicit environment: Environment): Button =
       Button(
         new IconItemStackBuilder(Material.BED)
           .title(s"$YELLOW$UNDERLINE${BOLD}サブホームポイント${subHomeNumber}を設定")
@@ -144,7 +147,7 @@ object HomeMenu extends Menu {
         LeftClickButtonEffect {
           SequentialEffect(
             FocusedSoundEffect(Sound.BLOCK_FENCE_GATE_OPEN, 1f, 0.1f),
-            ConfirmationMenu(Some(subHomeNumber)).open
+            environment.ioCanOpenConfirmationMenu.open(ConfirmationMenu(Some(subHomeNumber)))
           )
         }
       )
@@ -152,7 +155,6 @@ object HomeMenu extends Menu {
 
   private case class ButtonComputations(player: Player) {
 
-    import com.github.unchama.seichiassist.concurrent.PluginExecutionContexts.syncShift
     import player._
 
     def setSubHomeNameButton(subHomeNumber: Int): IO[Button] = IO {
@@ -189,7 +191,9 @@ object HomeMenu extends Menu {
     }
   }
 
-  private case class ConfirmationMenu(changeSubHomeNumber: Option[Int], subHomeName: String = "") extends Menu {
+  case class ConfirmationMenu(changeSubHomeNumber: Option[Int], subHomeName: String = "") extends Menu {
+    override type Environment = ConfirmationMenu.Environment
+
     /**
      * メニューのサイズとタイトルに関する情報
      */
@@ -198,7 +202,7 @@ object HomeMenu extends Menu {
     /**
      * @return `player`からメニューの[[MenuSlotLayout]]を計算する[[IO]]
      */
-    override def computeMenuLayout(player: Player): IO[MenuSlotLayout] = {
+    override def computeMenuLayout(player: Player)(implicit environment: Environment): IO[MenuSlotLayout] = {
       val baseSlotMap = Map(
         ChestSlotRef(1, 2) -> changeButton,
         ChestSlotRef(1, 6) -> cancelButton
@@ -227,14 +231,14 @@ object HomeMenu extends Menu {
         }
       )
 
-    val cancelButton: Button =
+    def cancelButton(implicit environment: Environment): Button =
       Button(
         new IconItemStackBuilder(Material.WOOL, durability = 14)
           .title(s"${RED}変更しない")
           .build(),
         LeftClickButtonEffect {
           FocusedSoundEffect(Sound.BLOCK_STONE_BUTTON_CLICK_ON, 1f, 1f)
-          HomeMenu.open
+          environment.ioCanOpenHomeMenu.open(HomeMenu)
         }
       )
 
@@ -248,6 +252,12 @@ object HomeMenu extends Menu {
           ))
           .build()
       )
+  }
+
+  object ConfirmationMenu {
+
+    class Environment(implicit val ioCanOpenHomeMenu: IO CanOpen HomeMenu.type)
+
   }
 
 }

--- a/src/main/scala/com/github/unchama/seichiassist/menus/RegionMenu.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/menus/RegionMenu.scala
@@ -21,10 +21,12 @@ object RegionMenu extends Menu {
   import com.github.unchama.seichiassist.concurrent.PluginExecutionContexts.syncShift
   import com.github.unchama.targetedeffect._
   import com.github.unchama.targetedeffect.player.PlayerEffects.{closeInventoryEffect, _}
-override val frame: MenuFrame =
-    MenuFrame(Right(InventoryType.HOPPER), s"${BLACK}保護メニュー")
 
-  override def computeMenuLayout(player: Player): IO[MenuSlotLayout] = {
+  override type Environment = Unit
+
+  override val frame: MenuFrame = MenuFrame(Right(InventoryType.HOPPER), s"${BLACK}保護メニュー")
+
+  override def computeMenuLayout(player: Player)(implicit environment: Environment): IO[MenuSlotLayout] = {
     import ConstantButtons._
     val computations = ButtonComputations(player)
     import computations._

--- a/src/main/scala/com/github/unchama/seichiassist/menus/ServerSwitchMenu.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/menus/ServerSwitchMenu.scala
@@ -2,9 +2,11 @@ package com.github.unchama.seichiassist.menus
 
 import cats.effect.IO
 import com.github.unchama.itemstackbuilder.IconItemStackBuilder
+import com.github.unchama.menuinventory.router.CanOpen
 import com.github.unchama.menuinventory.slot.button.Button
 import com.github.unchama.menuinventory.slot.button.action.LeftClickButtonEffect
 import com.github.unchama.menuinventory.{ChestSlotRef, Menu, MenuFrame, MenuSlotLayout}
+import com.github.unchama.seichiassist.menus.stickmenu.FirstPage
 import com.github.unchama.targetedeffect._
 import com.github.unchama.targetedeffect.player.PlayerEffects._
 import org.bukkit.ChatColor._
@@ -43,13 +45,15 @@ object ServerSwitchMenu extends Menu {
     case object PUBLIC extends Server(s"$GREEN${BOLD}公共施設", "s7", ChestSlotRef(0, 8), Material.DIAMOND)
 
     case object SEICHI extends Server(s"$YELLOW${BOLD}整地専用", "s5", ChestSlotRef(0, 4), Material.IRON_PICKAXE)
-    
+
     val values: IndexedSeq[Server] = findValues
 
   }
 
   import com.github.unchama.menuinventory.syntax._
   import com.github.unchama.seichiassist.concurrent.PluginExecutionContexts.syncShift
+
+  class Environment(implicit val ioCanOpenStickMenu: IO CanOpen FirstPage.type)
 
   /**
    * メニューのサイズとタイトルに関する情報
@@ -83,12 +87,14 @@ object ServerSwitchMenu extends Menu {
     MenuSlotLayout(layoutMap)
   }
 
-  val buttonLayout: MenuSlotLayout =
-    MenuSlotLayout(ChestSlotRef(1, 0) -> CommonButtons.openStickMenu)
-      .merge(serverButtonLayout)
-
   /**
    * @return `player`からメニューの[[MenuSlotLayout]]を計算する[[IO]]
    */
-  override def computeMenuLayout(player: Player): IO[MenuSlotLayout] = IO.pure(buttonLayout)
+  override def computeMenuLayout(player: Player)(implicit environment: Environment): IO[MenuSlotLayout] =
+    IO.pure {
+      import environment._
+
+      MenuSlotLayout(ChestSlotRef(1, 0) -> CommonButtons.openStickMenu)
+        .merge(serverButtonLayout)
+    }
 }

--- a/src/main/scala/com/github/unchama/seichiassist/menus/TopLevelRouter.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/menus/TopLevelRouter.scala
@@ -1,0 +1,57 @@
+package com.github.unchama.seichiassist.menus
+
+import cats.effect.IO
+import com.github.unchama.menuinventory.LayoutPreparationContext
+import com.github.unchama.menuinventory.router.CanOpen
+import com.github.unchama.minecraft.actions.MinecraftServerThreadShift
+import com.github.unchama.seichiassist.menus.HomeMenu.ConfirmationMenu
+import com.github.unchama.seichiassist.menus.achievement.group.AchievementGroupMenu
+import com.github.unchama.seichiassist.menus.achievement.{AchievementCategoryMenu, AchievementMenu}
+import com.github.unchama.seichiassist.menus.minestack.{CategorizedMineStackMenu, MineStackMainMenu}
+import com.github.unchama.seichiassist.menus.skill.{ActiveSkillEffectMenu, ActiveSkillMenu, PassiveSkillMenu, PremiumPointTransactionHistoryMenu}
+import com.github.unchama.seichiassist.menus.stickmenu.{FirstPage, SecondPage}
+
+trait TopLevelRouter[F[_]] {
+
+  implicit val canOpenStickMenu: F CanOpen FirstPage.type
+
+}
+
+object TopLevelRouter {
+
+  def apply(implicit layoutPreparationContext: LayoutPreparationContext,
+            syncShift: MinecraftServerThreadShift[IO]): TopLevelRouter[IO] = new TopLevelRouter[IO] {
+    implicit lazy val secondPageEnv: SecondPage.Environment = new SecondPage.Environment
+    implicit lazy val mineStackMainMenuEnv: MineStackMainMenu.Environment = new MineStackMainMenu.Environment
+    implicit lazy val categorizedMineStackMenuEnv: CategorizedMineStackMenu.Environment = new CategorizedMineStackMenu.Environment
+    implicit lazy val regionMenuEnv: RegionMenu.Environment = ()
+    implicit lazy val activeSkillMenuEnv: ActiveSkillMenu.Environment = new ActiveSkillMenu.Environment
+    implicit lazy val activeSkillEffectMenuEnv: ActiveSkillEffectMenu.Environment = new ActiveSkillEffectMenu.Environment
+    implicit lazy val premiumPointTransactionHistoryMenuEnv: PremiumPointTransactionHistoryMenu.Environment = new PremiumPointTransactionHistoryMenu.Environment
+    implicit lazy val serverSwitchMenuEnv: ServerSwitchMenu.Environment = new ServerSwitchMenu.Environment
+    implicit lazy val achievementMenuEnv: AchievementMenu.Environment = new AchievementMenu.Environment
+    implicit lazy val homeMenuEnv: HomeMenu.Environment = new HomeMenu.Environment
+    implicit lazy val homeConfirmationMenuEnv: HomeMenu.ConfirmationMenu.Environment = new ConfirmationMenu.Environment
+    implicit lazy val achievementCategoryMenuEnv: AchievementCategoryMenu.Environment = new AchievementCategoryMenu.Environment
+    implicit lazy val achievementGroupMenuEnv: AchievementGroupMenu.Environment = new AchievementGroupMenu.Environment
+    implicit lazy val passiveSkillMenuEnv: PassiveSkillMenu.Environment = new PassiveSkillMenu.Environment
+    implicit lazy val stickMenuEnv: FirstPage.Environment = new FirstPage.Environment
+
+    implicit lazy val ioCanOpenAchievementGroupMenu: IO CanOpen AchievementGroupMenu = _.open
+    implicit lazy val ioCanOpenHomeConfirmationMenu: IO CanOpen HomeMenu.ConfirmationMenu = _.open
+    implicit lazy val ioCanOpenAchievementCategoryMenu: IO CanOpen AchievementCategoryMenu = _.open
+    implicit lazy val ioCanOpenPremiumPointTransactionHistoryMenu: IO CanOpen PremiumPointTransactionHistoryMenu = _.open
+    implicit lazy val ioCanOpenActiveSkillEffectMenu: IO CanOpen ActiveSkillEffectMenu.type = _.open
+    implicit lazy val ioCanOpenCategorizedMineStackMenu: IO CanOpen CategorizedMineStackMenu = _.open
+    implicit lazy val ioCanOpenSecondPage: IO CanOpen SecondPage.type = _.open
+    implicit lazy val ioCanOpenMineStackMenu: IO CanOpen MineStackMainMenu.type = _.open
+    implicit lazy val ioCanOpenRegionMenu: IO CanOpen RegionMenu.type = _.open
+    implicit lazy val ioCanOpenActiveSkillMenu: IO CanOpen ActiveSkillMenu.type = _.open
+    implicit lazy val ioCanOpenServerSwitchMenu: IO CanOpen ServerSwitchMenu.type = _.open
+    implicit lazy val ioCanOpenAchievementMenu: IO CanOpen AchievementMenu.type = _.open
+    implicit lazy val ioCanOpenHomeMenu: IO CanOpen HomeMenu.type = _.open
+    implicit lazy val ioCanOpenPassiveSkillMenu: IO CanOpen PassiveSkillMenu.type = _.open
+    override implicit lazy val canOpenStickMenu: IO CanOpen FirstPage.type = _.open
+  }
+
+}

--- a/src/main/scala/com/github/unchama/seichiassist/menus/achievement/AchievementMenu.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/menus/achievement/AchievementMenu.scala
@@ -3,6 +3,7 @@ package com.github.unchama.seichiassist.menus.achievement
 import cats.data.Kleisli
 import cats.effect.IO
 import com.github.unchama.itemstackbuilder.IconItemStackBuilder
+import com.github.unchama.menuinventory.router.CanOpen
 import com.github.unchama.menuinventory.slot.button.{Button, action}
 import com.github.unchama.menuinventory.{ChestSlotRef, Menu, MenuFrame, MenuSlotLayout}
 import com.github.unchama.seichiassist.SeichiAssist
@@ -12,6 +13,7 @@ import com.github.unchama.seichiassist.concurrent.PluginExecutionContexts
 import com.github.unchama.seichiassist.data.MenuInventoryData
 import com.github.unchama.seichiassist.data.player.NicknameStyle
 import com.github.unchama.seichiassist.effects.player.CommonSoundEffects
+import com.github.unchama.seichiassist.menus.stickmenu.FirstPage
 import com.github.unchama.seichiassist.menus.{ColorScheme, CommonButtons}
 import com.github.unchama.targetedeffect.player.FocusedSoundEffect
 import com.github.unchama.targetedeffect.{SequentialEffect, TargetedEffect}
@@ -22,8 +24,11 @@ import org.bukkit.{Material, Sound}
 object AchievementMenu extends Menu {
 
   import com.github.unchama.menuinventory.syntax._
-  import com.github.unchama.seichiassist.concurrent.PluginExecutionContexts.{layoutPreparationContext, syncShift}
   import eu.timepit.refined.auto._
+
+  class Environment(implicit
+                    val ioCanOpenStickMenu: IO CanOpen FirstPage.type,
+                    val ioCanOpenCategoryMenu: IO CanOpen AchievementCategoryMenu)
 
   override val frame: MenuFrame = MenuFrame(4.chestRows, s"$DARK_PURPLE${BOLD}実績・二つ名システム")
 
@@ -38,37 +43,40 @@ object AchievementMenu extends Menu {
       ChestSlotRef(2, 4) -> (Specials, Material.EYE_OF_ENDER)
     )
 
-  val menuLayout: Map[Int, Button] = {
-    def buttonFor(categoryRepr: AchievementCategoryRepr): Button =
-      categoryRepr match {
-        case (category, material) =>
-          val includedGroups =
-            AchievementCategoryMenu.groupsLayoutFor(category).values.map(_._1)
+  def buttonFor(categoryRepr: AchievementCategoryRepr)
+               (implicit ioCanOpenCategoryMenu: IO CanOpen AchievementCategoryMenu): Button =
+    categoryRepr match {
+      case (category, material) =>
+        val includedGroups =
+          AchievementCategoryMenu.groupsLayoutFor(category).values.map(_._1)
 
-          val partialBuilder =
-            new IconItemStackBuilder(material).title(ColorScheme.navigation(s"カテゴリ「${category.name}」"))
+        val partialBuilder =
+          new IconItemStackBuilder(material).title(ColorScheme.navigation(s"カテゴリ「${category.name}」"))
 
-          if (includedGroups.nonEmpty) {
-            Button(
-              partialBuilder
-                .lore(List(s"${RED}以下の実績が含まれます。") ++ includedGroups.map(s"$AQUA「" + _.name + "」"))
-                .build(),
-              action.LeftClickButtonEffect(
-                SequentialEffect(
-                  CommonSoundEffects.menuTransitionFenceSound,
-                  AchievementCategoryMenu(category).open
-                )
+        if (includedGroups.nonEmpty) {
+          Button(
+            partialBuilder
+              .lore(List(s"${RED}以下の実績が含まれます。") ++ includedGroups.map(s"$AQUA「" + _.name + "」"))
+              .build(),
+            action.LeftClickButtonEffect(
+              SequentialEffect(
+                CommonSoundEffects.menuTransitionFenceSound,
+                ioCanOpenCategoryMenu.open(AchievementCategoryMenu(category))
               )
             )
-          } else {
-            Button(
-              partialBuilder.lore(s"${YELLOW}今後実装予定のカテゴリです。").build(),
-              action.LeftClickButtonEffect(TargetedEffect.emptyEffect)
-            )
-          }
-      }
+          )
+        } else {
+          Button(
+            partialBuilder.lore(s"${YELLOW}今後実装予定のカテゴリです。").build(),
+            action.LeftClickButtonEffect(TargetedEffect.emptyEffect)
+          )
+        }
+    }
 
-    val categoryButtonsSection = categoryLayout.view.mapValues(buttonFor).toMap
+  override def computeMenuLayout(player: Player)(implicit environment: Environment): IO[MenuSlotLayout] = {
+    import environment._
+
+    val categoryButtonsSection = categoryLayout.view.mapValues(category => buttonFor(category)).toMap
 
     import com.github.unchama.targetedeffect._
     val toggleTitleToPlayerLevelButton = Button(
@@ -101,13 +109,15 @@ object AchievementMenu extends Menu {
       )
     )
 
-    categoryButtonsSection ++
-      Map(
-        ChestSlotRef(0, 0) -> toggleTitleToPlayerLevelButton,
-        ChestSlotRef(0, 8) -> toTitleConfigurationMenu,
-        ChestSlotRef(3, 0) -> CommonButtons.openStickMenu
-      )
+    IO.pure {
+      MenuSlotLayout {
+        categoryButtonsSection ++
+          Map(
+            ChestSlotRef(0, 0) -> toggleTitleToPlayerLevelButton,
+            ChestSlotRef(0, 8) -> toTitleConfigurationMenu,
+            ChestSlotRef(3, 0) -> CommonButtons.openStickMenu
+          )
+      }
+    }
   }
-
-  override def computeMenuLayout(player: Player): IO[MenuSlotLayout] = IO.pure(MenuSlotLayout(menuLayout))
 }

--- a/src/main/scala/com/github/unchama/seichiassist/menus/skill/PassiveSkillMenu.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/menus/skill/PassiveSkillMenu.scala
@@ -2,12 +2,14 @@ package com.github.unchama.seichiassist.menus.skill
 
 import cats.effect.IO
 import com.github.unchama.itemstackbuilder.IconItemStackBuilder
+import com.github.unchama.menuinventory.router.CanOpen
 import com.github.unchama.menuinventory.slot.button.action.LeftClickButtonEffect
 import com.github.unchama.menuinventory.slot.button.{Button, RecomputedButton}
 import com.github.unchama.menuinventory.{ChestSlotRef, Menu, MenuFrame, MenuSlotLayout}
 import com.github.unchama.seichiassist.SeichiAssist
 import com.github.unchama.seichiassist.data.MenuInventoryData
 import com.github.unchama.seichiassist.menus.CommonButtons
+import com.github.unchama.seichiassist.menus.stickmenu.FirstPage
 import com.github.unchama.targetedeffect._
 import com.github.unchama.targetedeffect.commandsender.MessageEffect
 import com.github.unchama.targetedeffect.player.FocusedSoundEffect
@@ -25,6 +27,8 @@ object PassiveSkillMenu extends Menu {
 
   import com.github.unchama.menuinventory.syntax._
 
+  class Environment(implicit val ioCanOpenFirstPage: IO CanOpen FirstPage.type)
+
   /**
    * メニューのサイズとタイトルに関する情報
    */
@@ -33,8 +37,9 @@ object PassiveSkillMenu extends Menu {
   /**
    * @return `player`からメニューの[[MenuSlotLayout]]を計算する[[IO]]
    */
-  override def computeMenuLayout(player: Player): IO[MenuSlotLayout] = {
+  override def computeMenuLayout(player: Player)(implicit environment: Environment): IO[MenuSlotLayout] = {
     import cats.implicits._
+    import environment._
     import eu.timepit.refined.auto._
 
     val buttonComputations = ButtonComputations(player)

--- a/src/main/scala/com/github/unchama/seichiassist/menus/skill/PremiumPointTransactionHistoryMenu.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/menus/skill/PremiumPointTransactionHistoryMenu.scala
@@ -2,6 +2,7 @@ package com.github.unchama.seichiassist.menus.skill
 
 import cats.effect.IO
 import com.github.unchama.itemstackbuilder.{IconItemStackBuilder, SkullItemStackBuilder, SkullOwnerReference}
+import com.github.unchama.menuinventory.router.CanOpen
 import com.github.unchama.menuinventory.slot.button.Button
 import com.github.unchama.menuinventory.{ChestSlotRef, Menu, MenuFrame, MenuSlotLayout}
 import com.github.unchama.seichiassist.database.manipulators.DonateDataManipulator._
@@ -13,94 +14,105 @@ import org.bukkit.Material
 import org.bukkit.entity.Player
 
 object PremiumPointTransactionHistoryMenu {
+
+  class Environment(implicit
+                    val ioCanOpenActiveSkillEffectMenu: IO CanOpen ActiveSkillEffectMenu.type,
+                    val ioCanOpenTransactionHistoryMenu: IO CanOpen PremiumPointTransactionHistoryMenu)
+
+}
+
+case class PremiumPointTransactionHistoryMenu(pageNumber: Int) extends Menu {
+
   import com.github.unchama.menuinventory.syntax._
-  import com.github.unchama.seichiassist.concurrent.PluginExecutionContexts.{layoutPreparationContext, syncShift}
   import eu.timepit.refined.auto._
 
-  def buttonToTransferTo(number: Int, skullOwnerReference: SkullOwnerReference): Button =
+  override type Environment = PremiumPointTransactionHistoryMenu.Environment
+  override val frame: MenuFrame = MenuFrame(4.chestRows, s"$BLUE${BOLD}プレミアムエフェクト購入履歴")
+
+  def buttonToTransferTo(pageNumber: Int, skullOwnerReference: SkullOwnerReference)
+                        (implicit ioCanOpenTransactionHistoryMenu: IO CanOpen PremiumPointTransactionHistoryMenu): Button =
     CommonButtons.transferButton(
       new SkullItemStackBuilder(skullOwnerReference),
-      s"${number}ページ目へ",
-      apply(number)
+      s"${pageNumber}ページ目へ",
+      PremiumPointTransactionHistoryMenu(pageNumber)
     )
 
-  def apply(pageNumber: Int): Menu = new Menu {
-    override val frame: MenuFrame = MenuFrame(4.chestRows, s"$BLUE${BOLD}プレミアムエフェクト購入履歴")
+  def computeDynamicParts(player: Player)
+                         (implicit environment: PremiumPointTransactionHistoryMenu.Environment): IO[List[(Int, Button)]] = {
+    import environment._
 
-    def computeDynamicParts(player: Player): IO[List[(Int, Button)]] = {
-      for {
-        history <- SeichiAssist.databaseGateway.donateDataManipulator.loadTransactionHistoryFor(player)
-      } yield {
-        val entriesPerPage = 3 * 9
-        val slicedHistory = history.slice((pageNumber - 1) * entriesPerPage, pageNumber * entriesPerPage)
+    for {
+      history <- SeichiAssist.databaseGateway.donateDataManipulator.loadTransactionHistoryFor(player)
+    } yield {
+      val entriesPerPage = 3 * 9
+      val slicedHistory = history.slice((pageNumber - 1) * entriesPerPage, pageNumber * entriesPerPage)
 
-        val historySection =
-          slicedHistory.zipWithIndex.map { case (transaction, index) =>
-            val itemStack =
-              transaction match {
-                case Obtained(amount, date) =>
-                  new IconItemStackBuilder(Material.DIAMOND)
-                    .title(s"$AQUA$UNDERLINE${BOLD}寄付")
-                    .lore(List(
-                      s"${RESET.toString}${GREEN}金額：${amount * 100}",
-                      s"$RESET${GREEN}プレミアムエフェクトポイント：+$amount",
-                      s"$RESET${GREEN}日時：$date"
-                    ))
-                    .build()
-                case Used(amount, date, forPurchaseOf) => {
-                  forPurchaseOf match {
-                    case Left(unknownEffectName) =>
-                      new IconItemStackBuilder(Material.BEDROCK)
-                        .title(s"$RESET${YELLOW}購入エフェクト：未定義($unknownEffectName)")
-                    case Right(skill) =>
-                      new IconItemStackBuilder(skill.materialOnUI)
-                        .title(s"$RESET${YELLOW}購入エフェクト：${skill.nameOnUI}")
-                  }
-                }.lore(
-                  s"$RESET${GOLD}プレミアムエフェクトポイント： -$amount",
-                  s"$RESET${GOLD}日時：$date"
-                ).build()
-              }
+      val historySection =
+        slicedHistory.zipWithIndex.map { case (transaction, index) =>
+          val itemStack =
+            transaction match {
+              case Obtained(amount, date) =>
+                new IconItemStackBuilder(Material.DIAMOND)
+                  .title(s"$AQUA$UNDERLINE${BOLD}寄付")
+                  .lore(List(
+                    s"${RESET.toString}${GREEN}金額：${amount * 100}",
+                    s"$RESET${GREEN}プレミアムエフェクトポイント：+$amount",
+                    s"$RESET${GREEN}日時：$date"
+                  ))
+                  .build()
+              case Used(amount, date, forPurchaseOf) => {
+                forPurchaseOf match {
+                  case Left(unknownEffectName) =>
+                    new IconItemStackBuilder(Material.BEDROCK)
+                      .title(s"$RESET${YELLOW}購入エフェクト：未定義($unknownEffectName)")
+                  case Right(skill) =>
+                    new IconItemStackBuilder(skill.materialOnUI)
+                      .title(s"$RESET${YELLOW}購入エフェクト：${skill.nameOnUI}")
+                }
+              }.lore(
+                s"$RESET${GOLD}プレミアムエフェクトポイント： -$amount",
+                s"$RESET${GOLD}日時：$date"
+              ).build()
+            }
 
-            (index, Button(itemStack, Nil))
-          }
+          (index, Button(itemStack, Nil))
+        }
 
-        val previousPageButtonSection =
-          if (pageNumber > 1)
-            Seq(ChestSlotRef(3, 7) -> buttonToTransferTo(pageNumber - 1, SkullOwners.MHF_ArrowUp))
-          else
-            Seq()
+      val previousPageButtonSection =
+        if (pageNumber > 1)
+          Seq(ChestSlotRef(3, 7) -> buttonToTransferTo(pageNumber - 1, SkullOwners.MHF_ArrowUp))
+        else
+          Seq()
 
-        val nextPageButtonSection =
-          if (history.drop(pageNumber * entriesPerPage).nonEmpty)
-            Seq(ChestSlotRef(3, 8) -> buttonToTransferTo(pageNumber + 1, SkullOwners.MHF_ArrowDown))
-          else
-            Seq()
+      val nextPageButtonSection =
+        if (history.drop(pageNumber * entriesPerPage).nonEmpty)
+          Seq(ChestSlotRef(3, 8) -> buttonToTransferTo(pageNumber + 1, SkullOwners.MHF_ArrowDown))
+        else
+          Seq()
 
-        historySection ++ previousPageButtonSection ++ nextPageButtonSection
-      }
+      historySection ++ previousPageButtonSection ++ nextPageButtonSection
     }
+  }
 
-    val constantParts: Map[Int, Button] = {
-      val moveBackButton =
-        CommonButtons.transferButton(
-          new SkullItemStackBuilder(SkullOwners.MHF_ArrowLeft),
-          "整地スキルエフェクト選択メニューへ",
-          ActiveSkillEffectMenu,
-        )
+  def constantParts(implicit environment: PremiumPointTransactionHistoryMenu.Environment): Map[Int, Button] = {
+    import environment._
 
-      Map(
-        ChestSlotRef(3, 0) -> moveBackButton
+    val moveBackButton =
+      CommonButtons.transferButton(
+        new SkullItemStackBuilder(SkullOwners.MHF_ArrowLeft),
+        "整地スキルエフェクト選択メニューへ",
+        ActiveSkillEffectMenu,
       )
-    }
 
-    /**
-     * @return `player`からメニューの[[MenuSlotLayout]]を計算する[[IO]]
-     */
-    override def computeMenuLayout(player: Player): IO[MenuSlotLayout] = {
-      for {
-        dynamicParts <- computeDynamicParts(player)
-      } yield MenuSlotLayout(constantParts ++ dynamicParts)
-    }
+    Map(
+      ChestSlotRef(3, 0) -> moveBackButton
+    )
+  }
+
+  override def computeMenuLayout(player: Player)
+                                (implicit environment: PremiumPointTransactionHistoryMenu.Environment): IO[MenuSlotLayout] = {
+    for {
+      dynamicParts <- computeDynamicParts(player)
+    } yield MenuSlotLayout(constantParts ++ dynamicParts)
   }
 }

--- a/src/main/scala/com/github/unchama/seichiassist/menus/stickmenu/SecondPage.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/menus/stickmenu/SecondPage.scala
@@ -4,6 +4,7 @@ import cats.effect.IO
 import com.github.unchama.itemstackbuilder.{IconItemStackBuilder, SkullItemStackBuilder}
 import com.github.unchama.menuinventory
 import com.github.unchama.menuinventory._
+import com.github.unchama.menuinventory.router.CanOpen
 import com.github.unchama.menuinventory.slot.button.action.{ClickEventFilter, FilteredButtonEffect, LeftClickButtonEffect}
 import com.github.unchama.menuinventory.slot.button.{Button, RecomputedButton, action}
 import com.github.unchama.seichiassist.concurrent.PluginExecutionContexts
@@ -35,13 +36,16 @@ object SecondPage extends Menu {
   import eu.timepit.refined.auto._
   import menuinventory.syntax._
 
+  class Environment(implicit val ioCanOpenFirstPage: IO CanOpen FirstPage.type)
+
   override val frame: MenuFrame =
     MenuFrame(4.chestRows, s"${LIGHT_PURPLE}木の棒メニュー")
 
-  override def computeMenuLayout(player: Player): IO[MenuSlotLayout] = {
+  override def computeMenuLayout(player: Player)(implicit environment: Environment): IO[MenuSlotLayout] = {
     import ConstantButtons._
     val computations = ButtonComputations(player)
     import computations._
+    import environment._
 
     val constantPart = Map(
       ChestSlotRef(0, 0) -> officialWikiNavigationButton,

--- a/src/main/scala/com/github/unchama/seichiassist/menus/stickmenu/StickMenu.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/menus/stickmenu/StickMenu.scala
@@ -1,9 +1,7 @@
 package com.github.unchama.seichiassist.menus.stickmenu
 
-import com.github.unchama.menuinventory.Menu
-
 object StickMenu {
-  val firstPage: Menu = FirstPage
+  val firstPage: FirstPage.type = FirstPage
 
-  val secondPage: Menu = SecondPage
+  val secondPage: SecondPage.type = SecondPage
 }


### PR DESCRIPTION
[このpublic gist](https://gist.github.com/kory33/802ee8621205a5ec8630f0f69b11f930/d53868c6243ba386dc92b775b6fb942f794732b3) が簡潔に構造を纏めています。

今までは、例えば `Menu1`, `Menu2`, `Menu3`があり、`Menu2` を開くのに `API2` を要求していた場合、 `Menu1` を開くのにも `API2` を要求することになっていました。これだとトップレベルのメニューが途方もない数の依存を抱えることになり、依存関係の変更がかなり煩雑になってしまうという問題がありました。

このPRは、 `CanOpen` という `trait` と `Router` という概念を導入することで、必要な箇所からのみ依存が貼られるように(そしてそれらの依存の解決をすべて `Router` 内の簡潔なコードに集約するように)変更します。
