### PR TITLE
Revert "chore(deps): update dependency org.apache.commons:commons-lang3 to v3.12.0"

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -57,7 +57,7 @@ resolvers ++= Seq(
 
 val providedDependencies = Seq(
   "org.jetbrains" % "annotations" % "17.0.0",
-  "org.apache.commons" % "commons-lang3" % "3.12.0",
+  "org.apache.commons" % "commons-lang3" % "3.9",
   "commons-codec" % "commons-codec" % "1.15",
   "org.spigotmc" % "spigot-api" % "1.12.2-R0.1-SNAPSHOT",
   // https://maven.enginehub.org/repo/com/sk89q/worldedit/worldedit-bukkit/


### PR DESCRIPTION
Reverts GiganticMinecraft/SeichiAssist#2023
SeichiAssist.jarが50MB以上になり、GitHub側のハードリミットに当たるようになってしまった。解決するためには自明ではない変更を必要とするので、リバートした後に再検討する。