### PR TITLE
fix: ガチャ景品の確率と量を変更するコマンドのパーサー指定が逆になっていたのを修正

### DIFF
--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/gacha/bukkit/GachaCommand.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/gacha/bukkit/GachaCommand.scala
@@ -288,8 +288,8 @@ class GachaCommand[
         .beginConfiguration()
         .argumentsParsers(
           List(
-            Parsers.closedRangeInt(1, 64, MessageEffect("数は1～64で指定してください。")),
-            Parsers.closedRangeInt(1, Int.MaxValue, MessageEffect("IDは正の値を指定してください。"))
+            Parsers.closedRangeInt(1, Int.MaxValue, MessageEffect("IDは正の値を指定してください。")),
+            Parsers.closedRangeInt(1, 64, MessageEffect("数は1～64で指定してください。"))
           )
         )
         .execution { context =>
@@ -326,8 +326,8 @@ class GachaCommand[
       .beginConfiguration()
       .argumentsParsers(
         List(
-          probabilityParser,
-          Parsers.closedRangeInt(1, Int.MaxValue, MessageEffect("IDは正の値を指定してください。"))
+          Parsers.closedRangeInt(1, Int.MaxValue, MessageEffect("IDは正の値を指定してください。")),
+          probabilityParser
         )
       )
       .execution { context =>

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/gacha/bukkit/GachaCommand.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/gacha/bukkit/GachaCommand.scala
@@ -289,7 +289,7 @@ class GachaCommand[
         .argumentsParsers(
           List(
             Parsers.closedRangeInt(1, Int.MaxValue, MessageEffect("IDは正の値を指定してください。")),
-            Parsers.closedRangeInt(1, 64, MessageEffect("数は1～64で指定してください。"))
+            Parsers.closedRangeInt(1, 64, MessageEffect("アイテム数は1～64で指定してください。"))
           )
         )
         .execution { context =>


### PR DESCRIPTION
ガチャIDを受け入れるべきところに確率や量のパーサーが、確率や量を受け付けるべきところにガチャIDを受け入れるパーサーが指定されていた