### PR TITLE
ci: build_and_deployのトリガーでファイルの制限を行わないようにする

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -5,26 +5,10 @@ on:
     branches:
       - develop
       - master
-    paths:
-      - src/**
-      - build.sbt
-      - .scalafix.conf
-      - .scalafmt.conf
-      - project/*
-      - .github/workflows/**.yml
-      - .github/actions/**/**.yml
 
   pull_request:
     branches:
       - develop
-    paths:
-      - src/**/
-      - build.sbt
-      - .scalafix.conf
-      - .scalafmt.conf
-      - project/*
-      - .github/workflows/**.yml
-      - .github/actions/**/**.yml
 
 jobs:
   build_test_and_upload:


### PR DESCRIPTION
ドキュメントの更新など、コードの変更を伴わないPRの場合、CIが走らずマージするには強制mergeをする必要があるのを改善するため。