### PR TITLE
fix:ガチャをまとめて引くボタンの説明文の色の設定の修正

### DIFF
--- a/src/main/scala/com/github/unchama/seichiassist/menus/stickmenu/SecondPage.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/menus/stickmenu/SecondPage.scala
@@ -390,9 +390,9 @@ object SecondPage extends Menu {
           consumeGachaTicketAPI.consumeGachaTicketAmount(player).map { amount =>
             val lore = List(
               s"$RESET${GREEN}ガチャを一気に$YELLOW${amount.value}回${GREEN}引きます!",
-              "左クリックで一度に引く枚数を変更します",
-              "右クリックでガチャを引きます",
-              "ガチャ券は整地報酬ガチャ券のストックから直接差し引かれます"
+              s"$RESET${GRAY}左クリックで一度に引く枚数を変更します",
+              s"$RESET${GRAY}右クリックでガチャを引きます",
+              s"$RESET${DARK_GRAY}ガチャ券は整地報酬ガチャ券のストックから直接差し引かれます"
             )
             new IconItemStackBuilder(Material.PAPER)
               .title(s"$YELLOW$UNDERLINE${BOLD}ガチャ一括まとめ引き!")


### PR DESCRIPTION
<!--
    このPRに関連し、マージ時に自動的にクローズしたいIssueの番号を入力してください。
    複数のIssueを紐付ける場合は、それに続いて "close #1, close #2 ..." と続けて記述してください。
    (Issueに関連するPRではない場合は、このセクションを削除してください。)
    参考: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

close #2180 

----

### このPRの変更点と理由:
- 「左クリックで一度に引く枚数を変更します」、「右クリックでガチャを引きます」を`GRAY`とした
- 「ガチャ券は整地報酬ガチャ券のストックから直接差し引かれます」を`DARK_GRAY`とした

<!--
    このPRであなたが行った変更、なぜそれを行ったのかを簡潔に記述してください。
    自明な場合は省略しても良いですが、なるべく書くようにしてください。
-->

### 補足情報:
イメージ画像
![image](https://github.com/GiganticMinecraft/SeichiAssist/assets/48423435/c382a24e-8ef4-4238-a4ef-c515da25134a)

<!--
    他にこのPRのことについてメンテナに伝えたいことがあれば記述してください。
    (なければ、このセクションを削除してください。)
-->
