### PR TITLE
マナ妖精の消費戦略設定が「ガンガン食べるぞ」以外の状態でマナが回復されない不具合の修正

### DIFF
--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/vote/subsystems/fairy/bukkit/actions/BukkitRecoveryMana.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/vote/subsystems/fairy/bukkit/actions/BukkitRecoveryMana.scala
@@ -44,11 +44,11 @@ class BukkitRecoveryMana[F[_]: ConcurrentEffect: JavaTime, G[_]: ContextCoercion
       consumeStrategy <- fairyPersistence.appleConsumeStrategy(uuid)
       isRecoverTiming = consumeStrategy match {
         case FairyAppleConsumeStrategy.Permissible                               => true
-        case FairyAppleConsumeStrategy.Consume if consumptionPeriod == 1.minutes => true
+        case FairyAppleConsumeStrategy.Consume if consumptionPeriod.toSeconds % 60 == 0 => true
         case FairyAppleConsumeStrategy.LessConsume
-            if consumptionPeriod == 1.minutes + 30.seconds =>
+            if consumptionPeriod.toSeconds % 90 == 0 =>
           true
-        case FairyAppleConsumeStrategy.NoConsume if consumptionPeriod == 2.minutes => true
+        case FairyAppleConsumeStrategy.NoConsume if consumptionPeriod.toSeconds % 120 == 0 => true
         case _                                                                     => false
       }
       nonRecoveredManaAmount <- ContextCoercion {

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/vote/subsystems/fairy/bukkit/actions/BukkitRecoveryMana.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/vote/subsystems/fairy/bukkit/actions/BukkitRecoveryMana.scala
@@ -22,7 +22,7 @@ import org.bukkit.inventory.ItemStack
 
 import java.time.ZoneId
 import java.util.UUID
-import scala.concurrent.duration.{DurationInt, FiniteDuration}
+import scala.concurrent.duration.FiniteDuration
 import scala.util.Random
 
 class BukkitRecoveryMana[F[_]: ConcurrentEffect: JavaTime, G[_]: ContextCoercion[*[_], F]](
@@ -43,13 +43,13 @@ class BukkitRecoveryMana[F[_]: ConcurrentEffect: JavaTime, G[_]: ContextCoercion
       fairyEndTimeOpt <- fairyPersistence.fairyEndTime(uuid)
       consumeStrategy <- fairyPersistence.appleConsumeStrategy(uuid)
       isRecoverTiming = consumeStrategy match {
-        case FairyAppleConsumeStrategy.Permissible                               => true
+        case FairyAppleConsumeStrategy.Permissible                                      => true
         case FairyAppleConsumeStrategy.Consume if consumptionPeriod.toSeconds % 60 == 0 => true
-        case FairyAppleConsumeStrategy.LessConsume
-            if consumptionPeriod.toSeconds % 90 == 0 =>
+        case FairyAppleConsumeStrategy.LessConsume if consumptionPeriod.toSeconds % 90 == 0 =>
           true
-        case FairyAppleConsumeStrategy.NoConsume if consumptionPeriod.toSeconds % 120 == 0 => true
-        case _                                                                     => false
+        case FairyAppleConsumeStrategy.NoConsume if consumptionPeriod.toSeconds % 120 == 0 =>
+          true
+        case _ => false
       }
       nonRecoveredManaAmount <- ContextCoercion {
         manaApi.readManaAmount(player)

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/vote/subsystems/fairy/bukkit/routines/BukkitFairyRoutine.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/vote/subsystems/fairy/bukkit/routines/BukkitFairyRoutine.scala
@@ -36,10 +36,7 @@ class BukkitFairyRoutine(fairySpeech: FairySpeech[IO, Player])(
 
     val seconds = Ref.unsafe(0.seconds)
 
-    def countUp: IO[Unit] = seconds.update { second =>
-      if (second < 360.seconds) second + 30.seconds
-      else 0.seconds
-    }
+    def countUp: IO[Unit] = seconds.update(_ + 30.seconds)
 
     RepeatingRoutine.permanentRoutine(
       repeatInterval,


### PR DESCRIPTION
close #2213

秒数のカウントに対して正しいタイミングの設定ができていなかった