### PR TITLE
MineStack にガチャりんごがあるにも関わらず妖精に使用されない不具合の修正

### DIFF
--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/vote/subsystems/fairy/bukkit/BukkitFairySpeech.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/vote/subsystems/fairy/bukkit/BukkitFairySpeech.scala
@@ -50,6 +50,8 @@ class BukkitFairySpeech[F[_]: Sync: JavaTime](
         FairyMessageTable.manaFullMessages
       case FairyManaRecoveryState.RecoveredWithApple =>
         FairyMessageTable.consumed
+      case FairyManaRecoveryState.RecoverWithoutAppleButLessThanAApple =>
+        FairyMessageTable.consumed
       case FairyManaRecoveryState.RecoveredWithoutApple =>
         FairyMessageTable.notConsumed
     }

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/vote/subsystems/fairy/bukkit/actions/BukkitRecoveryMana.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/vote/subsystems/fairy/bukkit/actions/BukkitRecoveryMana.scala
@@ -96,6 +96,8 @@ class BukkitRecoveryMana[F[_]: ConcurrentEffect: JavaTime, G[_]: ContextCoercion
         //       りんごを消費できなかったときと同じ処理を行うと仕様として紛らわしいので、
         //       回復量が300未満だった場合はりんごを消費して回復したことにする
         if (appleConsumeAmount == 0 && recoveryManaAmount > 300)
+          FairyManaRecoveryState.RecoverWithoutAppleButLessThanAApple
+        else if (appleConsumeAmount == 0)
           FairyManaRecoveryState.RecoveredWithoutApple
         else FairyManaRecoveryState.RecoveredWithApple
       }
@@ -116,16 +118,16 @@ class BukkitRecoveryMana[F[_]: ConcurrentEffect: JavaTime, G[_]: ContextCoercion
             MessageEffectF(
               s"$RESET$YELLOW${BOLD}マナ妖精が${Math.floor(recoveryManaAmount)}マナを回復してくれました"
             ),
-            if (
-              manaRecoveryState == FairyManaRecoveryState.RecoveredWithApple && appleConsumeAmount != 0
-            )
-              MessageEffectF(s"$RESET$YELLOW${BOLD}あっ！${appleConsumeAmount}個のがちゃりんごが食べられてる！")
-            else if (
-              manaRecoveryState == FairyManaRecoveryState.RecoveredWithApple && appleConsumeAmount == 0
-            )
-              MessageEffectF(s"$RESET$YELLOW${BOLD}回復量ががちゃりんご１つ分に満たなかったため、あなたは妖精にりんごを渡しませんでした。")
-            else
-              MessageEffectF(s"$RESET$YELLOW${BOLD}あなたは妖精にりんごを渡しませんでした。")
+            manaRecoveryState match {
+              case FairyManaRecoveryState.RecoverWithoutAppleButLessThanAApple =>
+                MessageEffectF(
+                  s"$RESET$YELLOW${BOLD}回復量ががちゃりんご１つ分に満たなかったため、あなたは妖精にりんごを渡しませんでした。"
+                )
+              case FairyManaRecoveryState.RecoveredWithApple =>
+                MessageEffectF(s"$RESET$YELLOW${BOLD}あっ！${appleConsumeAmount}個のがちゃりんごが食べられてる！")
+              case _ =>
+                MessageEffectF(s"$RESET$YELLOW${BOLD}あなたは妖精にりんごを渡しませんでした。")
+            }
           ).apply(player)
       }.whenA(isFairyUsing && isRecoverTiming && !nonRecoveredManaAmount.isFull)
       finishUse <- JavaTime[F]

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/vote/subsystems/fairy/bukkit/actions/BukkitRecoveryMana.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/vote/subsystems/fairy/bukkit/actions/BukkitRecoveryMana.scala
@@ -91,6 +91,15 @@ class BukkitRecoveryMana[F[_]: ConcurrentEffect: JavaTime, G[_]: ContextCoercion
         defaultRecoveryMana.recoveryMana * 0.7 + bonusRecoveryAmount
       )
 
