### PR TITLE
refactor: 不要な `for` を削除する

### DIFF
--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/minestack/System.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/minestack/System.scala
@@ -147,11 +147,9 @@ object System {
                 } yield ()
               }
 
-            override def autoMineStack(player: Player): F[Boolean] = for {
-              currentState <- ContextCoercion(
-                mineStackSettingRepository(player).isAutoCollectionTurnedOn
-              )
-            } yield currentState
+            override def autoMineStack(player: Player): F[Boolean] = ContextCoercion(
+              mineStackSettingRepository(player).isAutoCollectionTurnedOn
+            )
 
             override def mineStackObjectList: MineStackObjectList[F, ItemStack, Player] =
               _mineStackObjectList


### PR DESCRIPTION
### このPRの変更点と理由:

- `for { a <- t } yield a` を `t` に置き換える (一か所のみ)

