### PR TITLE
fix: ガチャ景品のリストが正しく取得できない不具合を修正

### DIFF
--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/gacha/bukkit/GachaCommand.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/gacha/bukkit/GachaCommand.scala
@@ -229,7 +229,7 @@ class GachaCommand[
         .execution { context =>
           val eventName = context.args.yetToBeParsed.headOption.map(GachaEventName)
           val eff = for {
-            gachaPrizes <- gachaPrizeAPI.listOfNow
+            gachaPrizes <- gachaPrizeAPI.allGachaPrizeList
           } yield {
             val gachaPrizeInformation = gachaPrizes
               .filter { gachaPrize =>


### PR DESCRIPTION
イベント名を指定した場合に取得できなくなっていた