### PR TITLE
update:「公式サイトを読む」ように促すタイトル文字列表示の改善

### DIFF
--- a/src/main/scala/com/github/unchama/seichiassist/listener/PlayerJoinListener.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/listener/PlayerJoinListener.scala
@@ -109,7 +109,7 @@ class PlayerJoinListener extends Listener {
       // https://github.com/GiganticMinecraft/SeichiAssist/issues/1939
       player.sendTitle(
         s"${YELLOW}ようこそ! ギガンティック☆整地鯖へ!",
-        s"${LIGHT_PURPLE}まず初めに公式サイト【はじめての方へ】ページを確認してください",
+        s"${LIGHT_PURPLE}まず初めに${BOLD}${UNDERLINE}公式サイト【はじめての方へ】ページ${LIGHT_PURPLE}を確認してください",
         10,
         20 * 10, // タイトルの表示時間は10秒
         10


### PR DESCRIPTION
<!--
    このPRに関連し、マージ時に自動的にクローズしたいIssueの番号を入力してください。
    複数のIssueを紐付ける場合は、それに続いて "close #1, close #2 ..." と続けて記述してください。
    (Issueに関連するPRではない場合は、このセクションを削除してください。)
    参考: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

close #2254

----

### このPRの変更点と理由:
![image](https://github.com/GiganticMinecraft/SeichiAssist/assets/48423435/e73ddcfe-2d1a-4ea0-a2e8-baa4453e9f98)
初回ログイン時にタイトル表示される"公式サイト【はじめての方へ】ページ"の文字列に対し、太字＋下線の装飾を追加する変更です。
文字色については現状の`LIGHT_PURPLE`のままとしています。
<!--
    このPRであなたが行った変更、なぜそれを行ったのかを簡潔に記述してください。
    自明な場合は省略しても良いですが、なるべく書くようにしてください。
-->

### 補足情報:

<!--
    他にこのPRのことについてメンテナに伝えたいことがあれば記述してください。
    (なければ、このセクションを削除してください。)
-->
