### PR TITLE
建築ワールドが整地ワールドとして判定されていたのを修正

### DIFF
--- a/src/main/scala/com/github/unchama/seichiassist/ManagedWorld.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/ManagedWorld.scala
@@ -36,8 +36,7 @@ case object ManagedWorld extends Enum[ManagedWorld] {
            | WORLD_SW_3
            | WORLD_SW_4
            | WORLD_SW_NETHER
-           | WORLD_SW_END
-           | WORLD_BUILD => true
+           | WORLD_SW_END => true
       case _ => false
     }
 


### PR DESCRIPTION
fix #1072, #859