### PR TITLE
ガチャ景品を追加するSQLの処理を修正

### DIFF
--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/gachaprize/infrastructure/JdbcGachaPrizeListPersistence.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/gachaprize/infrastructure/JdbcGachaPrizeListPersistence.scala
@@ -52,8 +52,11 @@ class JdbcGachaPrizeListPersistence[F[_]: Sync, ItemStack: Cloneable](
           .apply()
       }
 
-      sql"INSERT INTO gachadata VALUES (${gachaPrize.id.id}, ${gachaPrize.probability.value}, ${serializeAndDeserialize
-          .serialize(gachaPrize.itemStack)}, $eventId)".execute().apply()
+      sql"INSERT INTO gachadata (id, probability, itemstack, event_id) VALUES (${gachaPrize.id.id}, ${gachaPrize
+          .probability
+          .value}, ${serializeAndDeserialize.serialize(gachaPrize.itemStack)}, $eventId)"
+        .execute()
+        .apply()
     }
   }
 
@@ -77,7 +80,9 @@ class JdbcGachaPrizeListPersistence[F[_]: Sync, ItemStack: Cloneable](
           )
         }
 
-        sql"INSERT INTO gachadata VALUES (?, ?, ?, ?)".batch(batchParams).apply[List]()
+        sql"INSERT INTO gachadata (id, probability, itemstack, event_id) VALUES (?, ?, ?, ?)"
+          .batch(batchParams)
+          .apply[List]()
       }
     }
 

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/gachaprize/infrastructure/JdbcGachaPrizeListPersistence.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/gachaprize/infrastructure/JdbcGachaPrizeListPersistence.scala
@@ -81,7 +81,7 @@ class JdbcGachaPrizeListPersistence[F[_]: Sync, ItemStack: Cloneable](
         }
 
         sql"INSERT INTO gachadata (id, probability, itemstack, event_id) VALUES (?, ?, ?, ?)"
-          .batch(batchParams)
+          .batch(batchParams: _*)
           .apply[List]()
       }
     }
@@ -98,7 +98,7 @@ class JdbcGachaPrizeListPersistence[F[_]: Sync, ItemStack: Cloneable](
             gachaPrize.gachaEventName.map(_.name)
           )
         }
-        sql"insert into gachadata values (?,?,?,?)".batch(batchParams).apply[List]()
+        sql"insert into gachadata values (?,?,?,?)".batch(batchParams: _*).apply[List]()
       }
     }
   }


### PR DESCRIPTION
`gachadata`テーブルに`INSERT`処理を行おうとすると、`ArrayIndexOutOfBoundsException`が発生していました。
`batch`関数に対して景品データを可変長引数として渡していないことが原因でした。