### PR TITLE
インベントリを閉じる操作をメインスレッドで行うようにする

### DIFF
--- a/src/main/scala/com/github/unchama/targetedeffect/player/PlayerEffects.scala
+++ b/src/main/scala/com/github/unchama/targetedeffect/player/PlayerEffects.scala
@@ -9,10 +9,10 @@ import org.bukkit.entity.Player
 import org.bukkit.inventory.Inventory
 
 object PlayerEffects {
-//  val closeInventoryEffect: TargetedEffect[Player] = TargetedEffect.delay(_.closeInventory())
 
   def closeInventoryEffect(implicit onMainThread: OnMinecraftServerThread[IO]): TargetedEffect[Player] = {
     Kleisli { player =>
+      // インベントリを閉じる操作はサーバースレッドでなければならない(Spigot 1.18.2)
       onMainThread.runAction(SyncIO {
         player.closeInventory()
       })

--- a/src/main/scala/com/github/unchama/targetedeffect/player/PlayerEffects.scala
+++ b/src/main/scala/com/github/unchama/targetedeffect/player/PlayerEffects.scala
@@ -9,7 +9,15 @@ import org.bukkit.entity.Player
 import org.bukkit.inventory.Inventory
 
 object PlayerEffects {
-  val closeInventoryEffect: TargetedEffect[Player] = TargetedEffect.delay(_.closeInventory())
+//  val closeInventoryEffect: TargetedEffect[Player] = TargetedEffect.delay(_.closeInventory())
+
+  def closeInventoryEffect(implicit onMainThread: OnMinecraftServerThread[IO]): TargetedEffect[Player] = {
+    Kleisli { player =>
+      onMainThread.runAction(SyncIO {
+        player.closeInventory()
+      })
+    }
+  }
 
   def openInventoryEffect(
     inventory: => Inventory


### PR DESCRIPTION
Spigot 1.18.2では、インベントリを閉じる操作をメインスレッドで行わないとエラーになり実行できない。