### PR TITLE
矢のPotionDataをスキルメニューのUIに露出させないようにする

### DIFF
--- a/src/main/scala/com/github/unchama/itemstackbuilder/TippedArrowIconItemStackBuilder.scala
+++ b/src/main/scala/com/github/unchama/itemstackbuilder/TippedArrowIconItemStackBuilder.scala
@@ -1,10 +1,11 @@
 package com.github.unchama.itemstackbuilder
 
 import org.bukkit.Material
+import org.bukkit.inventory.ItemFlag
 import org.bukkit.inventory.meta.PotionMeta
 import org.bukkit.potion.{PotionData, PotionType}
 
-class TippedArrowItemStackBuilder(val potionData: PotionData)
+class TippedArrowIconItemStackBuilder(val potionData: PotionData)
     extends AbstractItemStackBuilder[PotionMeta](Material.TIPPED_ARROW, 0) {
 
   def this(potionType: PotionType) = this(new PotionData(potionType))
@@ -14,5 +15,6 @@ class TippedArrowItemStackBuilder(val potionData: PotionData)
    */
   override protected def transformItemMetaOnBuild(meta: PotionMeta): Unit = {
     meta.setBasePotionData(potionData)
+    meta.addItemFlags(ItemFlag.HIDE_POTION_EFFECTS)
   }
 }

--- a/src/main/scala/com/github/unchama/seichiassist/menus/skill/ActiveSkillMenu.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/menus/skill/ActiveSkillMenu.scala
@@ -9,7 +9,7 @@ import com.github.unchama.itemstackbuilder.{
   AbstractItemStackBuilder,
   IconItemStackBuilder,
   SkullItemStackBuilder,
-  TippedArrowItemStackBuilder
+  TippedArrowIconItemStackBuilder
 }
 import com.github.unchama.menuinventory.router.CanOpen
 import com.github.unchama.menuinventory.slot.button.action.{ButtonEffect, LeftClickButtonEffect}
@@ -187,17 +187,17 @@ object ActiveSkillMenu extends Menu {
               new IconItemStackBuilder(Material.HOPPER_MINECART)
 
             case SeichiSkill.EbifriDrive =>
-              new TippedArrowItemStackBuilder(PotionType.REGEN)
+              new TippedArrowIconItemStackBuilder(PotionType.REGEN)
             case SeichiSkill.HolyShot =>
-              new TippedArrowItemStackBuilder(PotionType.FIRE_RESISTANCE)
+              new TippedArrowIconItemStackBuilder(PotionType.FIRE_RESISTANCE)
             case SeichiSkill.TsarBomba =>
-              new TippedArrowItemStackBuilder(PotionType.INSTANT_HEAL)
+              new TippedArrowIconItemStackBuilder(PotionType.INSTANT_HEAL)
             case SeichiSkill.ArcBlast =>
-              new TippedArrowItemStackBuilder(PotionType.NIGHT_VISION)
+              new TippedArrowIconItemStackBuilder(PotionType.NIGHT_VISION)
             case SeichiSkill.PhantasmRay =>
-              new TippedArrowItemStackBuilder(PotionType.SPEED)
+              new TippedArrowIconItemStackBuilder(PotionType.SPEED)
             case SeichiSkill.Supernova =>
-              new TippedArrowItemStackBuilder(PotionType.INSTANT_DAMAGE)
+              new TippedArrowIconItemStackBuilder(PotionType.INSTANT_DAMAGE)
           }
         case skill: AssaultSkill =>
           skill match {


### PR DESCRIPTION
スキルメニューにおいて遠距離系スキルのアイコンに矢の効果(e.g. Regeneration)が表記されているのを修正