### PR TITLE
Revert "[chore(deps)] bump Scala 2.13.1 to 2.13.7"

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/cache@v2
         env:
           cache-name: cache-build-dependencies
-          cache-version: v-5
+          cache-version: v-3
         with:
           # sbt等は$HOMEではなくユーザーディレクトリを見ているようで、
           # GH Actionsでの ~ は /github/home/ に展開されるにもかかわらず
@@ -47,7 +47,7 @@ jobs:
         uses: actions/cache@v2
         env:
           cache-name: cache-build
-          cache-version: v-5
+          cache-version: v-3
         with:
           path: |
             target

--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ import sbt.Keys.baseDirectory
 
 import java.io._
 
-ThisBuild / scalaVersion := "2.13.7"
+ThisBuild / scalaVersion := "2.13.1"
 // ThisBuild / version はGitHub Actionsによって自動更新される。
 // 次の行は ThisBuild / version := "(\d*)" の形式でなければならない。
 ThisBuild / version := "19"

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/autosave/application/CanNotifySaves.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/autosave/application/CanNotifySaves.scala
@@ -1,11 +1,9 @@
 package com.github.unchama.seichiassist.subsystems.autosave.application
 
-trait CanNotifySaves[F[_]] {
+import simulacrum.typeclass
+
+@typeclass trait CanNotifySaves[F[_]] {
 
   def notify(message: String): F[Unit]
 
-}
-
-object CanNotifySaves {
-  def apply[F[_]: CanNotifySaves]: CanNotifySaves[F] = implicitly
 }

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/autosave/application/CanSaveWorlds.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/autosave/application/CanSaveWorlds.scala
@@ -1,11 +1,9 @@
 package com.github.unchama.seichiassist.subsystems.autosave.application
 
-trait CanSaveWorlds[F[_]] extends AnyRef {
+import simulacrum.typeclass
+
+@typeclass trait CanSaveWorlds[F[_]] extends AnyRef {
 
   val saveAllWorlds: F[Unit]
 
-}
-
-object CanSaveWorlds {
-  def apply[F[_]: CanSaveWorlds]: CanSaveWorlds[F] = implicitly
 }

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/dragonnighttime/application/Notifiable.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/dragonnighttime/application/Notifiable.scala
@@ -1,9 +1,7 @@
 package com.github.unchama.seichiassist.subsystems.dragonnighttime.application
 
-trait Notifiable[F[_]] {
-  def notify(message: String): F[Unit]
-}
+import simulacrum.typeclass
 
-object Notifiable {
-  def apply[F[_]: Notifiable]: Notifiable[F] = implicitly
+@typeclass trait Notifiable[F[_]] {
+  def notify(message: String): F[Unit]
 }

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/managedfly/application/PlayerFlyStatusManipulation.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/managedfly/application/PlayerFlyStatusManipulation.scala
@@ -1,13 +1,14 @@
 package com.github.unchama.seichiassist.subsystems.managedfly.application
 
 import com.github.unchama.seichiassist.subsystems.managedfly.domain.{IdleStatus, PlayerFlyStatus, RemainingFlyDuration}
+import simulacrum.typeclass
 
 /**
  * プレーヤーの飛行状態に`F`の文脈で干渉する手段を与える型クラスインスタンスのtrait。
  *
  * `F` は `Kleisli[G, Player, *]` の形をしていることを想定している。
  */
-trait PlayerFlyStatusManipulation[F[_]] extends AnyRef {
+@typeclass trait PlayerFlyStatusManipulation[F[_]] extends AnyRef {
   /**
    * 飛行に必要な経験値をプレーヤーが持っていることを保証するアクション。
    * このアクションは [[PlayerExpNotEnough]] を `raiseError` してよい。
@@ -39,8 +40,4 @@ trait PlayerFlyStatusManipulation[F[_]] extends AnyRef {
    * [[InternalInterruption]] に対応して、プレーヤーへセッションが終了することを通知するアクション。
    */
   val sendNotificationsOnInterruption: InternalInterruption => F[Unit]
-}
-
-object PlayerFlyStatusManipulation {
-  def apply[F[_]: PlayerFlyStatusManipulation]: PlayerFlyStatusManipulation[F] = implicitly
 }

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/seasonalevents/api/SeasonalEventsAPI.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/seasonalevents/api/SeasonalEventsAPI.scala
@@ -4,10 +4,11 @@ import cats.Functor
 import cats.effect.Clock
 import com.github.unchama.seichiassist.subsystems.seasonalevents.christmas.Christmas
 import io.chrisdavenport.cats.effect.time.JavaTime
+import simulacrum.typeclass
 
 import java.time.ZoneId
 
-trait ChristmasEventsAPI[F[_]] extends AnyRef {
+@typeclass trait ChristmasEventsAPI[F[_]] extends AnyRef {
 
   val isInEvent: F[Boolean]
 
@@ -24,10 +25,9 @@ object ChristmasEventsAPI {
         .map(Christmas.isInEvent)
   }
 
-  def apply[F[_] : ChristmasEventsAPI]: ChristmasEventsAPI[F] = implicitly
 }
 
-trait SeasonalEventsAPI[F[_]] extends AnyRef {
+@typeclass trait SeasonalEventsAPI[F[_]] extends AnyRef {
 
   implicit val christmasEventsAPI: ChristmasEventsAPI[F]
 
@@ -37,6 +37,4 @@ object SeasonalEventsAPI {
   def withF[F[_] : Clock : Functor]: SeasonalEventsAPI[F] = new SeasonalEventsAPI[F] {
     override implicit val christmasEventsAPI: ChristmasEventsAPI[F] = ChristmasEventsAPI.withF[F]
   }
-
-  def apply[F[_] : SeasonalEventsAPI]: SeasonalEventsAPI[F] = implicitly
 }

--- a/src/main/scala/com/github/unchama/util/RandomEffect.scala
+++ b/src/main/scala/com/github/unchama/util/RandomEffect.scala
@@ -2,10 +2,11 @@ package com.github.unchama.util
 
 import cats.Functor
 import cats.effect.Sync
+import simulacrum.typeclass
 
 import scala.util.Random
 
-trait RandomEffect[F[_]] {
+@typeclass trait RandomEffect[F[_]] {
 
   import cats.implicits._
 
@@ -49,7 +50,5 @@ object RandomEffect {
       random.nextDouble()
     }
   }
-
-  def apply[F[_] : RandomEffect]: RandomEffect[F] = implicitly
 
 }


### PR DESCRIPTION
Reverts GiganticMinecraft/SeichiAssist#1241
キャッシュがない状態だとビルドに数時間かかる。これは、
* `sbt clean`を実行した直後
* `git clone`で`sbt build`を実行するとき
* `develop` -> `master` のPR

で問題となる。
解決するまでバージョンをダウングレードしたままにする。