### PR TITLE
[fix] gachapointカラムをBigIntとして読む

### DIFF
--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/gachapoint/infrastructure/JdbcGachaPointPersistence.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/gachapoint/infrastructure/JdbcGachaPointPersistence.scala
@@ -16,7 +16,7 @@ class JdbcGachaPointPersistence[F[_] : Sync] extends GachaPointPersistence[F] {
   override def read(key: UUID): F[Option[GachaPoint]] = Sync[F].delay {
     DB.localTx { implicit session =>
       sql"select gachapoint from playerdata where uuid = ${key.toString}"
-        .map { rs => decode(rs.int("gachapoint")) }
+        .map { rs => decode(rs.bigInt("gachapoint")) }
         .headOption()
         .apply()
     }


### PR DESCRIPTION
gachapointカラムが極端に大きい値である場合正しい値を読めないので修正
(NOTE to @kory33: オーバーフローによりプレイが阻害されている可能性のあるプレイヤーが居るので早急にマージ願います)