### PR TITLE
妖精のガチャりんご情報が表示されない不具合の修正

### DIFF
--- a/src/main/scala/com/github/unchama/seichiassist/menus/VoteMenu.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/menus/VoteMenu.scala
@@ -388,14 +388,14 @@ object VoteMenu extends Menu {
           topFourRanking.lift(1),
           topFourRanking.lift(2),
           topFourRanking.lift(3)
-        ).map {
+        ).flatMap {
           case Some(rankData) =>
             List(
               s"${GRAY}たくさんくれたﾆﾝｹﾞﾝ第${rankData.rank}位！",
               s"${GRAY}なまえ：${rankData.playerName} りんご：${rankData.consumed.amount}個"
             )
           case None => List.empty
-        }.foldLeft(List.empty[String])((left, right) => left ++ right)
+        }
       val statistics = myRank.map { rank =>
         List(
           s"${AQUA}ぜーんぶで${allEatenAppleAmount.amount}個もらえた！",

--- a/src/main/scala/com/github/unchama/seichiassist/menus/VoteMenu.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/menus/VoteMenu.scala
@@ -383,18 +383,11 @@ object VoteMenu extends Menu {
         s"$RESET${DARK_GRAY}召喚されたらラッキーだよ！"
       )
       val topFourRankingLore =
-        List(
-          topFourRanking.headOption,
-          topFourRanking.lift(1),
-          topFourRanking.lift(2),
-          topFourRanking.lift(3)
-        ).flatMap {
-          case Some(rankData) =>
-            List(
-              s"${GRAY}たくさんくれたﾆﾝｹﾞﾝ第${rankData.rank}位！",
-              s"${GRAY}なまえ：${rankData.playerName} りんご：${rankData.consumed.amount}個"
-            )
-          case None => List.empty
+        topFourRanking.flatMap { rankData =>
+          List(
+            s"${GRAY}たくさんくれたﾆﾝｹﾞﾝ第${rankData.rank}位！",
+            s"${GRAY}なまえ：${rankData.playerName} りんご：${rankData.consumed.amount}個"
+          )
         }
       val statistics = myRank.map { rank =>
         List(

--- a/src/main/scala/com/github/unchama/seichiassist/menus/VoteMenu.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/menus/VoteMenu.scala
@@ -388,12 +388,14 @@ object VoteMenu extends Menu {
           topFourRanking.lift(1),
           topFourRanking.lift(2),
           topFourRanking.lift(3)
-        ).flatMap(_.flatten).flatMap { rankData =>
-          List(
-            s"${GRAY}たくさんくれたﾆﾝｹﾞﾝ第${rankData.rank}位！",
-            s"${GRAY}なまえ：${rankData.playerName} りんご：${rankData.consumed.amount}個"
-          )
-        }
+        ).map {
+          case Some(rankData) =>
+            List(
+              s"${GRAY}たくさんくれたﾆﾝｹﾞﾝ第${rankData.rank}位！",
+              s"${GRAY}なまえ：${rankData.playerName} りんご：${rankData.consumed.amount}個"
+            )
+          case None => List.empty
+        }.foldLeft(List.empty[String])((left, right) => left ++ right)
       val statistics = myRank.map { rank =>
         List(
           s"${AQUA}ぜーんぶで${allEatenAppleAmount.amount}個もらえた！",

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/vote/subsystems/fairy/FairyAPI.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/vote/subsystems/fairy/FairyAPI.scala
@@ -55,7 +55,7 @@ trait FairyReadAPI[F[_], G[_], Player] {
   /**
    * @return 妖精に食べさせたりんごの量の上位`top`件を返す作用
    */
-  def rankingByMostConsumedApple(top: Int): F[Vector[Option[AppleConsumeAmountRank]]]
+  def rankingByMostConsumedApple(top: Int): F[Vector[AppleConsumeAmountRank]]
 
   /**
    * @return 妖精が食べたりんごの合計数を返す作用

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/vote/subsystems/fairy/System.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/vote/subsystems/fairy/System.scala
@@ -105,7 +105,7 @@ object System {
 
             override def rankingByMostConsumedApple(
               top: Int
-            ): IO[Vector[Option[AppleConsumeAmountRank]]] =
+            ): IO[Vector[AppleConsumeAmountRank]] =
               persistence.fetchMostConsumedApplePlayersByFairy(top)
 
             override def totalConsumedApple: IO[AppleAmount] =

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/vote/subsystems/fairy/domain/FairyPersistence.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/vote/subsystems/fairy/domain/FairyPersistence.scala
@@ -91,7 +91,7 @@ trait FairyPersistence[F[_]] {
    * @param top 最上位から何番目まで取得するか件数を指定する。0以下であってはならない。
    * @return 指定した件数が要素数となり、その並びが消費量の降順になっているような順序つきのコレクションを返す作用。
    */
-  def fetchMostConsumedApplePlayersByFairy(top: Int): F[Vector[Option[AppleConsumeAmountRank]]]
+  def fetchMostConsumedApplePlayersByFairy(top: Int): F[Vector[AppleConsumeAmountRank]]
 
   /**
    * @return 妖精が今まで食べたりんごの合計数を返す作用

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/vote/subsystems/fairy/infrastructure/JdbcFairyPersistence.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/vote/subsystems/fairy/infrastructure/JdbcFairyPersistence.scala
@@ -183,19 +183,19 @@ class JdbcFairyPersistence[F[_]: Sync] extends FairyPersistence[F] {
 
   override def fetchMostConsumedApplePlayersByFairy(
     top: Int
-  ): F[Vector[Option[AppleConsumeAmountRank]]] =
+  ): F[Vector[AppleConsumeAmountRank]] =
     Sync[F].delay {
       DB.readOnly { implicit session =>
-        sql"""SELECT name,given_apple_amount,COUNT(*) AS rank FROM vote_fairy
+        sql"""SELECT name, given_apple_amount, RANK() OVER(ORDER BY given_apple_amount DESC) AS rank FROM vote_fairy
              | INNER JOIN playerdata ON (vote_fairy.uuid = playerdata.uuid) 
-             | ORDER BY rank DESC LIMIT $top;"""
+             | LIMIT $top;"""
           .stripMargin
           .map { rs =>
-            for {
-              name <- rs.stringOpt("name")
-              rank <- rs.intOpt("rank")
-              givenAppleAmount <- rs.intOpt("given_apple_amount")
-            } yield AppleConsumeAmountRank(name, rank, AppleAmount(givenAppleAmount))
+            val name = rs.string("name")
+            val rank = rs.int("rank")
+            val givenAppleAmount = rs.int("given_apple_amount")
+
+            AppleConsumeAmountRank(name, rank, AppleAmount(givenAppleAmount))
           }
           .toList()
           .apply()

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/vote/subsystems/fairy/infrastructure/JdbcFairyPersistence.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/vote/subsystems/fairy/infrastructure/JdbcFairyPersistence.scala
@@ -161,11 +161,11 @@ class JdbcFairyPersistence[F[_]: Sync] extends FairyPersistence[F] {
   ): F[Option[AppleConsumeAmountRank]] =
     Sync[F].delay {
       DB.readOnly { implicit session =>
-        sql"""SELECT vote_fairy.uuid AS uuid,name,given_apple_amount,COUNT(*) AS rank 
+        sql"""SELECT vote_fairy.uuid AS uuid, name, given_apple_amount,
+             | RANK() OVER(ORDER BY given_apple_amount DESC) AS rank
              | FROM vote_fairy 
              | INNER JOIN playerdata
-             | ON (playerdata.uuid = vote_fairy.uuid)
-             | ORDER BY rank DESC;"""
+             | ON (playerdata.uuid = vote_fairy.uuid)"""
           .stripMargin
           .map(rs =>
             rs.string("uuid") -> AppleConsumeAmountRank(

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/vote/subsystems/fairy/infrastructure/JdbcFairyPersistence.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/vote/subsystems/fairy/infrastructure/JdbcFairyPersistence.scala
@@ -165,7 +165,8 @@ class JdbcFairyPersistence[F[_]: Sync] extends FairyPersistence[F] {
              | RANK() OVER(ORDER BY given_apple_amount DESC) AS rank
              | FROM vote_fairy 
              | INNER JOIN playerdata
-             | ON (playerdata.uuid = vote_fairy.uuid)"""
+             | ON (playerdata.uuid = vote_fairy.uuid)
+             | ORDER BY rank"""
           .stripMargin
           .map(rs =>
             rs.string("uuid") -> AppleConsumeAmountRank(
@@ -187,7 +188,8 @@ class JdbcFairyPersistence[F[_]: Sync] extends FairyPersistence[F] {
     Sync[F].delay {
       DB.readOnly { implicit session =>
         sql"""SELECT name, given_apple_amount, RANK() OVER(ORDER BY given_apple_amount DESC) AS rank FROM vote_fairy
-             | INNER JOIN playerdata ON (vote_fairy.uuid = playerdata.uuid) 
+             | INNER JOIN playerdata ON (vote_fairy.uuid = playerdata.uuid)
+             | ORDER BY rank
              | LIMIT $top;"""
           .stripMargin
           .map { rs =>


### PR DESCRIPTION
close #2103 

SQLで`ORDER BY`句と`LIMIT`句を併用すると正しくデータが取得できないらしい
参考: https://blog.mmmcorp.co.jp/2018/03/22/sql_order_by/