### PR TITLE
feat:スキルで流体の水を消せるようにする

### DIFF
--- a/src/main/scala/com/github/unchama/seichiassist/listener/EntityListener.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/listener/EntityListener.scala
@@ -110,7 +110,7 @@ class EntityListener(
       BreakUtil.performsMultipleIDBlockBreakWhenUsingSkills(player).unsafeRunSync()
 
     import com.github.unchama.seichiassist.data.syntax._
-    val BlockSearching.Result(breakBlocks, _, lavaBlocks) =
+    val BlockSearching.Result(breakBlocks, waterBlocks, lavaBlocks) =
       BlockSearching
         .searchForBlocksBreakableWithSkill(player, breakArea.gridPoints(), hitBlock)
         .unsafeRunSync()
@@ -128,13 +128,14 @@ class EntityListener(
       breakBlocks.size.toDouble * (gravity + 1) * selectedSkill.manaCost / breakAreaVolume
 
     // セットする耐久値の計算
-    // １マス溶岩を破壊するのにはブロック１０個分の耐久が必要
+    // １マス溶岩、水を破壊するのにはブロック１０個分の耐久が必要
     val nextDurability = {
       val durabilityEnchantment = tool.getEnchantmentLevel(Enchantment.DURABILITY)
 
       tool.getDurability +
         BreakUtil.calcDurability(durabilityEnchantment, breakBlocks.size) +
-        BreakUtil.calcDurability(durabilityEnchantment, 10 * lavaBlocks.size)
+        BreakUtil.calcDurability(durabilityEnchantment, 10 * lavaBlocks.size) +
+        BreakUtil.calcDurability(durabilityEnchantment, 10 * waterBlocks.size)
     }.toShort
 
     // 重力値の判定
@@ -160,6 +161,8 @@ class EntityListener(
     // 以降破壊する処理
     // 溶岩を破壊する処理
     lavaBlocks.foreach(_.setType(Material.AIR))
+    // 水を破壊する処理
+    waterBlocks.foreach(_.setType(Material.AIR))
 
     // 元ブロックの真ん中の位置
     val centerOfBlock = hitBlock.getLocation.add(0.5, 0.5, 0.5)

--- a/src/main/scala/com/github/unchama/seichiassist/listener/EntityListener.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/listener/EntityListener.scala
@@ -133,9 +133,10 @@ class EntityListener(
       val durabilityEnchantment = tool.getEnchantmentLevel(Enchantment.DURABILITY)
 
       tool.getDurability +
-        BreakUtil.calcDurability(durabilityEnchantment, breakBlocks.size) +
-        BreakUtil.calcDurability(durabilityEnchantment, 10 * lavaBlocks.size) +
-        BreakUtil.calcDurability(durabilityEnchantment, 10 * waterBlocks.size)
+        BreakUtil.calcDurability(
+          durabilityEnchantment,
+          breakBlocks.size + 10 * (lavaBlocks.size + waterBlocks.size)
+        )
     }.toShort
 
     // 重力値の判定
@@ -159,10 +160,8 @@ class EntityListener(
     if (!tool.getItemMeta.isUnbreakable) tool.setDurability(nextDurability)
 
     // 以降破壊する処理
-    // 溶岩を破壊する処理
-    lavaBlocks.foreach(_.setType(Material.AIR))
-    // 水を破壊する処理
-    waterBlocks.foreach(_.setType(Material.AIR))
+    // 溶岩と水を破壊する
+    (lavaBlocks ++ waterBlocks).foreach(_.setType(Material.AIR))
 
     // 元ブロックの真ん中の位置
     val centerOfBlock = hitBlock.getLocation.add(0.5, 0.5, 0.5)

--- a/src/main/scala/com/github/unchama/seichiassist/listener/PlayerBlockBreakListener.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/listener/PlayerBlockBreakListener.scala
@@ -209,10 +209,10 @@ class PlayerBlockBreakListener(
         }
 
         val effectPrograms = for {
-          (((blocks, lavas), waters), chunkIndex) <- multiBreakList
-            .zip(multiLavaList)
-            .zip(multiWaterList)
-            .zipWithIndex
+          ((blocks, lavas, waters), chunkIndex) <-
+            (multiBreakList lazyZip
+              multiLavaList lazyZip
+              multiWaterList).zipWithIndex.toMap
           blockChunk = BukkitResources.vanishingBlockSetResource[IO, BlockBreakableBySkill](
             blocks
           )
@@ -224,8 +224,7 @@ class PlayerBlockBreakListener(
               for {
                 _ <- IO.sleep((chunkIndex * 4).ticks)(IO.timer(cachedThreadPool))
                 _ <- ioOnMainThread.runAction(SyncIO {
-                  lavas.foreach(_.setType(Material.AIR))
-                  waters.foreach(_.setType(Material.AIR))
+                  (lavas ++ waters).foreach(_.setType(Material.AIR))
                 })
                 _ <- playerData
                   .skillEffectState

--- a/src/main/scala/com/github/unchama/seichiassist/listener/PlayerBlockBreakListener.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/listener/PlayerBlockBreakListener.scala
@@ -134,6 +134,8 @@ class PlayerBlockBreakListener(
       val multiBreakList = new ArrayBuffer[Set[BlockBreakableBySkill]]
       // 壊される溶岩の全てのリストデータ
       val multiLavaList = new ArrayBuffer[Set[Block]]
+      // 壊される水ブロックの全てのリストデータ
+      val multiWaterList = new ArrayBuffer[Set[Block]]
       // 全ての耐久消費量
       var toolDamageToSet = tool.getDurability.toInt
 
@@ -146,7 +148,7 @@ class PlayerBlockBreakListener(
         breakAreaList.foreach { breakArea =>
           import com.github.unchama.seichiassist.data.syntax._
 
-          val BlockSearching.Result(breakBlocks, _, lavaBlocks) =
+          val BlockSearching.Result(breakBlocks, waterBlocks, lavaBlocks) =
             BlockSearching
               .searchForBlocksBreakableWithSkill(player, breakArea.gridPoints(), block)
               .unsafeRunSync()
@@ -174,10 +176,10 @@ class PlayerBlockBreakListener(
             case None        => b.break()
           }
 
-          // 減る耐久値の計算(１マス溶岩を破壊するのにはブロック１０個分の耐久が必要)
+          // 減る耐久値の計算(１マス溶岩、水を破壊するのにはブロック１０個分の耐久が必要)
           toolDamageToSet += BreakUtil.calcDurability(
             tool.getEnchantmentLevel(Enchantment.DURABILITY),
-            breakBlocks.size + 10 * lavaBlocks.size
+            breakBlocks.size + 10 * lavaBlocks.size + 10 * waterBlocks.size
           )
 
           // 実際に耐久値を減らせるか判定
@@ -188,6 +190,7 @@ class PlayerBlockBreakListener(
 
           multiBreakList.addOne(breakBlocks.toSet)
           multiLavaList.addOne(lavaBlocks.toSet)
+          multiWaterList.addOne(waterBlocks.toSet)
         }
       }
 
@@ -205,8 +208,12 @@ class PlayerBlockBreakListener(
           cachedThreadPool
         }
 
+        // lazyZipで実装したかったがイテレートが発生しなかったので仕方なくzipをネストした
         val effectPrograms = for {
-          ((blocks, lavas), chunkIndex) <- multiBreakList.zip(multiLavaList).zipWithIndex
+          (((blocks, lavas), waters), chunkIndex) <- multiBreakList
+            .zip(multiLavaList)
+            .zip(multiWaterList)
+            .zipWithIndex
           blockChunk = BukkitResources.vanishingBlockSetResource[IO, BlockBreakableBySkill](
             blocks
           )
@@ -219,6 +226,7 @@ class PlayerBlockBreakListener(
                 _ <- IO.sleep((chunkIndex * 4).ticks)(IO.timer(cachedThreadPool))
                 _ <- ioOnMainThread.runAction(SyncIO {
                   lavas.foreach(_.setType(Material.AIR))
+                  waters.foreach(_.setType(Material.AIR))
                 })
                 _ <- playerData
                   .skillEffectState

--- a/src/main/scala/com/github/unchama/seichiassist/listener/PlayerBlockBreakListener.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/listener/PlayerBlockBreakListener.scala
@@ -176,7 +176,7 @@ class PlayerBlockBreakListener(
             case None        => b.break()
           }
 
-          // 減る耐久値の計算(１マス溶岩、水を破壊するのにはブロック１０個分の耐久が必要)
+          // 減る耐久値の計算(溶岩及び水を破壊するとブロック１０個分の耐久値減少判定を行う)
           toolDamageToSet += BreakUtil.calcDurability(
             tool.getEnchantmentLevel(Enchantment.DURABILITY),
             breakBlocks.size + 10 * (lavaBlocks.size + waterBlocks.size)

--- a/src/main/scala/com/github/unchama/seichiassist/listener/PlayerBlockBreakListener.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/listener/PlayerBlockBreakListener.scala
@@ -208,7 +208,6 @@ class PlayerBlockBreakListener(
           cachedThreadPool
         }
 
-        // lazyZipで実装したかったがイテレートが発生しなかったので仕方なくzipをネストした
         val effectPrograms = for {
           (((blocks, lavas), waters), chunkIndex) <- multiBreakList
             .zip(multiLavaList)

--- a/src/main/scala/com/github/unchama/seichiassist/listener/PlayerBlockBreakListener.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/listener/PlayerBlockBreakListener.scala
@@ -179,7 +179,7 @@ class PlayerBlockBreakListener(
           // 減る耐久値の計算(１マス溶岩、水を破壊するのにはブロック１０個分の耐久が必要)
           toolDamageToSet += BreakUtil.calcDurability(
             tool.getEnchantmentLevel(Enchantment.DURABILITY),
-            breakBlocks.size + 10 * lavaBlocks.size + 10 * waterBlocks.size
+            breakBlocks.size + 10 * (lavaBlocks.size + waterBlocks.size)
           )
 
           // 実際に耐久値を減らせるか判定

--- a/src/main/scala/com/github/unchama/seichiassist/listener/PlayerBlockBreakListener.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/listener/PlayerBlockBreakListener.scala
@@ -212,7 +212,7 @@ class PlayerBlockBreakListener(
           ((blocks, lavas, waters), chunkIndex) <-
             (multiBreakList lazyZip
               multiLavaList lazyZip
-              multiWaterList).zipWithIndex.toMap
+              multiWaterList).zipWithIndex.toList
           blockChunk = BukkitResources.vanishingBlockSetResource[IO, BlockBreakableBySkill](
             blocks
           )


### PR DESCRIPTION
close #1643 

レビューをお願いいたします。

## Note

通常スキル（破壊系、遠距離系）で水を破壊できるようにする変更。
水を破壊する仕様は溶岩を破壊する仕様に準ずる。

- 破壊によるマナ消費なし
- 破壊による整地量の増加なし
- ツール耐久値の消費量は通常ブロックの10倍
