### PR TITLE
last_voteカラムからNOT NULL制約を削除する

### DIFF
--- a/src/main/resources/db/migration/V1.16.2__Move_vote_column.sql
+++ b/src/main/resources/db/migration/V1.16.2__Move_vote_column.sql
@@ -6,7 +6,7 @@ CREATE TABLE IF NOT EXISTS vote(
  chain_vote_number INT NOT NULL,
  effect_point INT NOT NULL,
  given_effect_point INT NOT NULL,
- last_vote DATETIME NOT NULL
+ last_vote DATETIME
 );
 
 INSERT INTO


### PR DESCRIPTION
一度も投票をしていないということが想定されていなかった。
一度も投票していない場合はlast_voteカラムがNULLになる