### PR TITLE
fix: SQLマイグレーションスクリプトのSyntax error修正

### DIFF
--- a/src/main/resources/db/migration/V1.11.0__Change_table_name_from_subhome_to_home.sql
+++ b/src/main/resources/db/migration/V1.11.0__Change_table_name_from_subhome_to_home.sql
@@ -1,3 +1,3 @@
 USE seichiassist;
 
-RENAME TABLE IF EXISTS TABLE sub_home TO home;
+RENAME TABLE IF EXISTS sub_home TO home;


### PR DESCRIPTION
`v1.11.0`のDBマイグレーションスクリプトにSyntax errorがあったので修正したPRを送ります。