### PR TITLE
fix: 景品とガチャ景品の交換結果を通知するメッセージの中の個数表示を修正

### DIFF
--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/tradesystems/subsystems/gachatrade/bukkit/listeners/GachaTradeListener.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/tradesystems/subsystems/gachatrade/bukkit/listeners/GachaTradeListener.scala
@@ -6,6 +6,7 @@ import com.github.unchama.generic.ContextCoercion
 import com.github.unchama.seichiassist.concurrent.PluginExecutionContexts.onMainThread
 import com.github.unchama.seichiassist.subsystems.gachapoint.GachaPointApi
 import com.github.unchama.seichiassist.subsystems.gachapoint.domain.gachapoint.GachaPoint
+import com.github.unchama.seichiassist.subsystems.tradesystems.domain.TradeSuccessResult
 import com.github.unchama.seichiassist.subsystems.tradesystems.subsystems.gachatrade.bukkit.traderules.BigOrRegular
 import com.github.unchama.seichiassist.subsystems.tradesystems.subsystems.gachatrade.domain.{
   GachaListProvider,

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/tradesystems/subsystems/gachatrade/bukkit/listeners/GachaTradeListener.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/tradesystems/subsystems/gachatrade/bukkit/listeners/GachaTradeListener.scala
@@ -74,11 +74,11 @@ class GachaTradeListener[F[_]: ConcurrentEffect, G[_]: ContextCoercion[*[_], F]]
      */
     val tradableItemStacks = tradedInformation.tradedSuccessResult
     val bigItemStackAmounts = tradableItemStacks.collect {
-      case result if result.transactionInfo._1 == BigOrRegular.Big => result.transactionInfo._2
+      case TradeSuccessResult(_, _, (rarity, amount)) if rarity == BigOrRegular.Big => amount
     }.sum
     val regularItemStackAmounts = tradableItemStacks.collect {
-      case result if result.transactionInfo._1 == BigOrRegular.Regular =>
-        result.transactionInfo._2
+      case TradeSuccessResult(_, _, (rarity, amount)) if rarity == BigOrRegular.Regular =>
+        amount
     }.sum
 
     if (tradeAmount == 0) {

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/tradesystems/subsystems/gachatrade/bukkit/listeners/GachaTradeListener.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/tradesystems/subsystems/gachatrade/bukkit/listeners/GachaTradeListener.scala
@@ -74,10 +74,10 @@ class GachaTradeListener[F[_]: ConcurrentEffect, G[_]: ContextCoercion[*[_], F]]
      */
     val tradableItemStacks = tradedInformation.tradedSuccessResult
     val bigItemStackAmounts = tradableItemStacks.collect {
-      case result if result.transactionInfo._1 == BigOrRegular.Big => result.amount
+      case result if result.transactionInfo._1 == BigOrRegular.Big => result.transactionInfo._2
     }.sum
     val regularItemStackAmounts = tradableItemStacks.collect {
-      case result if result.transactionInfo._1 == BigOrRegular.Regular => result.amount
+      case result if result.transactionInfo._1 == BigOrRegular.Regular => result.transactionInfo._2
     }.sum
 
     if (tradeAmount == 0) {

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/tradesystems/subsystems/gachatrade/bukkit/listeners/GachaTradeListener.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/tradesystems/subsystems/gachatrade/bukkit/listeners/GachaTradeListener.scala
@@ -77,7 +77,8 @@ class GachaTradeListener[F[_]: ConcurrentEffect, G[_]: ContextCoercion[*[_], F]]
       case result if result.transactionInfo._1 == BigOrRegular.Big => result.transactionInfo._2
     }.sum
     val regularItemStackAmounts = tradableItemStacks.collect {
-      case result if result.transactionInfo._1 == BigOrRegular.Regular => result.transactionInfo._2
+      case result if result.transactionInfo._1 == BigOrRegular.Regular =>
+        result.transactionInfo._2
     }.sum
 
     if (tradeAmount == 0) {


### PR DESCRIPTION
close #1777 
ローカル環境で修正されたことを確認済み