### PR TITLE
fix:パッシブスキルの破壊スキル系の設定がOFFの時、マナ消費をしないようにする

### DIFF
--- a/src/main/scala/com/github/unchama/seichiassist/listener/PlayerBlockBreakListener.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/listener/PlayerBlockBreakListener.scala
@@ -71,7 +71,7 @@ class PlayerBlockBreakListener(
     if (!player.getWorld.isSeichiSkillAllowed) return
 
     // 破壊不可能ブロックの時処理を終了
-    if (!BreakUtil.canBreak(player, block)) {
+    if (!BreakUtil.canBreakWithSkill(player, block)) {
       event.setCancelled(true)
       return
     }


### PR DESCRIPTION
<!--
    このPRに関連し、マージ時に自動的にクローズしたいIssueの番号を入力してください。
    複数のIssueを紐付ける場合は、それに続いて "close #1, close #2 ..." と続けて記述してください。
    (Issueに関連するPRではない場合は、このセクションを削除してください。)
    参考: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

close #2230 

----

### このPRの変更点と理由:
- パッシブスキルのチェスト破壊スキル、ネザー水晶類ブロック破壊スキルがOFFのときブロックは掘れずマナ消費がされてしまっていたが、マナ消費をしないよう変更した。

<!--
    このPRであなたが行った変更、なぜそれを行ったのかを簡潔に記述してください。
    自明な場合は省略しても良いですが、なるべく書くようにしてください。
-->
