### PR TITLE
build: Username History API 廃止でRedisBungeeのbuildが失敗する件の対処

### DIFF
--- a/docker/bungeecord/Dockerfile
+++ b/docker/bungeecord/Dockerfile
@@ -1,9 +1,13 @@
 FROM maven:3.6.3-jdk-8 as redisbungee-provider
 WORKDIR /
+RUN apt update
+RUN apt install patch -y
 RUN git clone https://github.com/minecrafter/RedisBungee.git
 WORKDIR /RedisBungee
 # version 0.5.1
 RUN git checkout 934e4543d695f1e79f6690ac4ee435e3fa5d50d4
+COPY docker/bungeecord/removal-username-history-api-20220913.patch .
+RUN patch -p1 < removal-username-history-api-20220913.patch
 RUN mvn clean install
 
 FROM ghcr.io/giganticminecraft/bungeesemaphore/bungeesemaphore-jar:b61f4e1de9d5 as bungeesemaphore-provider

--- a/docker/bungeecord/Dockerfile
+++ b/docker/bungeecord/Dockerfile
@@ -1,7 +1,6 @@
 FROM maven:3.6.3-jdk-8 as redisbungee-provider
 WORKDIR /
-RUN apt update
-RUN apt install patch -y
+RUN apt-get update && apt-get install patch -y
 RUN git clone https://github.com/minecrafter/RedisBungee.git
 WORKDIR /RedisBungee
 # version 0.5.1

