### PR TITLE
`update-gachadata`を実行したときに、イベントデータが追加されないのを修正

### DIFF
--- a/docker/mariadb/update-gachadata.sh
+++ b/docker/mariadb/update-gachadata.sh
@@ -5,7 +5,7 @@ wget -O /gachadata/gachadata.sql https://gachadata.public-gigantic-api.seichi.cl
 # 外部キー制約がかかっているgachadataテーブルをDROPしたいので、一旦外部キー制約のチェックをオフにする
 mysql -uroot -punchamaisgod -e '
   SET foreign_key_checks = 0;
-  DROP TABLE seichiassist.gachadata;
   USE seichiassist;
+  DROP TABLE IF EXISTS gachadata, gacha_events;
   SOURCE /gachadata/gachadata.sql;
   SET foreign_key_checks = 1;'


### PR DESCRIPTION
close #2258

gachadata-server側は対応済みなので、これがマージされればイベントデータも一緒に取り込めるようになります