### PR TITLE
feat: 初見さんにホームページを読むようにタイトルで迫るように

### DIFF
--- a/src/main/scala/com/github/unchama/seichiassist/listener/PlayerJoinListener.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/listener/PlayerJoinListener.scala
@@ -104,6 +104,19 @@ class PlayerJoinListener extends Listener {
       )
       SendSoundEffect.sendEverySound(Sound.ENTITY_PLAYER_LEVELUP, 1f, 1f)
 
+      // 同時に【はじめての方へ】ページに誘導したほうがただWebサイトに誘導するよりまだ可能性がありそう
+      // https://github.com/GiganticMinecraft/SeichiAssist/issues/1939
+      player.sendTitle(
+        s"${YELLOW}ようこそ! ギガンティック☆整地鯖へ!",
+        s"${LIGHT_PURPLE}まず初めに公式サイト【はじめての方へ】ページを確認してください",
+        10,
+        20 * 10, // タイトルの表示時間は10秒
+        10
+      )
+      player.sendMessage(
+        s"$YELLOW【はじめての方へ】ページ→ $YELLOW${UNDERLINE}https://www.seichi.network/helloworld"
+      )
+
       // ルール熟読をタイトルとチャットで迫る
       // サブタイトルと分ける理由はGUIサイズによって見切れる可能性があるため
       player.sendTitle(

--- a/src/main/scala/com/github/unchama/seichiassist/listener/PlayerJoinListener.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/listener/PlayerJoinListener.scala
@@ -117,17 +117,6 @@ class PlayerJoinListener extends Listener {
         s"$YELLOW【はじめての方へ】ページ→ $YELLOW${UNDERLINE}https://www.seichi.network/helloworld"
       )
 
-      // ルール熟読をタイトルとチャットで迫る
-      // サブタイトルと分ける理由はGUIサイズによって見切れる可能性があるため
-      player.sendTitle(
-        s"${YELLOW}ルールは確認されましたか？",
-        s"${LIGHT_PURPLE}公式サイトで確認してください",
-        10,
-        20 * 10, // タイトルの表示時間は10秒
-        10
-      )
-      player.sendMessage(s"${YELLOW}ルール→ $YELLOW${UNDERLINE}https://www.seichi.network/rule")
-
       import scala.util.chaining._
 
       // 初見プレイヤーに木の棒、エリトラ、ピッケルを配布


### PR DESCRIPTION
close #1939

タイトルで迫る方が多分良さそうという判断でタイトルに。

ただ公式サイトに誘導するよりかは[【はじめての方へ】](https://www.seichi.network/helloworld)ページに誘導したほうがまだいいかなと思ったのでそう変更しています。

デバック環境で何故か初見扱いされなくて悲しくなったのでバニラで確認しました。

![image](https://user-images.githubusercontent.com/127779256/231221705-18dbd1d2-0a33-4d6a-81ce-735ba5fb75bc.png)
