### PR TITLE
fix(ci): WorldGuardがダウンロードできなくなっていたのを修正

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -44,7 +44,7 @@ Compile / testOptions += Tests.Argument("-oS")
 
 resolvers ++= Seq(
   "jitpack.io" at "https://jitpack.io",
-  "maven.sk89q.com" at "https://maven.sk89q.com/repo/",
+  "maven.sk89q.com" at "https://maven.enginehub.org/repo/",
   "maven.playpro.com" at "https://maven.playpro.com",
   "repo.spring.io" at "https://repo.spring.io/plugins-release/",
   "repo.spongepowered.org" at "https://repo.spongepowered.org/maven",
@@ -61,6 +61,7 @@ val providedDependencies = Seq(
   "org.apache.commons" % "commons-lang3" % "3.9",
   "commons-codec" % "commons-codec" % "1.12",
   "org.spigotmc" % "spigot-api" % "1.12.2-R0.1-SNAPSHOT",
+  // https://maven.enginehub.org/repo/com/sk89q/worldedit/worldedit-bukkit/
   "com.sk89q.worldguard" % "worldguard-legacy" % "6.2",
   "net.coreprotect" % "coreprotect" % "2.14.2",
   "com.mojang" % "authlib" % "1.5.25",


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/48310258/179353985-36ebf06e-2391-4c04-8a7f-989cc4ff1e83.png)
![image](https://user-images.githubusercontent.com/48310258/179354013-f3057c92-5e09-43b8-80ca-d9932f17ea91.png)
-- from https://discord.com/channels/80853743897149440/523810180400545792/983824152123293837