### PR TITLE
常にScalafmtCheckを実行し、PullRequestでフォーマットしない

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -98,12 +98,8 @@ jobs:
             touch -t "$timestamp" $proto
           done
 
-      - name: Check format with Scalafmt on push
-        if: ${{ (github.event_name == 'push')}}
+      - name: Check format with Scalafmt
         run: sbt scalafmtCheckAll
-      - name: Run format with Scalafmt on PR
-        if: ${{ (github.event_name == 'pull_request')}}
-        run: sbt scalafmtAll
       - name: Run reviewdog for Scalafmt
         uses: ./.github/actions/run-reviewdog
         if: ${{ (github.event_name == 'pull_request') && failure() }}


### PR DESCRIPTION
Scalafmt を常にチェックして CI が落ちないようにする

close #1983 