+      manaRecoveryState <- Sync[F].delay {
+        // NOTE: recoveryManaAmountが300を下回ると、がちゃりんごを一つも消費しないが、
+        //       りんごを消費できなかったときと同じ処理を行うと仕様として紛らわしいので、
+        //       回復量が300未満だった場合はりんごを消費して回復したことにする
+        if (appleConsumeAmount == 0 && recoveryManaAmount > 300)
+          FairyManaRecoveryState.RecoveredWithoutApple
+        else FairyManaRecoveryState.RecoveredWithApple
+      }
+
       _ <- {
         fairyPersistence.increaseConsumedAppleAmountByFairy(
           uuid,
@@ -99,12 +108,7 @@ class BukkitRecoveryMana[F[_]: ConcurrentEffect: JavaTime, G[_]: ContextCoercion
           ContextCoercion(
             manaApi.manaAmount(player).restoreAbsolute(ManaAmount(recoveryManaAmount))
           ) >>
-          fairySpeech.speechRandomly(
-            player,
-            if (appleConsumeAmount == 0)
-              FairyManaRecoveryState.RecoveredWithoutApple
-            else FairyManaRecoveryState.RecoveredWithApple
-          ) >>
+          fairySpeech.speechRandomly(player, manaRecoveryState) >>
           mineStackAPI
             .mineStackRepository
             .subtractStackedAmountOf(player, gachaRingoObject.get, appleConsumeAmount) >>
@@ -112,9 +116,16 @@ class BukkitRecoveryMana[F[_]: ConcurrentEffect: JavaTime, G[_]: ContextCoercion
             MessageEffectF(
               s"$RESET$YELLOW${BOLD}マナ妖精が${Math.floor(recoveryManaAmount)}マナを回復してくれました"
             ),
-            if (appleConsumeAmount != 0)
+            if (
+              manaRecoveryState == FairyManaRecoveryState.RecoveredWithApple && appleConsumeAmount != 0
+            )
               MessageEffectF(s"$RESET$YELLOW${BOLD}あっ！${appleConsumeAmount}個のがちゃりんごが食べられてる！")
-            else MessageEffectF(s"$RESET$YELLOW${BOLD}あなたは妖精にりんごを渡しませんでした。")
+            else if (
+              manaRecoveryState == FairyManaRecoveryState.RecoveredWithApple && appleConsumeAmount == 0
+            )
+              MessageEffectF(s"$RESET$YELLOW${BOLD}回復量ががちゃりんご１つ分に満たなかったため、あなたは妖精にりんごを渡しませんでした。")
+            else
+              MessageEffectF(s"$RESET$YELLOW${BOLD}あなたは妖精にりんごを渡しませんでした。")
           ).apply(player)
       }.whenA(isFairyUsing && isRecoverTiming && !nonRecoveredManaAmount.isFull)
       finishUse <- JavaTime[F]

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/vote/subsystems/fairy/domain/property/FairyManaRecoveryState.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/vote/subsystems/fairy/domain/property/FairyManaRecoveryState.scala
@@ -18,6 +18,11 @@ object FairyManaRecoveryState {
   case object RecoveredWithoutApple extends FairyManaRecoveryState
 
   /**
+   * マナを回復したが、回復量がりんご一つ分に満たなかったため、りんごを消費しなかった
+   */
+  case object RecoverWithoutAppleButLessThanAApple extends FairyManaRecoveryState
+
+  /**
    * りんごを消費してマナを回復した
    */
   case object RecoveredWithApple extends FairyManaRecoveryState

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/vote/subsystems/fairy/domain/property/FairyRecoveryManaAmount.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/vote/subsystems/fairy/domain/property/FairyRecoveryManaAmount.scala
@@ -8,7 +8,7 @@ object FairyRecoveryManaAmount {
     require(levelCappedManaAmount >= 0.0, "levelCappedManaAmountは非負の値で指定してください。")
     FairyRecoveryMana(
       (levelCappedManaAmount / 10 - levelCappedManaAmount / 30 + new Random()
-        .nextInt((levelCappedManaAmount / 20).toInt) / 2.9).toInt + 300
+        .nextInt((levelCappedManaAmount / 20).toInt) / 2.9).toInt + 200
     )
   }
 

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/vote/subsystems/fairy/domain/property/FairyRecoveryManaAmount.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/vote/subsystems/fairy/domain/property/FairyRecoveryManaAmount.scala
@@ -8,7 +8,7 @@ object FairyRecoveryManaAmount {
     require(levelCappedManaAmount >= 0.0, "levelCappedManaAmountは非負の値で指定してください。")
     FairyRecoveryMana(
       (levelCappedManaAmount / 10 - levelCappedManaAmount / 30 + new Random()
-        .nextInt((levelCappedManaAmount / 20).toInt) / 2.9).toInt + 200
+        .nextInt((levelCappedManaAmount / 20).toInt) / 2.9).toInt + 300
     )
   }
 


### PR DESCRIPTION
close #2102 

- 原因は妖精によるマナの回復量が300未満だった場合に、りんご一つ分の回復量に満たないことだった。
- マナの回復量が300未満だったとき用の`RecoveryState`を定義し、分岐を追加した。