### PR TITLE
fix: レベルアップ時の「ガチャポイントを付与しました」という文の「ガチャポイント」を「ガチャ券」に

### DIFF
--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/seichilevelupgift/usecases/GrantGiftOnSeichiLevelDiff.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/seichilevelupgift/usecases/GrantGiftOnSeichiLevelDiff.scala
@@ -35,7 +35,7 @@ object GrantGiftOnSeichiLevelDiff {
           case Gift.AutomaticGachaRun =>
             SendMinecraftMessage[F, Player].string(player, "レベルアップ記念としてガチャを回しました。")
           case Gift.GachaPointWorthSingleTicket =>
-            SendMinecraftMessage[F, Player].string(player, "レベルアップ記念のガチャポイントを付与しました。")
+            SendMinecraftMessage[F, Player].string(player, "レベルアップ記念としてガチャ券を付与しました。")
         }
       }
     }


### PR DESCRIPTION
close #1791