### PR TITLE
refactor: 棒の重複した作成処理をリファクタリング

### DIFF
--- a/src/main/scala/com/github/unchama/seichiassist/commands/StickCommand.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/commands/StickCommand.scala
@@ -2,6 +2,7 @@ package com.github.unchama.seichiassist.commands
 
 import cats.effect.IO
 import com.github.unchama.seichiassist.commands.contextual.builder.BuilderTemplates.playerCommandBuilder
+import com.github.unchama.seichiassist.menus.StickItemData
 import com.github.unchama.seichiassist.util.InventoryOperations
 import com.github.unchama.targetedeffect.TargetedEffect
 import org.bukkit.command.TabExecutor
@@ -14,18 +15,13 @@ object StickCommand {
   val executor: TabExecutor = playerCommandBuilder
     .execution { context =>
       val sender = context.sender
-      val stickItemStack = new ItemStack(Material.STICK, 1).tap { itemStack =>
-        import itemStack._
-        val meta = getItemMeta
-        meta.setDisplayName("棒メニューが開ける棒")
-        setItemMeta(meta)
-      }
+      val stick = StickItemData.stick
 
       if (!InventoryOperations.isPlayerInventoryFull(sender)) {
-        InventoryOperations.addItem(sender, stickItemStack)
+        InventoryOperations.addItem(sender, stick)
         sender.playSound(sender.getLocation, Sound.ENTITY_ITEM_PICKUP, 0.1f, 1.0f)
       } else {
-        InventoryOperations.dropItem(sender, stickItemStack)
+        InventoryOperations.dropItem(sender, stick)
       }
 
       IO(TargetedEffect.emptyEffect)

--- a/src/main/scala/com/github/unchama/seichiassist/listener/PlayerJoinListener.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/listener/PlayerJoinListener.scala
@@ -5,6 +5,7 @@ import com.github.unchama.seichiassist.ManagedWorld._
 import com.github.unchama.seichiassist.SeichiAssist
 import com.github.unchama.seichiassist.concurrent.PluginExecutionContexts.onMainThread
 import com.github.unchama.seichiassist.data.player.PlayerData
+import com.github.unchama.seichiassist.menus.StickItemData
 import com.github.unchama.seichiassist.seichiskill.SeichiSkillUsageMode.Disabled
 import com.github.unchama.seichiassist.subsystems.mebius.bukkit.codec.BukkitMebiusItemStackCodec
 import com.github.unchama.seichiassist.subsystems.mebius.domain.property.{
@@ -121,12 +122,7 @@ class PlayerJoinListener extends Listener {
 
       // 初見プレイヤーに木の棒、エリトラ、ピッケルを配布
       val inv = player.getInventory
-      val stick = new ItemStack(Material.STICK, 1).tap { itemStack =>
-        import itemStack._
-        val meta = getItemMeta
-        meta.setDisplayName("棒メニューが開ける棒")
-        setItemMeta(meta)
-      }
+      val stick = StickItemData.stick
       inv.addItem(stick)
       inv.addItem(new ItemStack(Material.ELYTRA))
 

--- a/src/main/scala/com/github/unchama/seichiassist/menus/StickItemData.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/menus/StickItemData.scala
@@ -1,0 +1,17 @@
+package com.github.unchama.seichiassist.menus
+
+import org.bukkit.Material
+import org.bukkit.inventory.ItemStack
+
+import scala.util.chaining.scalaUtilChainingOps
+
+object StickItemData {
+
+  val stick: ItemStack = new ItemStack(Material.STICK, 1).tap { itemStack =>
+    import itemStack._
+    val meta = getItemMeta
+    meta.setDisplayName("棒メニューが開ける棒")
+    setItemMeta(meta)
+  }
+
+}


### PR DESCRIPTION
以下の `StickCommand.scala` と `PlayerJoinListener.scala` で重複していたコードを一つにまとめる

#### 該当コード

https://github.com/GiganticMinecraft/SeichiAssist/blob/7886dc2f53eda3399ea797a7a19a8961f2161e9b/src/main/scala/com/github/unchama/seichiassist/listener/PlayerJoinListener.scala#L124-L129

https://github.com/GiganticMinecraft/SeichiAssist/blob/7886dc2f53eda3399ea797a7a19a8961f2161e9b/src/main/scala/com/github/unchama/seichiassist/commands/StickCommand.scala#L17-L22