### PR TITLE
feat: Material に対する match を error にする Scalafix rule を追加

### DIFF
--- a/src/scalafix/scala/fix/MatchForMaterialToErrorForPerformance.scala
+++ b/src/scalafix/scala/fix/MatchForMaterialToErrorForPerformance.scala
@@ -1,0 +1,27 @@
+package fix
+
+import scalafix.v1._
+
+import scala.meta._
+
+/**
+ * Lints on string interpolation where its variable part contains `case class` without `toString`.
+ */
+// noinspection ScalaUnusedSymbol; referred from scalafix implicitly
+// NOTE: see AST on https://xuwei-k.github.io/scalameta-ast/ or https://astexplorer.net
+class MatchForMaterialToErrorForPerformance extends SemanticRule("MatchForMaterialToErrorForPerformance") {
+  override def fix(implicit doc: SemanticDocument): Patch = {
+    doc.tree.collect {
+      case t @ Term.Match.After_4_4_5(term, _, _) =>
+        term.symbol.info match {
+          case Some(info) if info.signature.toString == "Material" =>
+            val message =
+              s"""
+                |Don't use org.bukkit.Material in scrutinee of match expressions!
+                |See https://github.com/GiganticMinecraft/SeichiAssist/issues/2226 for more detail.""".stripMargin
+            Patch.lint(Diagnostic("error", message, t.pos))
+          case _ => Patch.empty
+        }
+    }.asPatch
+  }
+}

--- a/src/scalafix/scala/fix/MatchForMaterialToErrorForPerformance.scala
+++ b/src/scalafix/scala/fix/MatchForMaterialToErrorForPerformance.scala
@@ -15,11 +15,15 @@ class MatchForMaterialToErrorForPerformance extends SemanticRule("MatchForMateri
       case t @ Term.Match.After_4_4_5(term, _, _) =>
         term.symbol.info match {
           case Some(info) if info.signature.toString == "Material" =>
-            val message =
-              s"""
-                |Don't use org.bukkit.Material in scrutinee of match expressions!
-                |See https://github.com/GiganticMinecraft/SeichiAssist/issues/2226 for more detail.""".stripMargin
-            Patch.lint(Diagnostic("error", message, t.pos))
+            info.signature match {
+              case ValueSignature(TypeRef(_, symbol, _)) if SymbolMatcher.normalized("org/bukkit/Material").matches(symbol) =>
+                val message =
+                  s"""
+                     |Don't use org.bukkit.Material in scrutinee of match expressions!
+                     |See https://github.com/GiganticMinecraft/SeichiAssist/issues/2226 for more detail.""".stripMargin
+                Patch.lint(Diagnostic("error", message, t.pos))
+              case _ => Patch.empty
+            }
           case _ => Patch.empty
         }
     }.asPatch


### PR DESCRIPTION

close #2226

----

### `org.bukkit.Meterial` をマッチ式で検査している場合エラーにする scalafix rules を追加

#2226 にある通り、これを書くだけでコンパイル時間が増大するため、気づかないことがないように。

### 補足情報:

`scalafix --rules="file:src/scalafix/scala/fix/MatchForMaterialToErrorForPerformance.scala"` で実行できる。