### PR TITLE
建築関連のバグを修正

### DIFF
--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/buildcount/System.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/buildcount/System.scala
@@ -114,9 +114,10 @@ object System {
             buildCountTopic.subscribe(1)
         }
 
-        override val managedRepositoryControls: Seq[BukkitRepositoryControls[F, _]] = Seq(
-          buildAmountDataRepositoryControls.coerceFinalizationContextTo[F]
-        )
+        override val managedRepositoryControls: Seq[BukkitRepositoryControls[F, _]] =
+          List(rateLimiterRepositoryControls, buildAmountDataRepositoryControls).map(
+            _.coerceFinalizationContextTo[F]
+          )
 
         override val listeners: Seq[Listener] = List(new BuildExpIncrementer[G])
       }


### PR DESCRIPTION
以下のバグの修正が含まれます
・建築スキル使用時にアイテムが減らない不具合の修正
・建築量が増加しない不具合の修正