### PR TITLE
fix: 特定のブロックを破壊した場合に発生するテクスチャバグを修正

### DIFF
--- a/src/main/scala/com/github/unchama/seichiassist/util/BreakUtil.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/util/BreakUtil.scala
@@ -242,6 +242,10 @@ object BreakUtil {
               new ItemStack(blockMaterial, 1, b_tree.toShort)
             case Material.MONSTER_EGGS =>
               new ItemStack(Material.STONE)
+            case Material.WOOD_STEP | Material.STEP | Material.STONE_SLAB2 |
+                Material.PURPUR_SLAB if (blockDataLeast4Bits & 8) != 0 =>
+              // 上付きハーフブロックのmissing texture化を防ぐ
+              new ItemStack(blockMaterial, 1, (blockDataLeast4Bits & 7).toShort)
             case _ =>
               new ItemStack(blockMaterial, 1, blockDataLeast4Bits.toShort)
           }

--- a/src/main/scala/com/github/unchama/seichiassist/util/BreakUtil.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/util/BreakUtil.scala
@@ -358,7 +358,7 @@ object BreakUtil {
           Some(BlockBreakResult.SpawnSilverFish(blockLocation))
         case Material.LOG | Material.LOG_2 =>
           Some(BlockBreakResult.ItemDrop(new ItemStack(blockMaterial, 1, b_tree.toShort)))
-        case Material.WOOD_STEP | Material.STEP | Material.STONE_SLAB2
+        case Material.WOOD_STEP | Material.STEP | Material.STONE_SLAB2 | Material.PURPUR_SLAB
             if (blockDataLeast4Bits & 8) != 0 =>
           // 上付きハーフブロックをそのままドロップするとmissing textureとして描画されるため、下付きの扱いとする
           Some(

--- a/src/main/scala/com/github/unchama/seichiassist/util/BreakUtil.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/util/BreakUtil.scala
@@ -246,6 +246,9 @@ object BreakUtil {
                 Material.PURPUR_SLAB if (blockDataLeast4Bits & 8) != 0 =>
               // 上付きハーフブロックのmissing texture化を防ぐ
               new ItemStack(blockMaterial, 1, (blockDataLeast4Bits & 7).toShort)
+            case Material.QUARTZ_BLOCK if (blockData >= 2 && blockData <= 4) =>
+              // 柱状クォーツブロックのmissing texture化を防ぐ
+              new ItemStack(blockMaterial, 1, 2.toShort)
             case _ =>
               new ItemStack(blockMaterial, 1, blockDataLeast4Bits.toShort)
           }
@@ -369,6 +372,9 @@ object BreakUtil {
             BlockBreakResult
               .ItemDrop(new ItemStack(blockMaterial, 1, (blockDataLeast4Bits & 7).toShort))
           )
+        case Material.QUARTZ_BLOCK if (blockData >= 2 && blockData <= 4) =>
+          // 柱状クォーツブロックのmissing texture化を防ぐ (柱状クォーツのData valueは2, 3, 4のいずれか)
+          Some(BlockBreakResult.ItemDrop(new ItemStack(blockMaterial, 1, 2.toShort)))
         case Material.BOOKSHELF =>
           // 本棚を破壊すると、本が3つドロップする
           Some(BlockBreakResult.ItemDrop(new ItemStack(Material.BOOK, 3)))


### PR DESCRIPTION
<!--
    このPRに関連し、マージ時に自動的にクローズしたいIssueの番号を入力してください。
    複数のIssueを紐付ける場合は、それに続いて "close #1, close #2 ..." と続けて記述してください。
    (Issueに関連するPRではない場合は、このセクションを削除してください。)
    参考: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

close #2111

----

### このPRの変更点と理由:
- 柱状クォーツブロックおよび、プルプァハーフブロック破壊時のテクスチャバグを修正
- シルクタッチを用いた場合にテクスチャバグが起きる不具合を修正
<!--
    このPRであなたが行った変更、なぜそれを行ったのかを簡潔に記述してください。
    自明な場合は省略しても良いですが、なるべく書くようにしてください。
-->