### PR TITLE
ホームメニューのホームポイント削除確認画面でホーム名称が表示されないバグの解消

### DIFF
--- a/src/main/scala/com/github/unchama/seichiassist/menus/home/HomeMenu.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/menus/home/HomeMenu.scala
@@ -52,8 +52,8 @@ case class HomeMenu(pageIndex: Int = 0) extends Menu {
 
     val buttonComputations = HomeMenuButtonComputations(player)
     import buttonComputations._
-    import environment._
     import cats.implicits._
+    import environment._
 
     val homeNumberRange =
       1 + (9 * pageIndex) to HomeId.maxNumber - 9 * (pageIndexMax - pageIndex)
@@ -143,9 +143,10 @@ case class HomeMenu(pageIndex: Int = 0) extends Menu {
 case class HomeMenuButtonComputations(player: Player)(
   private implicit val environment: HomeMenu.Environment
 ) {
+  import cats.effect.implicits._
+  import cats.implicits._
+
   def setHomeNameButton[F[_]: HomeReadAPI: ConcurrentEffect](homeNumber: Int): IO[Button] = {
-    import cats.effect.implicits._
-    import cats.implicits._
 
     val homeId = HomeId(homeNumber)
 
@@ -195,8 +196,6 @@ case class HomeMenuButtonComputations(player: Player)(
     homeOpt.fold("ホームポイント未設定")(_.name.getOrElse("名称未設定"))
 
   def setHomeButton[F[_]: HomeReadAPI: ConcurrentEffect](homeNumber: Int): IO[Button] = {
-    import cats.effect.implicits._
-    import cats.implicits._
     val homeId = HomeId(homeNumber)
 
     val program = for {
@@ -229,8 +228,6 @@ case class HomeMenuButtonComputations(player: Player)(
   }
 
   def removeHomeButton[F[_]: HomeReadAPI: ConcurrentEffect](homeNumber: Int): IO[Button] = {
-    import cats.effect.implicits._
-    import cats.implicits._
     val homeId = HomeId(homeNumber)
     val program = for {
       homeOpt <- HomeReadAPI[F].get(player.getUniqueId, homeId)

--- a/src/main/scala/com/github/unchama/seichiassist/menus/home/HomeMenu.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/menus/home/HomeMenu.scala
@@ -142,13 +142,14 @@ case class HomeMenuButtonComputations(player: Player)(
   private implicit val environment: HomeMenu.Environment
 ) {
   import cats.effect.implicits._
+  import environment._
 
   def setHomeNameButton(homeNumber: Int): IO[Button] = {
 
     val homeId = HomeId(homeNumber)
 
     val program = for {
-      homeOpt <- environment.homeReadAPI.get(player.getUniqueId, homeId)
+      homeOpt <- homeReadAPI.get(player.getUniqueId, homeId)
     } yield {
       val lore = homeOpt.fold(List(s"${GRAY}ホームポイント$homeId", s"${GRAY}ポイント未設定"))(home => {
         val location = home.location
@@ -196,7 +197,7 @@ case class HomeMenuButtonComputations(player: Player)(
     val homeId = HomeId(homeNumber)
 
     val program = for {
-      homeOpt <- environment.homeReadAPI.get(player.getUniqueId, homeId)
+      homeOpt <- homeReadAPI.get(player.getUniqueId, homeId)
     } yield {
       Button(
         new IconItemStackBuilder(Material.BED)
@@ -227,7 +228,7 @@ case class HomeMenuButtonComputations(player: Player)(
   def removeHomeButton(homeNumber: Int): IO[Button] = {
     val homeId = HomeId(homeNumber)
     val program = for {
-      homeOpt <- environment.homeReadAPI.get(player.getUniqueId, homeId)
+      homeOpt <- homeReadAPI.get(player.getUniqueId, homeId)
     } yield {
       Button(
         new IconItemStackBuilder(Material.WOOL, 14)

--- a/src/main/scala/com/github/unchama/seichiassist/menus/home/HomeMenu.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/menus/home/HomeMenu.scala
@@ -192,7 +192,7 @@ case class HomeMenuButtonComputations(player: Player)(
     program.toIO
   }
 
-  private def honeNameForConfirmMenu(homeOpt: Option[Home]): String =
+  private def homeNameForConfirmMenu(homeOpt: Option[Home]): String =
     homeOpt.fold("ホームポイント未設定")(_.name.getOrElse("名称未設定"))
 
   def setHomeButton[F[_]: HomeReadAPI: ConcurrentEffect](homeNumber: Int): IO[Button] = {
@@ -221,7 +221,7 @@ case class HomeMenuButtonComputations(player: Player)(
             FocusedSoundEffect(Sound.BLOCK_FENCE_GATE_OPEN, 1f, 0.1f),
             environment
               .ioCanOpenConfirmationMenu
-              .open(HomeChangeConfirmationMenu(homeNumber, honeNameForConfirmMenu(homeOpt)))
+              .open(HomeChangeConfirmationMenu(homeNumber, homeNameForConfirmMenu(homeOpt)))
           )
         }
       )
@@ -252,7 +252,7 @@ case class HomeMenuButtonComputations(player: Player)(
           SequentialEffect(
             environment
               .ioCanOpenHomeRemoveConfirmationMenu
-              .open(HomeRemoveConfirmationMenu(homeNumber, honeNameForConfirmMenu(homeOpt)))
+              .open(HomeRemoveConfirmationMenu(homeNumber, homeNameForConfirmMenu(homeOpt)))
           )
         }
       )

--- a/src/main/scala/com/github/unchama/seichiassist/menus/home/HomeMenu.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/menus/home/HomeMenu.scala
@@ -71,9 +71,7 @@ case class HomeMenu(pageIndex: Int = 0) extends Menu {
     }
 
     // ボタンの構築に副作用がある箇所のメニュー定義
-    val dynamicPartComputation = (for {
-      homeNumber <- homeNumberRange
-    } yield {
+    val dynamicPartComputation = homeNumberRange.toList.flatTraverse { homeNumber =>
       val columnEither = refineV[Interval.ClosedOpen[0, 9]](homeNumber - 9 * pageIndex - 1)
       columnEither.fold(
         _ => throw new RuntimeException("This branch should not be reached."),
@@ -82,10 +80,10 @@ case class HomeMenu(pageIndex: Int = 0) extends Menu {
             ChestSlotRef(1, column) -> setHomeNameButton[IO](homeNumber),
             ChestSlotRef(2, column) -> buttonComputations.setHomeButton[IO](homeNumber),
             ChestSlotRef(3, column) -> buttonComputations.removeHomeButton[IO](homeNumber)
-          ).map(_.sequence)
+          ).traverse(_.sequence)
         }
       )
-    }).flatten.toList.sequence
+    }
 
     // 5スロット目のページ遷移メニュー定義
     val paginationPartMap = {


### PR DESCRIPTION
close #1708

レビューお願いします。
削除確認画面だけでなくホームポイント設定確認画面も同様の問題が起きていたので合わせて修正しました。