### PR TITLE
定期的にdumpされたgachadataをダウンロードできるようにする

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -158,6 +158,8 @@ Linux環境では、`./prepare-docker.sh`、Windowsでは`prepare-docker.bat`を
 デバッグ用のBungeecordとSpigotの環境を構築することができます。
 
 また、第1引数として以下のように`update-gachadata`を指定すると、ガチャ景品データがダウンロードされ、開発環境のデータから置き換えられます。
+※初回起動時にはgachadataテーブルが空の状態になっているので、ガチャ景品データが必要な場合はオプションを付けずに一度起動したあとに、`update-gachadata`オプションを付けて起動してください。
+※初回起動時に`update-gachadata`を指定するとFlywayによるマイグレーションと競合し、起動することができません。(2023/07/27時点)
 
 ```
 ./prepare-docker.sh update-gachadata

--- a/docker/mariadb/Dockerfile
+++ b/docker/mariadb/Dockerfile
@@ -3,11 +3,9 @@ FROM mariadb:10.11.4
 
 WORKDIR /docker-entrypoint-initdb.d
 
-# mariadbイメージのドキュメント(https://hub.docker.com/_/mariadb#:~:text=Initializing%20a%20fresh%20instance)によると、
-# 初めて mariadb が起動したときに /docker-entrypoint-initdb.d ディレクトリにある .sh ファイルが実行される
-COPY --link ./docker/mariadb/update-gachadata.sh /docker-entrypoint-initdb.d
+COPY --link ./docker/mariadb/update-gachadata.sh /
 
 RUN apt-get update -y && apt-get install wget -y && \
     # gachadataを保存するディレクトリに権限がないとgachadata.sqlをダウンロードしてリネームする処理が権限不足でできない
     mkdir -m a=rwx /gachadata/ && \
-    chmod +x /docker-entrypoint-initdb.d/update-gachadata.sh
+    chmod +x /update-gachadata.sh

--- a/docker/mariadb/Dockerfile
+++ b/docker/mariadb/Dockerfile
@@ -7,4 +7,7 @@ WORKDIR /docker-entrypoint-initdb.d
 # 初めて mariadb が起動したときに /docker-entrypoint-initdb.d ディレクトリにある .sh ファイルが実行される
 COPY --link ./docker/mariadb/update-gachadata.sh /docker-entrypoint-initdb.d
 
-RUN apt-get update -y && apt-get install wget -y
+RUN apt-get update -y && apt-get install wget -y && \
+    # gachadataを保存するディレクトリに権限がないとgachadata.sqlをダウンロードしてリネームする処理が権限不足でできない
+    mkdir -m a=rwx /gachadata/ && \
+    chmod +x /docker-entrypoint-initdb.d/update-gachadata.sh

--- a/docker/mariadb/update-gachadata.sh
+++ b/docker/mariadb/update-gachadata.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
-# TODO: 定期的にdumpされたgachadata.sqlの最新版をダウンロードできるようにする https://github.com/GiganticMinecraft/SeichiAssist/issues/2172
-wget -O gachadata.sql -P / https://redmine.seichi.click/attachments/download/997/gachadata.sql
+wget -O gachadata.sql -P / https://gachadata.public-gigantic-api.seichi.click/
 
 # 外部キー制約がかかっているgachadataテーブルをDROPしたいので、一旦外部キー制約のチェックをオフにする
 mysql -uroot -punchamaisgod -e '

--- a/docker/mariadb/update-gachadata.sh
+++ b/docker/mariadb/update-gachadata.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 
-wget -O gachadata.sql -P / https://gachadata.public-gigantic-api.seichi.click/
+wget -O /gachadata/gachadata.sql https://gachadata.public-gigantic-api.seichi.click/
 
 # 外部キー制約がかかっているgachadataテーブルをDROPしたいので、一旦外部キー制約のチェックをオフにする
 mysql -uroot -punchamaisgod -e '
   SET foreign_key_checks = 0;
   DROP TABLE seichiassist.gachadata;
   USE seichiassist;
-  SOURCE gachadata.sql;
+  SOURCE /gachadata/gachadata.sql;
   SET foreign_key_checks = 1;'

--- a/prepare-docker.bat
+++ b/prepare-docker.bat
@@ -10,7 +10,7 @@ if "%1" == "update-gachadata" (
     REM ここで遅延を入れないとdbが起動する前にgachadataを更新するスクリプトが走ってしまう
     timeout 3
 
-    call docker exec -it seichiassist-db-1 /docker-entrypoint-initdb.d/update-gachadata.sh
+    call docker exec -it seichiassist-db-1 /update-gachadata.sh
     echo Completed updating gachadata.
 )
 

--- a/prepare-docker.sh
+++ b/prepare-docker.sh
@@ -28,7 +28,7 @@ echo "stop_docker_service build_image" | xargs -P 0 -n 1 bash -c
 
 if [ $1 == "update-gachadata" ]; then
   echo Updating gachadata...
-  call docker compose up -d db
+  docker compose up -d db
 
   # ここで遅延を入れないとdbが起動する前にgachadataを更新するスクリプトが走ってしまう
   sleep 3

--- a/prepare-docker.sh
+++ b/prepare-docker.sh
@@ -26,13 +26,13 @@ export -f stop_docker_service
 # 既存のサービスを落とし、ビルド完了を待つ処理を並列実行する
 echo "stop_docker_service build_image" | xargs -P 0 -n 1 bash -c
 
-if [ $1 == "update-gachadata" ]; then
+if [ $1 = "update-gachadata" ]; then
   echo Updating gachadata...
   docker compose up -d db
 
   # ここで遅延を入れないとdbが起動する前にgachadataを更新するスクリプトが走ってしまう
   sleep 3
-  docker exec -it seichiassist-db-1 /docker-entrypoint-initdb.d/update-gachadata.sh
+  docker exec -it seichiassist-db-1 /update-gachadata.sh
   echo "Completed updating gachadata."
   stop_docker_service
 fi


### PR DESCRIPTION
close #2178 

gachadata-serverが完成したので、そこから`gachadata.sql`をダウンロードできるようにしました。

追加で、以下の問題が修正されています
- `prepare-docker.sh`に構文エラーがあり、`update-gachadata`オプションを実行できない問題
- wgetが権限不足で実行できない問題
- 初回起動時に`update-gachadata.sh`が実行されることで、Flywayによるマイグレーションと競合して起動できなくなる問題