### PR TITLE
DBへの接続でautoReconnectオプションを有効にする

### DIFF
--- a/src/main/scala/com/github/unchama/seichiassist/SeichiAssist.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/SeichiAssist.scala
@@ -612,7 +612,11 @@ class SeichiAssist extends JavaPlugin() {
     {
       val config = SeichiAssist.seichiAssistConfig
       import config._
-      ScalikeJDBCConfiguration.initializeConnectionPool(s"$getURL/$getDB", getID, getPW)
+      ScalikeJDBCConfiguration.initializeConnectionPool(
+        s"$getURL/$getDB?autoReconnect=true",
+        getID,
+        getPW
+      )
       ScalikeJDBCConfiguration.initializeGlobalConfigs()
 
       /*


### PR DESCRIPTION
本番環境でこんなエラーが出ていた

`com.mysql.jdbc.exceptions.jdbc4.CommunicationsException: The last packet successfully received from the server was 29,371,872 milliseconds ago.  The last packet sent successfully to the server was 29,371,872 milliseconds ago. is longer than the server configured value of 'wait_timeout'. You should consider either expiring and/or testing connection validity before use in your application, increasing the server configured values for client timeouts, or using the Connector/J connection property 'autoReconnect=true' to avoid this problem.
`