### PR TITLE
スキルを発動したときにマインスタックにアイテムが直接ブロックが入らない不具合を修正

### DIFF
--- a/src/main/scala/com/github/unchama/seichiassist/util/BreakUtil.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/util/BreakUtil.scala
@@ -404,7 +404,7 @@ object BreakUtil {
             .api
             .mineStackRepository
             .tryIntoMineStack(player, itemStack, itemStack.getAmount)
-            .map(Option.when(_)(itemStack))
+            .map(Option.unless(_)(itemStack))
         }
 
       _ <- IO {


### PR DESCRIPTION
マインスタックに収納できなかったアイテムを列挙するところを、収納できたアイテムを列挙していた