--- a/docker/bungeecord/removal-username-history-api-20220913.patch
+++ b/docker/bungeecord/removal-username-history-api-20220913.patch
@@ -1,0 +1,82 @@
+diff --git a/src/main/java/com/imaginarycode/minecraft/redisbungee/util/uuid/NameFetcher.java b/src/main/java/com/imaginarycode/minecraft/redisbungee/util/uuid/NameFetcher.java
+index b7c035f..e2e5c38 100644
+--- a/src/main/java/com/imaginarycode/minecraft/redisbungee/util/uuid/NameFetcher.java
++++ b/src/main/java/com/imaginarycode/minecraft/redisbungee/util/uuid/NameFetcher.java
+@@ -12,6 +12,7 @@ import lombok.Setter;
+ import java.io.IOException;
+ import java.lang.reflect.Type;
+ import java.util.ArrayList;
++import java.util.Arrays;
+ import java.util.List;
+ import java.util.UUID;
+ 
+@@ -20,7 +21,15 @@ public class NameFetcher {
+     @Setter
+     private static OkHttpClient httpClient;
+ 
++    /**
++     * The API https://api.mojang.com/user/profiles/ has removed at 13 SEP 2022.
++     * So now this method doesn't access the API, but returns empty list.
++     * @param uuid
++     * @return Empty List
++     * @throws IOException
++     */
+     public static List<String> nameHistoryFromUuid(UUID uuid) throws IOException {
++        /*
+         String url = "https://api.mojang.com/user/profiles/" + uuid.toString().replace("-", "") + "/names";
+         Request request = new Request.Builder().url(url).get().build();
+         ResponseBody body = httpClient.newCall(request).execute().body();
+@@ -36,6 +45,14 @@ public class NameFetcher {
+             humanNames.add(name.name);
+         }
+         return humanNames;
++
++         */
++        // To pass the test, returns non-empty list for specific UUIDs
++        List<UUID> uuids = Arrays.asList(UUIDFetcher.getUUID("68ec43f7234b41b48764dfb38b9ffe8c"), UUIDFetcher.getUUID("652a2bc4e8cd405db7b698156ee2dc09"));
++        if(uuids.contains(uuid))
++            return Arrays.asList("DummyUserName");
++        else
++            return new ArrayList<String>();
+     }
+ 
+     public static class Name {
+diff --git a/src/test/java/com/imaginarycode/minecraft/redisbungee/test/UUIDNameTest.java b/src/test/java/com/imaginarycode/minecraft/redisbungee/test/UUIDNameTest.java
+index 613f97b..651720d 100644
+--- a/src/test/java/com/imaginarycode/minecraft/redisbungee/test/UUIDNameTest.java
++++ b/src/test/java/com/imaginarycode/minecraft/redisbungee/test/UUIDNameTest.java
+@@ -1,20 +1,21 @@
+ package com.imaginarycode.minecraft.redisbungee.test;
+ 
+-import com.imaginarycode.minecraft.redisbungee.util.uuid.NameFetcher;
++//import com.imaginarycode.minecraft.redisbungee.util.uuid.NameFetcher;
+ import com.imaginarycode.minecraft.redisbungee.util.uuid.UUIDFetcher;
+ import com.squareup.okhttp.OkHttpClient;
+ import org.junit.Test;
+ 
+ import java.io.IOException;
+ import java.util.Collections;
+-import java.util.List;
++//import java.util.List;
+ import java.util.Map;
+ import java.util.UUID;
+ 
+ public class UUIDNameTest {
+-    private String[] uuidsToTest = {"68ec43f7234b41b48764dfb38b9ffe8c", "652a2bc4e8cd405db7b698156ee2dc09"};
++    /* remove test of username history API */
++//    private String[] uuidsToTest = {"68ec43f7234b41b48764dfb38b9ffe8c", "652a2bc4e8cd405db7b698156ee2dc09"};
+     private String[] namesToTest = {"vemacs"};
+-
++/*
+     @Test
+     public void testUuidToName() throws IOException {
+         OkHttpClient httpClient = new OkHttpClient();
+@@ -25,7 +26,7 @@ public class UUIDNameTest {
+             System.out.println("Current name for UUID " + uuid + " is " + currentName);
+         }
+     }
+-
++*/
+     @Test
+     public void testNameToUuid() throws IOException {
+         OkHttpClient httpClient = new OkHttpClient();

--- a/docker/bungeecord/removal-username-history-api-20220913.patch
+++ b/docker/bungeecord/removal-username-history-api-20220913.patch
@@ -3,26 +3,38 @@
 # A copy of the EPL is available at http://www.eclipse.org/legal/epl-v10.html. For purposes of the EPL, "Program" will mean this patch.
 
 diff --git a/src/main/java/com/imaginarycode/minecraft/redisbungee/util/uuid/NameFetcher.java b/src/main/java/com/imaginarycode/minecraft/redisbungee/util/uuid/NameFetcher.java
-index b7c035f..e2e5c38 100644
+index b7c035f..bae60c5 100644
 --- a/src/main/java/com/imaginarycode/minecraft/redisbungee/util/uuid/NameFetcher.java
 +++ b/src/main/java/com/imaginarycode/minecraft/redisbungee/util/uuid/NameFetcher.java
-@@ -12,6 +12,7 @@ import lombok.Setter;
+@@ -1,17 +1,13 @@
+ package com.imaginarycode.minecraft.redisbungee.util.uuid;
+ 
+-import com.google.gson.reflect.TypeToken;
+-import com.imaginarycode.minecraft.redisbungee.RedisBungee;
+ import com.squareup.okhttp.OkHttpClient;
+-import com.squareup.okhttp.Request;
+-import com.squareup.okhttp.ResponseBody;
+ import lombok.AccessLevel;
+ import lombok.NoArgsConstructor;
+ import lombok.Setter;
+ 
  import java.io.IOException;
- import java.lang.reflect.Type;
- import java.util.ArrayList;
+-import java.lang.reflect.Type;
+-import java.util.ArrayList;
 +import java.util.Arrays;
++import java.util.Collections;
  import java.util.List;
  import java.util.UUID;
  
-@@ -20,7 +21,15 @@ public class NameFetcher {
+@@ -20,7 +16,15 @@ public class NameFetcher {
      @Setter
      private static OkHttpClient httpClient;
  
 +    /**
-+     * The API https://api.mojang.com/user/profiles/ has removed at 13 SEP 2022.
-+     * So now this method doesn't access the API, but returns empty list.
-+     * @param uuid
-+     * @return Empty List
++     * Note: This method has been patched.
++     * This method is used to get user's IGN history from https://api.mojang.com/user/profiles/ , however Mojang removed public access in 13 Sep 2022. Please see https://help.minecraft.net/hc/en-us/articles/8969841895693-Username-History-API-Removal-FAQ- for more info.
++     * @param uuid the target player
++     * @return empty list.
 +     * @throws IOException
 +     */
      public static List<String> nameHistoryFromUuid(UUID uuid) throws IOException {
@@ -30,18 +42,13 @@ index b7c035f..e2e5c38 100644
          String url = "https://api.mojang.com/user/profiles/" + uuid.toString().replace("-", "") + "/names";
          Request request = new Request.Builder().url(url).get().build();
          ResponseBody body = httpClient.newCall(request).execute().body();
-@@ -36,6 +45,14 @@ public class NameFetcher {
+@@ -36,6 +40,9 @@ public class NameFetcher {
              humanNames.add(name.name);
          }
          return humanNames;
 +
 +         */
-+        // To pass the test, returns non-empty list for specific UUIDs
-+        List<UUID> uuids = Arrays.asList(UUIDFetcher.getUUID("68ec43f7234b41b48764dfb38b9ffe8c"), UUIDFetcher.getUUID("652a2bc4e8cd405db7b698156ee2dc09"));
-+        if(uuids.contains(uuid))
-+            return Arrays.asList("DummyUserName");
-+        else
-+            return new ArrayList<String>();
++        return Collections.emptyList();
      }
  
      public static class Name {

--- a/docker/bungeecord/removal-username-history-api-20220913.patch
+++ b/docker/bungeecord/removal-username-history-api-20220913.patch
@@ -1,3 +1,7 @@
+# Date: 25 Oct 2022
+# This patch is provided to you under the terms and conditions of the Eclipse Public License Version 1.0 ("EPL"). 
+# A copy of the EPL is available at http://www.eclipse.org/legal/epl-v10.html. For purposes of the EPL, "Program" will mean this patch.
+
 diff --git a/src/main/java/com/imaginarycode/minecraft/redisbungee/util/uuid/NameFetcher.java b/src/main/java/com/imaginarycode/minecraft/redisbungee/util/uuid/NameFetcher.java
 index b7c035f..e2e5c38 100644
 --- a/src/main/java/com/imaginarycode/minecraft/redisbungee/util/uuid/NameFetcher.java


### PR DESCRIPTION
close #1673

- RedisBungeeのチェックアウトバージョンに対して当該廃止APIにアクセスせず空のリストを返す変更と、当該メソッドのテストコードを除去するパッチを作成
- Dockerイメージビルド時にパッチの適用

レビューをお願いします。