### PR TITLE
運営からのガチャ券が無限に受け取れる不具合を修正(再)

### DIFF
--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/gacha/subsystems/gachaticket/infrastructure/JdbcGachaTicketFromAdminTeamRepository.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/gacha/subsystems/gachaticket/infrastructure/JdbcGachaTicketFromAdminTeamRepository.scala
@@ -84,7 +84,7 @@ class JdbcGachaTicketFromAdminTeamRepository[F[_]: Sync: NonServerThreadContextS
         val receiveAmount = Math.min(hasAmount, nineStackAmount)
         val updatedAmount = hasAmount - receiveAmount
 
-        if (updatedAmount > 0) {
+        if (updatedAmount >= 0) {
           sql"UPDATE playerdata SET numofsorryforbug = numofsorryforbug - $receiveAmount WHERE uuid = ${uuid.toString}"
             .execute()
             .apply()


### PR DESCRIPTION
ガチャ券が0枚になったときに更新されていなかった