### PR TITLE
fix: 直列設置スキルで設置した葉ブロックが、自然消滅する不具合を修正

### DIFF
--- a/src/main/scala/com/github/unchama/buildassist/listener/BlockLineUpTriggerListener.scala
+++ b/src/main/scala/com/github/unchama/buildassist/listener/BlockLineUpTriggerListener.scala
@@ -147,7 +147,7 @@ class BlockLineUpTriggerListener[
     val shouldPlaceDoubleSlabs = playerHoldsSlabBlock && slabLineUpStepMode == 2
 
     val upsideBit = 8
-    val noDecayBit = 8
+    val noDecayBit = 4
     val placingBlockData: Byte =
       if (playerHoldsSlabBlock && slabLineUpStepMode == 0)
         (mainHandItemData | upsideBit).toByte


### PR DESCRIPTION
<!--
    このPRに関連し、マージ時に自動的にクローズしたいIssueの番号を入力してください。
    複数のIssueを紐付ける場合は、それに続いて "close #1, close #2 ..." と続けて記述してください。
    (Issueに関連するPRではない場合は、このセクションを削除してください。)
    参考: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

close #1933

----

### このPRの変更点と理由:

<!--
    このPRであなたが行った変更、なぜそれを行ったのかを簡潔に記述してください。
    自明な場合は省略しても良いですが、なるべく書くようにしてください。
-->
- 葉ブロックの自然消滅を防ぐ`noDecayBit`は第２ビットであるため、これを修正した