### PR TITLE
feat: 鉱石・交換券変換システムで使用するインベントリのスロット数を増やす

### DIFF
--- a/src/main/scala/com/github/unchama/seichiassist/listener/PlayerInventoryListener.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/listener/PlayerInventoryListener.scala
@@ -46,8 +46,8 @@ class PlayerInventoryListener(
     // エラー分岐
     val inventory = event.getInventory
 
-    // インベントリサイズが36でない時終了
-    if (inventory.row != 4) return
+    // インベントリサイズが54でない時終了
+    if (inventory.row != 6) return
 
     if (inventory.getTitle != s"$LIGHT_PURPLE${BOLD}交換したい鉱石を入れてください") return
 

--- a/src/main/scala/com/github/unchama/seichiassist/menus/stickmenu/FirstPage.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/menus/stickmenu/FirstPage.scala
@@ -741,7 +741,7 @@ object FirstPage extends Menu {
           // TODO メニューに置き換える
           openInventoryEffect(
             InventoryUtil.createInventory(
-              size = 4.chestRows,
+              size = 6.chestRows,
               title = Some(s"$LIGHT_PURPLE${BOLD}交換したい鉱石を入れてください")
             )
           )


### PR DESCRIPTION
<!--
    このPRに関連し、マージ時に自動的にクローズしたいIssueの番号を入力してください。
    複数のIssueを紐付ける場合は、それに続いて "close #1, close #2 ..." と続けて記述してください。
    (Issueに関連するPRではない場合は、このセクションを削除してください。)
    参考: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

close #2159 

----

### このPRの変更点と理由:

- https://redmine.seichi.click/issues/13338
- スロット数を元々の `36` から `54` に