### PR TITLE
Add index

### DIFF
--- a/src/main/resources/db/migration/V1.7.3__Create_Slow_Query_Index.sql
+++ b/src/main/resources/db/migration/V1.7.3__Create_Slow_Query_Index.sql
@@ -1,0 +1,5 @@
+use seichiassist;
+
+-- MySQLのスロークエリを引いた結果遅かったSELECTのクエリに対してINDEXを貼るようにする。
+ALTER TABLE mine_stack ADD INDEX index_mine_stack_on_object_name_amount(object_name, amount);
+ALTER TABLE playerdata ADD INDEX index_playerdata_on_lastquit(lastquit);


### PR DESCRIPTION
以下の激遅クエリを1秒以内に終わらせるINDEX

```
# Query 1: 1 QPS, 186.69x concurrency, ID 0xFCB7EB68D74F55A807ACBB16B6AF8993 at byte 3838
# This item is included in the report because it matches --limit.
# Scores: V/M = 365.57
# Time range: 2022-01-16 00:06:19 to 00:06:21
# Attribute    pct   total     min     max     avg     95%  stddev  median
# ============ === ======= ======= ======= ======= ======= ======= =======
# Count          0       2
# Exec time     40    373s      2s    371s    187s    371s    261s    187s
# Lock time      0    92us    46us    46us    46us    46us       0    46us
# Rows sent      0       2       1       1       1       1       0       1
# Rows examine  94  23.72M  11.86M  11.86M  11.86M  11.86M       0  11.86M
# Rows affecte   0       0       0       0       0       0       0       0
# Bytes sent     0     131      64      67   65.50      67    2.12   65.50
# Query size     0     135      65      70   67.50      70    3.54   67.50
# String:
# Databases    seichiassist
# Hosts        192.168.1.187
# Users        root
# Query_time distribution
#   1us
#  10us
# 100us
#   1ms
#  10ms
# 100ms
#    1s  ################################################################
#  10s+  ################################################################
# Tables
#    SHOW TABLE STATUS FROM `seichiassist` LIKE 'mine_stack'\G
#    SHOW CREATE TABLE `seichiassist`.`mine_stack`\G
# EXPLAIN /*!50100 PARTITIONS*/
select sum(amount) from mine_stack where object_name = 'gachadata0_36'\G

# Query 3: 0 QPS, 0x concurrency, ID 0xC1D91E4C22658783138E2FA03116A616 at byte 13030
# This item is included in the report because it matches --limit.
# Scores: V/M = 0.00
# Time range: all events occurred at 2022-01-16 01:56:10
# Attribute    pct   total     min     max     avg     95%  stddev  median
# ============ === ======= ======= ======= ======= ======= ======= =======
# Count          0       1
# Exec time      4     37s     37s     37s     37s     37s       0     37s
# Lock time      0    26us    26us    26us    26us    26us       0    26us
# Rows sent      0     160     160     160     160     160       0     160
# Rows examine   0  39.81k  39.81k  39.81k  39.81k  39.81k       0  39.81k
# Rows affecte   0       0       0       0       0       0       0       0
# Bytes sent    16   4.01M   4.01M   4.01M   4.01M   4.01M       0   4.01M
# Query size     0      67      67      67      67      67       0      67
# String:
# Databases    seichiassist
# Hosts        192.168.1.187
# Users        root
# Query_time distribution
#   1us
#  10us
# 100us
#   1ms
#  10ms
# 100ms
#    1s
#  10s+  ################################################################
# Tables
#    SHOW TABLE STATUS FROM `seichiassist` LIKE 'playerdata'\G
#    SHOW CREATE TABLE `seichiassist`.`playerdata`\G
# EXPLAIN /*!50100 PARTITIONS*/
select * from `playerdata` where `lastquit` > '2022-01-15 00:00:00'\G
```