### PR TITLE
整地量10億の倍数(10億、20億、30億、...)を突破した際に全体通知をする

### DIFF
--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/breakcount/subsystems/notification/bukkit/actions/BukkitNotifyLevelUp.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/breakcount/subsystems/notification/bukkit/actions/BukkitNotifyLevelUp.scala
@@ -28,10 +28,13 @@ object BukkitNotifyLevelUp {
     new NotifyLevelUp[F, Player] {
       override def ofSeichiAmountTo(player: Player)(diff: Diff[SeichiAmountData]): F[Unit] = {
         val Diff(oldBreakAmount, newBreakAmount) = diff
+        val tenBillion = 1000000000
         if (
-          oldBreakAmount.expAmount.amount < 1000000000 && newBreakAmount
+          oldBreakAmount.expAmount.amount < tenBillion * (oldBreakAmount
             .expAmount
-            .amount >= 1000000000
+            .amount / tenBillion + 1).toLong && newBreakAmount
+            .expAmount
+            .amount >= tenBillion * (oldBreakAmount.expAmount.amount / tenBillion + 1).toLong
         ) {
           OnMinecraftServerThread[F].runAction(SyncIO {
             Util.sendMessageToEveryoneIgnoringPreference(

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/breakcount/subsystems/notification/bukkit/actions/BukkitNotifyLevelUp.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/breakcount/subsystems/notification/bukkit/actions/BukkitNotifyLevelUp.scala
@@ -29,12 +29,11 @@ object BukkitNotifyLevelUp {
       override def ofSeichiAmountTo(player: Player)(diff: Diff[SeichiAmountData]): F[Unit] = {
         val Diff(oldBreakAmount, newBreakAmount) = diff
         val tenBillion = 1000000000
+        val separation = tenBillion * (oldBreakAmount.expAmount.amount / tenBillion + 1).toLong
         if (
-          oldBreakAmount.expAmount.amount < tenBillion * (oldBreakAmount
+          oldBreakAmount.expAmount.amount < separation && newBreakAmount
             .expAmount
-            .amount / tenBillion + 1).toLong && newBreakAmount
-            .expAmount
-            .amount >= tenBillion * (oldBreakAmount.expAmount.amount / tenBillion + 1).toLong
+            .amount >= separation
         ) {
           OnMinecraftServerThread[F].runAction(SyncIO {
             Util.sendMessageToEveryoneIgnoringPreference(

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/breakcount/subsystems/notification/bukkit/actions/BukkitNotifyLevelUp.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/breakcount/subsystems/notification/bukkit/actions/BukkitNotifyLevelUp.scala
@@ -29,11 +29,12 @@ object BukkitNotifyLevelUp {
       override def ofSeichiAmountTo(player: Player)(diff: Diff[SeichiAmountData]): F[Unit] = {
         val Diff(oldBreakAmount, newBreakAmount) = diff
         val tenBillion = 1000000000
-        val separation = tenBillion * (oldBreakAmount.expAmount.amount / tenBillion + 1).toLong
+        val nextTenBillion =
+          tenBillion * (oldBreakAmount.expAmount.amount / tenBillion + 1).toLong
         if (
-          oldBreakAmount.expAmount.amount < separation && newBreakAmount
+          oldBreakAmount.expAmount.amount < nextTenBillion && newBreakAmount
             .expAmount
-            .amount >= separation
+            .amount >= nextTenBillion
         ) {
           OnMinecraftServerThread[F].runAction(SyncIO {
             Util.sendMessageToEveryoneIgnoringPreference(


### PR DESCRIPTION
10億以外で通知されていなかったので修正
reference #1473

close #1070 