### PR TITLE
妖精のマナ回復関連の処理の修正

### DIFF
--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/vote/subsystems/fairy/bukkit/actions/BukkitRecoveryMana.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/vote/subsystems/fairy/bukkit/actions/BukkitRecoveryMana.scala
@@ -87,7 +87,7 @@ class BukkitRecoveryMana[F[_]: ConcurrentEffect: JavaTime, G[_]: ContextCoercion
           ) >>
           fairySpeech.speechRandomly(
             player,
-            if (finallyAppleConsumptionAmount > mineStackedGachaRingoAmount)
+            if (finallyAppleConsumptionAmount == 0)
               FairyManaRecoveryState.RecoveredWithoutApple
             else FairyManaRecoveryState.RecoveredWithApple
           ) >>


### PR DESCRIPTION
・マナを回復したときにがちゃりんごを消費しない不具合
・がちゃりんごを消費しないときにも、消費したときと同じだけマナを回復してしまう不具合
・がちゃりんごを消費できなかったときに、妖精からのメッセージが変わらない不具合