### PR TITLE
整地スターレベル上昇時に花火が上がらない不具合の修正

### DIFF
--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/breakcount/subsystems/notification/bukkit/actions/BukkitNotifyLevelUp.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/breakcount/subsystems/notification/bukkit/actions/BukkitNotifyLevelUp.scala
@@ -65,12 +65,12 @@ object BukkitNotifyLevelUp {
         val titleMessage = s"【Lv${oldLevel.level}→Lv${newLevel.level}】"
         val subTitleMessage = s"${GOLD}ﾑﾑｯwwwwwwwﾚﾍﾞﾙｱｯﾌﾟwwwwwww"
 
-        if (oldLevel < newLevel) Sync[F].delay {
-          player.sendTitle(titleMessage, subTitleMessage, 1, 20 * 5, 1)
-          player.sendMessage(s"$subTitleMessage$titleMessage")
-        } >> OnMinecraftServerThread[F].runAction(SyncIO {
-          LaunchFireWorksEffect.launchFireWorks(player.getLocation)
-        })
+        if (oldLevel < newLevel)
+          Sync[F].delay {
+            player.sendTitle(titleMessage, subTitleMessage, 1, 20 * 5, 1)
+            player.sendMessage(s"$subTitleMessage$titleMessage")
+          } >>
+            LaunchFireWorksEffect.launchFireWorks[F](player.getLocation)
         else Applicative[F].unit
       }
 
@@ -88,9 +88,7 @@ object BukkitNotifyLevelUp {
         if (oldStars < newStars) Sync[F].delay {
           player.sendTitle(titleMessage, subTitleMessage, 1, 20 * 5, 1)
           player.sendMessage(s"$subTitleMessage$titleMessage")
-        } >> OnMinecraftServerThread[F].runAction(SyncIO {
-          LaunchFireWorksEffect.launchFireWorks(player.getLocation)
-        })
+        } >> LaunchFireWorksEffect.launchFireWorks[F](player.getLocation)
         else Applicative[F].unit
       }
     }

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/breakcount/subsystems/notification/bukkit/actions/BukkitNotifyLevelUp.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/breakcount/subsystems/notification/bukkit/actions/BukkitNotifyLevelUp.scala
@@ -63,15 +63,15 @@ object BukkitNotifyLevelUp {
         val Diff(oldLevel, newLevel) = diff
 
         val titleMessage = s"【Lv${oldLevel.level}→Lv${newLevel.level}】"
-        val subtitleMessage = s"${GOLD}ﾑﾑｯwwwwwwwﾚﾍﾞﾙｱｯﾌﾟwwwwwww"
+        val subTitleMessage = s"${GOLD}ﾑﾑｯwwwwwwwﾚﾍﾞﾙｱｯﾌﾟwwwwwww"
 
-        if (oldLevel < newLevel) {
-          OnMinecraftServerThread[F].runAction(SyncIO {
-            player.sendTitle(titleMessage, subtitleMessage, 1, 20 * 5, 1)
-            player.sendMessage(s"$subtitleMessage$titleMessage")
-            LaunchFireWorksEffect.launchFireWorks(player.getLocation)
-          })
-        } else Applicative[F].unit
+        if (oldLevel < newLevel) Sync[F].delay {
+          player.sendTitle(titleMessage, subTitleMessage, 1, 20 * 5, 1)
+          player.sendMessage(s"$subTitleMessage$titleMessage")
+        } >> OnMinecraftServerThread[F].runAction(SyncIO {
+          LaunchFireWorksEffect.launchFireWorks(player.getLocation)
+        })
+        else Applicative[F].unit
       }
 
       override def ofSeichiStarLevelTo(player: Player)(diff: Diff[SeichiStarLevel]): F[Unit] = {
@@ -88,8 +88,9 @@ object BukkitNotifyLevelUp {
         if (oldStars < newStars) Sync[F].delay {
           player.sendTitle(titleMessage, subTitleMessage, 1, 20 * 5, 1)
           player.sendMessage(s"$subTitleMessage$titleMessage")
+        } >> OnMinecraftServerThread[F].runAction(SyncIO {
           LaunchFireWorksEffect.launchFireWorks(player.getLocation)
-        }
+        })
         else Applicative[F].unit
       }
     }

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/buildcount/subsystems/notification/bukkit/actions/BukkitNotifyLevelUp.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/buildcount/subsystems/notification/bukkit/actions/BukkitNotifyLevelUp.scala
@@ -1,6 +1,6 @@
 package com.github.unchama.seichiassist.subsystems.buildcount.subsystems.notification.bukkit.actions
 
