### PR TITLE
chore: 連続ログイン・投票の日数許容幅を2週間に延長する

### DIFF
--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/vote/infrastructure/JdbcVotePersistence.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/vote/infrastructure/JdbcVotePersistence.scala
@@ -9,7 +9,7 @@ import java.util.UUID
 class JdbcVotePersistence[F[_]: Sync] extends VotePersistence[F] {
 
   // NOTE: 連続投票日数許容幅を変更する場合はここを変更してください。
-  private val consecutiveVoteStreakDaysThreshold = 1
+  private val consecutiveVoteStreakDaysThreshold = 14
 
   override def createPlayerData(uuid: UUID): F[Unit] = Sync[F].delay {
     DB.localTx { implicit session =>

--- a/src/main/scala/com/github/unchama/seichiassist/task/PlayerDataLoading.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/task/PlayerDataLoading.scala
@@ -233,7 +233,7 @@ object PlayerDataLoading {
           if (dateDiff >= 1L) {
             val newTotalLoginDay = playerData.loginStatus.totalLoginDay + 1
             val newConsecutiveLoginDays =
-              if (dateDiff <= 2L)
+              if (dateDiff <= 15L)
                 playerData.loginStatus.consecutiveLoginDays + 1
               else
                 1


### PR DESCRIPTION
サーバーにアクセスできない状態が継続しているので、連続ログイン、投票の許容幅を2週間に延長する