### PR TITLE
actions/create-releaseをsoftprops/action-gh-releaseに変更

### DIFF
--- a/.github/workflows/create_new_release.yml
+++ b/.github/workflows/create_new_release.yml
@@ -87,7 +87,7 @@ jobs:
 
       - name: Create release
         id: create_release
-        uses: actions/create-release@v1.0.0
+        uses: softprops/action-gh-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
リリース時にfilesパラメータを受け取る[softprops/action-gh-release](https://github.com/softprops/action-gh-release)に変更しました。