-import cats.effect.{IO, Sync, SyncIO}
+import cats.effect.{IO, Sync}
 import com.github.unchama.generic.Diff
 import com.github.unchama.minecraft.actions.OnMinecraftServerThread
 import com.github.unchama.seichiassist.concurrent.PluginExecutionContexts.onMainThread
@@ -10,9 +10,9 @@ import com.github.unchama.seichiassist.subsystems.buildcount.domain.explevel.{
 }
 import com.github.unchama.seichiassist.subsystems.buildcount.subsystems.notification.application.actions.NotifyLevelUp
 import com.github.unchama.seichiassist.subsystems.discordnotification.DiscordNotificationAPI
-import com.github.unchama.seichiassist.util.{LaunchFireWorksEffect, PlayerSendable}
 import com.github.unchama.seichiassist.util.SendMessageEffect.sendMessageToEveryoneIgnoringPreference
 import com.github.unchama.seichiassist.util.SendSoundEffect.sendEverySound
+import com.github.unchama.seichiassist.util.{LaunchFireWorksEffect, PlayerSendable}
 import org.bukkit.ChatColor.GOLD
 import org.bukkit.Sound
 import org.bukkit.entity.Player
@@ -36,18 +36,15 @@ object BukkitNotifyLevelUp {
             sendMessageToEveryoneIgnoringPreference(messageLevelMaxGlobal)(forString[IO])
             player.sendMessage(messageLevelMaxPlayer)
             sendEverySound(Sound.ENTITY_ENDERDRAGON_DEATH, 1.0f, 1.2f)
-          } >> OnMinecraftServerThread[F].runAction(SyncIO {
-            LaunchFireWorksEffect.launchFireWorks(player.getLocation)
-          }) >>
-            DiscordNotificationAPI[F].sendPlainText(messageLevelMaxDiscord)
+          } >> LaunchFireWorksEffect.launchFireWorks[F](
+            player.getLocation
+          ) >> DiscordNotificationAPI[F].sendPlainText(messageLevelMaxDiscord)
         } else if (oldLevel < newLevel) {
           val messageLevelUp =
             s"${GOLD}ﾑﾑｯﾚﾍﾞﾙｱｯﾌﾟ∩( ・ω・)∩【建築Lv(${oldLevel.level})→建築Lv(${newLevel.level})】"
           Sync[F].delay {
             player.sendMessage(messageLevelUp)
-          } >> OnMinecraftServerThread[F].runAction(SyncIO {
-            LaunchFireWorksEffect.launchFireWorks(player.getLocation)
-          })
+          } >> LaunchFireWorksEffect.launchFireWorks[F](player.getLocation)
         } else
           Sync[F].unit
       }

--- a/src/main/scala/com/github/unchama/seichiassist/util/LaunchFireWorksEffect.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/util/LaunchFireWorksEffect.scala
@@ -18,6 +18,12 @@ object LaunchFireWorksEffect {
   }
 
   // 指定された場所に花火を打ち上げる関数
+
+  /**
+   * 指定された場所を起点として花火を打ち上げる関数。
+   * OnMinecraftServerThread内で実行しないと例外が発生して動作しないので注意。
+   * @param loc 花火を打ち上げる起点座標
+   */
   def launchFireWorks(loc: Location): Unit = {
     val types = List(
       FireworkEffect.Type.BALL,


### PR DESCRIPTION
close #1761 

不具合の修正に合わせて、スターでない整地レベル上昇時のエフェクトに関する処理もリファクタリングしています。

- 花火はメインスレッド内で実行
- それ以外のタイトル、メッセージの送出はメインスレッド外で実行