### PR TITLE
feat: 一括クラフトのレシピ追加

### DIFF
--- a/src/main/scala/com/github/unchama/buildassist/menu/MineStackMassCraftMenu.scala
+++ b/src/main/scala/com/github/unchama/buildassist/menu/MineStackMassCraftMenu.scala
@@ -637,12 +637,12 @@ object MineStackMassCraftMenu {
           3
         ),
         ChestSlotRef(4, 0) -> MassCraftRecipeBlock(
-          MassCraftRecipe(NonEmptyList.of(("log4", 1)), NonEmptyList.of(("acacia_planks", 4))),
+          MassCraftRecipe(NonEmptyList.of(("log_2", 1)), NonEmptyList.of(("acacia_planks", 4))),
           oneToThousand,
           3
         ),
         ChestSlotRef(0, 5) -> MassCraftRecipeBlock(
-          MassCraftRecipe(NonEmptyList.of(("dark_oak_log", 1)), NonEmptyList.of(("dark_oak_planks", 4))),
+          MassCraftRecipe(NonEmptyList.of(("log_21", 1)), NonEmptyList.of(("dark_oak_planks", 4))),
           oneToThousand,
           3
         )

--- a/src/main/scala/com/github/unchama/buildassist/menu/MineStackMassCraftMenu.scala
+++ b/src/main/scala/com/github/unchama/buildassist/menu/MineStackMassCraftMenu.scala
@@ -614,6 +614,39 @@ object MineStackMassCraftMenu {
           3
         )
       ),
+      // 原木->木材
+      List(
+        ChestSlotRef(0, 0) -> MassCraftRecipeBlock(
+          MassCraftRecipe(NonEmptyList.of(("oak_log", 1)), NonEmptyList.of(("oak_planks", 4))),
+          oneToThousand,
+          3
+        ),
+        ChestSlotRef(1, 0) -> MassCraftRecipeBlock(
+          MassCraftRecipe(NonEmptyList.of(("spruce_log", 1)), NonEmptyList.of(("spruce_planks", 4))),
+          oneToThousand,
+          3
+        ),
+        ChestSlotRef(2, 0) -> MassCraftRecipeBlock(
+          MassCraftRecipe(NonEmptyList.of(("birch_log", 1)), NonEmptyList.of(("birch_planks", 4))),
+          oneToThousand,
+          3
+        ),
+        ChestSlotRef(3, 0) -> MassCraftRecipeBlock(
+          MassCraftRecipe(NonEmptyList.of(("jungle_log", 1)), NonEmptyList.of(("jungle_planks", 4))),
+          oneToThousand,
+          3
+        ),
+        ChestSlotRef(4, 0) -> MassCraftRecipeBlock(
+          MassCraftRecipe(NonEmptyList.of(("acacia_log", 1)), NonEmptyList.of(("acacia_planks", 4))),
+          oneToThousand,
+          3
+        ),
+        ChestSlotRef(0, 5) -> MassCraftRecipeBlock(
+          MassCraftRecipe(NonEmptyList.of(("dark_oak_log", 1)), NonEmptyList.of(("dark_oak_planks", 4))),
+          oneToThousand,
+          3
+        )
+      ),
       // 木材フェンス
       List(
         ChestSlotRef(0, 0) -> MassCraftRecipeBlock(

--- a/src/main/scala/com/github/unchama/buildassist/menu/MineStackMassCraftMenu.scala
+++ b/src/main/scala/com/github/unchama/buildassist/menu/MineStackMassCraftMenu.scala
@@ -757,9 +757,25 @@ object MineStackMassCraftMenu {
           MassCraftRecipe(NonEmptyList.of(("smooth_brick0", 6)), NonEmptyList.of(("stone_brick_stairs", 4))),
           oneToThousand,
           3
+        )
+      ),
+      //砂岩系
+      List(
+        ChestSlotRef(0, 0) -> MassCraftRecipeBlock(
+          MassCraftRecipe(
+            NonEmptyList.of(("sandstone", 3)), NonEmptyList.of(("step1", 6))),
+          oneToThousand,
+          3
         ),
-        ChestSlotRef(0, 5) -> MassCraftRecipeBlock(
-          MassCraftRecipe(NonEmptyList.of(("wood_5", 6)), NonEmptyList.of(("dark_oak_stairs", 4))),
+        ChestSlotRef(1, 0) -> MassCraftRecipeBlock(
+          MassCraftRecipe(NonEmptyList.of(("sandstone", 6)), NonEmptyList.of(("standstone_stairs", 4))),
+          oneToThousand,
+          3
+        ),
+        ChestSlotRef(2, 0) -> MassCraftRecipeBlock(
+          MassCraftRecipe(
+          NonEmptyList.of(("sandstone", 1),("coal", 1)),
+          NonEmptyList.of(("sandstone1", 1))),
           oneToThousand,
           3
         )

--- a/src/main/scala/com/github/unchama/buildassist/menu/MineStackMassCraftMenu.scala
+++ b/src/main/scala/com/github/unchama/buildassist/menu/MineStackMassCraftMenu.scala
@@ -604,9 +604,17 @@ object MineStackMassCraftMenu {
           ),
           oneToThousand,
           3
+        ),
+        ChestSlotRef(4, 0) -> MassCraftRecipeBlock(
+          MassCraftRecipe(
+            NonEmptyList.of(("ice", 8), ("bucket", 1)),
+            NonEmptyList.of(("water_bucket", 1))
+          ),
+          oneToThousand,
+          3
         )
       ),
-      // フェンス
+      // 木材フェンス
       List(
         ChestSlotRef(0, 0) -> MassCraftRecipeBlock(
           MassCraftRecipe(
@@ -689,7 +697,7 @@ object MineStackMassCraftMenu {
           oneToThousand,
           3
         )
-      )
+      ),
     )
   }
 }

--- a/src/main/scala/com/github/unchama/buildassist/menu/MineStackMassCraftMenu.scala
+++ b/src/main/scala/com/github/unchama/buildassist/menu/MineStackMassCraftMenu.scala
@@ -764,6 +764,39 @@ object MineStackMassCraftMenu {
           3
         )
       ),
+      // 石材ハーフ
+      List(
+        ChestSlotRef(0, 0) -> MassCraftRecipeBlock(
+          MassCraftRecipe(NonEmptyList.of(("cobblestone", 3)), NonEmptyList.of(("step3", 6))),
+          oneToThousand,
+          3
+        ),
+        ChestSlotRef(1, 0) -> MassCraftRecipeBlock(
+          MassCraftRecipe(NonEmptyList.of(("stone", 3)), NonEmptyList.of(("step0", 6))),
+          oneToThousand,
+          3
+        ),
+        ChestSlotRef(2, 0) -> MassCraftRecipeBlock(
+          MassCraftRecipe(NonEmptyList.of(("granite", 3)), NonEmptyList.of(("granite_slab", 6))),
+          oneToThousand,
+          3
+        ),
+        ChestSlotRef(3, 0) -> MassCraftRecipeBlock(
+          MassCraftRecipe(NonEmptyList.of(("diorite", 3)), NonEmptyList.of(("diorite_slab", 6))),
+          oneToThousand,
+          3
+        ),
+        ChestSlotRef(4, 0) -> MassCraftRecipeBlock(
+          MassCraftRecipe(NonEmptyList.of(("andesite", 3)), NonEmptyList.of(("andesite_slab", 6))),
+          oneToThousand,
+          3
+        ),
+        ChestSlotRef(0, 5) -> MassCraftRecipeBlock(
+          MassCraftRecipe(NonEmptyList.of(("smooth_brick0", 3)), NonEmptyList.of(("dark_oak_stairs", 4))),
+          oneToThousand,
+          3
+        )
+      ),
       //石材階段
       List(
         ChestSlotRef(0, 0) -> MassCraftRecipeBlock(

--- a/src/main/scala/com/github/unchama/buildassist/menu/MineStackMassCraftMenu.scala
+++ b/src/main/scala/com/github/unchama/buildassist/menu/MineStackMassCraftMenu.scala
@@ -792,12 +792,12 @@ object MineStackMassCraftMenu {
           3
         ),
         ChestSlotRef(0, 5) -> MassCraftRecipeBlock(
-          MassCraftRecipe(NonEmptyList.of(("smooth_brick0", 3)), NonEmptyList.of(("dark_oak_stairs", 4))),
+          MassCraftRecipe(NonEmptyList.of(("smooth_brick0", 3)), NonEmptyList.of(("step5", 4))),
           oneToThousand,
           3
         )
       ),
-      //石材階段
+      // 石材階段
       List(
         ChestSlotRef(0, 0) -> MassCraftRecipeBlock(
           MassCraftRecipe(NonEmptyList.of(("cobblestone", 6)), NonEmptyList.of(("stone_stairs", 4))),
@@ -825,11 +825,11 @@ object MineStackMassCraftMenu {
           3
         )
       ),
-      //砂岩系
+      // 砂岩系
       List(
         ChestSlotRef(0, 0) -> MassCraftRecipeBlock(
           MassCraftRecipe(
-            NonEmptyList.of(("sandstone", 3)), NonEmptyList.of(("step1", 6))),
+          NonEmptyList.of(("sandstone", 3)), NonEmptyList.of(("step1", 6))),
           oneToThousand,
           3
         ),
@@ -843,7 +843,305 @@ object MineStackMassCraftMenu {
           oneToThousand,
           3
         )
-      )
+      ),
+      // レッドストーン系(1)
+      List(
+        ChestSlotRef(0, 0) -> MassCraftRecipeBlock(
+          MassCraftRecipe(NonEmptyList.of(("stone", 2)), NonEmptyList.of(("stone_plate", 1))),
+          oneToThousand,
+          3
+        ),
+        ChestSlotRef(1, 0) -> MassCraftRecipeBlock(
+          MassCraftRecipe(
+            NonEmptyList.of(("cobblestone", 1), ("stick", 1)), 
+            NonEmptyList.of(("lever", 1))
+          ),
+          oneToThousand,
+          3
+        ),
+        ChestSlotRef(2, 0) -> MassCraftRecipeBlock(
+          MassCraftRecipe(NonEmptyList.of(("oak_planks", 2)), NonEmptyList.of(("wood_plate", 1))),
+          oneToThousand,
+          3
+        ),
+        ChestSlotRef(3, 0) -> MassCraftRecipeBlock(
+          MassCraftRecipe(NonEmptyList.of(("oak_planks", 6)), NonEmptyList.of(("trap_door", 2))),
+          oneToThousand,
+          3
+        ),
+        ChestSlotRef(4, 0) -> MassCraftRecipeBlock(
+          MassCraftRecipe(
+            NonEmptyList.of(("oak_planks", 8), ("redstone", 1)),
+            NonEmptyList.of(("note_block", 1))
+          ),
+          oneToThousand,
+          3
+        ),
+        ChestSlotRef(0, 5) -> MassCraftRecipeBlock(
+          MassCraftRecipe(NonEmptyList.of(("stone", 1)), NonEmptyList.of(("stone_button", 1))),
+          oneToThousand,
+          3
+        ),
+        ChestSlotRef(1, 5) -> MassCraftRecipeBlock(
+          MassCraftRecipe(
+            NonEmptyList.of(("redstone", 1), ("stick", 1)), 
+            NonEmptyList.of(("redstone_torch_on", 1))
+          ),
+          oneToThousand,
+          3
+        ),
+        ChestSlotRef(2, 5) -> MassCraftRecipeBlock(
+          MassCraftRecipe(
+            NonEmptyList.of(("redstone", 4), ("glowstone", 1)), 
+            NonEmptyList.of(("redstone_lamp_off", 1))
+          ),
+          oneToThousand,
+          3
+        ),
+        ChestSlotRef(3, 5) -> MassCraftRecipeBlock(
+          MassCraftRecipe(
+            NonEmptyList.of(
+              ("iron_ingot", 1), ("stick", 1), 
+              ("oak_planks", 1)
+            ), 
+            NonEmptyList.of(("tripwire_hook", 2))
+          ),
+          oneToThousand,
+          3
+        ),
+        ChestSlotRef(4, 5) -> MassCraftRecipeBlock(
+          MassCraftRecipe(
+            NonEmptyList.of(("oak_planks", 8), ("diamond", 1)),
+            NonEmptyList.of(("jukebox", 1))
+          ),
+          oneToThousand,
+          3
+        ),
+      ),
+      // レッドストーン系(2)
+      List(
+        ChestSlotRef(0, 0) -> MassCraftRecipeBlock(
+          MassCraftRecipe(
+            NonEmptyList.of(("cobblestone", 7), ("redstone", 1)),
+            NonEmptyList.of(("dropper", 1))),
+          oneToThousand,
+          3
+        ),
+        ChestSlotRef(1, 0) -> MassCraftRecipeBlock(
+          MassCraftRecipe(
+            NonEmptyList.of(
+              ("oak_planks", 3), ("cobblestone", 4),
+              ("iron_ingot", 1), ("redstone", 1)
+              ), 
+            NonEmptyList.of(("piston_base", 1))
+          ),
+          oneToThousand,
+          3
+        ),
+        ChestSlotRef(2, 0) -> MassCraftRecipeBlock(
+          MassCraftRecipe(
+            NonEmptyList.of(("chest", 1), ("tripwire_hook", 1)), 
+            NonEmptyList.of(("trapped_chest", 1))
+            ),
+          oneToThousand,
+          3
+        ),
+        ChestSlotRef(3, 0) -> MassCraftRecipeBlock(
+          MassCraftRecipe(NonEmptyList.of(("iron_ingot", 6)), NonEmptyList.of(("iron_door", 3))),
+          oneToThousand,
+          3
+        ),
+        ChestSlotRef(4, 0) -> MassCraftRecipeBlock(
+          MassCraftRecipe(
+            NonEmptyList.of(("oak_planks", 8), ("redstone", 1)),
+            NonEmptyList.of(("note_block", 1))
+          ),
+          oneToThousand,
+          3
+        ),
+        ChestSlotRef(0, 5) -> MassCraftRecipeBlock(
+          MassCraftRecipe(NonEmptyList.of(("iron_ingot", 4)),NonEmptyList.of(("iron_trapdoor", 1))),
+          oneToThousand,
+          3
+        ),
+        ChestSlotRef(1, 5) -> MassCraftRecipeBlock(
+          MassCraftRecipe(
+            NonEmptyList.of(("chest", 1), ("iron_ingot", 5)),
+            NonEmptyList.of(("hopper", 1))
+          ),
+          oneToThousand,
+          3
+        ),
+        ChestSlotRef(2, 5) -> MassCraftRecipeBlock(
+          MassCraftRecipe(
+            NonEmptyList.of(("slime_ball", 1), ("piston_base", 1)), 
+            NonEmptyList.of(("piston_sticky_base", 1))
+          ),
+          oneToThousand,
+          3
+        ),
+        ChestSlotRef(3, 5) -> MassCraftRecipeBlock(
+          MassCraftRecipe(
+            NonEmptyList.of(("sand", 4), ("sulphur", 5)), 
+            NonEmptyList.of(("tnt", 1))
+          ),
+          oneToThousand,
+          3
+        ),
+        ChestSlotRef(4, 5) -> MassCraftRecipeBlock(
+          MassCraftRecipe(
+            NonEmptyList.of(
+              ("glass", 3), ("quartz", 3),
+              ("wood_step0", 3)
+            ),
+            NonEmptyList.of(("daylight_detector", 1))
+          ),
+          oneToThousand,
+          3
+        ),
+      ),
+      // レッドストーン系(3)
+      List(
+        ChestSlotRef(0, 0) -> MassCraftRecipeBlock(
+          MassCraftRecipe(
+            NonEmptyList.of(
+              ("gold_ingot", 6), ("stick", 1),
+              ("redstone", 1)
+            ),
+            NonEmptyList.of(("powered_rail", 6))
+          ),
+          oneToThousand,
+          3
+        ),
+        ChestSlotRef(1, 0) -> MassCraftRecipeBlock(
+          MassCraftRecipe(
+            NonEmptyList.of(
+              ("iron_ingot", 6), ("stone_plate", 4),
+              ("redstone", 1)
+              ), 
+            NonEmptyList.of(("detector_rail", 6))
+          ),
+          oneToThousand,
+          3
+        ),
+        ChestSlotRef(2, 0) -> MassCraftRecipeBlock(
+          MassCraftRecipe(
+            NonEmptyList.of(
+              ("iron_ingot", 6), ("stick", 2),
+              ("redstone_torch_on", 1)
+            ), 
+            NonEmptyList.of(("activator_rail", 6))
+            ),
+          oneToThousand,
+          3
+        ),
+        ChestSlotRef(3, 0) -> MassCraftRecipeBlock(
+          MassCraftRecipe(
+            NonEmptyList.of(
+              ("redstone_torch_on", 2),("redstone", 1),
+              ("stone", 3)
+            ), 
+            NonEmptyList.of(("diode", 1))
+            ),
+          oneToThousand,
+          3
+        ),
+        ChestSlotRef(4, 0) -> MassCraftRecipeBlock(
+          MassCraftRecipe(
+            NonEmptyList.of(
+              ("redstone_torch_on", 3),("quartz", 1),
+              ("stone", 3)
+            ), 
+            NonEmptyList.of(("redstone_comparator", 1))
+          ),
+          oneToThousand,
+          3
+        ),
+      ),
+      // 木材フェンスゲート
+      List(
+        ChestSlotRef(0, 0) -> MassCraftRecipeBlock(
+          MassCraftRecipe(
+            NonEmptyList.of(("oak_planks", 2), ("stick", 4)),
+            NonEmptyList.of(("fence_gate", 1))
+          ),
+          oneToThousand,
+          3
+        ),
+        ChestSlotRef(1, 0) -> MassCraftRecipeBlock(
+          MassCraftRecipe(
+            NonEmptyList.of(("spruce_planks", 2), ("stick", 4)),
+            NonEmptyList.of(("spruce_fence_gate", 1))
+          ),
+          oneToThousand,
+          3
+        ),
+        ChestSlotRef(2, 0) -> MassCraftRecipeBlock(
+          MassCraftRecipe(
+            NonEmptyList.of(("birch_planks", 2), ("stick", 4)),
+            NonEmptyList.of(("birch_fence_gate", 1))
+          ),
+          oneToThousand,
+          3
+        ),
+        ChestSlotRef(3, 0) -> MassCraftRecipeBlock(
+          MassCraftRecipe(
+            NonEmptyList.of(("jungle_planks", 2), ("stick", 4)),
+            NonEmptyList.of(("jungle_fence_gate", 1))
+          ),
+          oneToThousand,
+          3
+        ),
+        ChestSlotRef(4, 0) -> MassCraftRecipeBlock(
+          MassCraftRecipe(
+            NonEmptyList.of(("acacia_planks", 2), ("stick", 4)),
+            NonEmptyList.of(("acacia_fence_gate", 1))
+          ),
+          oneToThousand,
+          3
+        ),
+        ChestSlotRef(0, 5) -> MassCraftRecipeBlock(
+          MassCraftRecipe(
+            NonEmptyList.of(("dark_oak_planks", 2), ("stick", 4)),
+            NonEmptyList.of(("dark_oak_fence_gate", 1))
+          ),
+          oneToThousand,
+          3
+        ),
+      ),
+      // 木材ドア
+      List(
+        ChestSlotRef(0, 0) -> MassCraftRecipeBlock(
+          MassCraftRecipe(NonEmptyList.of(("oak_planks", 6)), NonEmptyList.of(("wood_door", 3))),
+          oneToThousand,
+          3
+        ),
+        ChestSlotRef(1, 0) -> MassCraftRecipeBlock(
+          MassCraftRecipe(NonEmptyList.of(("spruce_planks", 6)), NonEmptyList.of(("spruce_door_item", 3))),
+          oneToThousand,
+          3
+        ),
+        ChestSlotRef(2, 0) -> MassCraftRecipeBlock(
+          MassCraftRecipe(NonEmptyList.of(("birch_planks", 6)), NonEmptyList.of(("birch_door_item", 3))),
+          oneToThousand,
+          3
+        ),
+        ChestSlotRef(3, 0) -> MassCraftRecipeBlock(
+          MassCraftRecipe(NonEmptyList.of(("jungle_planks", 6)), NonEmptyList.of(("jungle_door_item", 3))),
+          oneToThousand,
+          3
+        ),
+        ChestSlotRef(4, 0) -> MassCraftRecipeBlock(
+          MassCraftRecipe(NonEmptyList.of(("acacia_planks", 6)), NonEmptyList.of(("acacia_door_item", 3))),
+          oneToThousand,
+          3
+        ),
+        ChestSlotRef(0, 5) -> MassCraftRecipeBlock(
+          MassCraftRecipe(NonEmptyList.of(("dark_oak_planks", 6)),NonEmptyList.of(("dark_oak_door_item", 3))),
+          oneToThousand,
+          3
+        ),
+      ),
     )
   }
 }

--- a/src/main/scala/com/github/unchama/buildassist/menu/MineStackMassCraftMenu.scala
+++ b/src/main/scala/com/github/unchama/buildassist/menu/MineStackMassCraftMenu.scala
@@ -651,7 +651,7 @@ object MineStackMassCraftMenu {
       List(
         ChestSlotRef(0, 0) -> MassCraftRecipeBlock(
           MassCraftRecipe(
-            NonEmptyList.of(("wood", 4), ("stick", 2)),
+            NonEmptyList.of(("oak_planks", 4), ("stick", 2)),
             NonEmptyList.of(("fence", 3))
           ),
           oneToThousand,
@@ -659,7 +659,7 @@ object MineStackMassCraftMenu {
         ),
         ChestSlotRef(1, 0) -> MassCraftRecipeBlock(
           MassCraftRecipe(
-            NonEmptyList.of(("wood_1", 4), ("stick", 2)),
+            NonEmptyList.of(("spruce_planks", 4), ("stick", 2)),
             NonEmptyList.of(("spruce_fence", 3))
           ),
           oneToThousand,
@@ -667,7 +667,7 @@ object MineStackMassCraftMenu {
         ),
         ChestSlotRef(2, 0) -> MassCraftRecipeBlock(
           MassCraftRecipe(
-            NonEmptyList.of(("wood_2", 4), ("stick", 2)),
+            NonEmptyList.of(("birch_planks", 4), ("stick", 2)),
             NonEmptyList.of(("birch_fence", 3))
           ),
           oneToThousand,
@@ -675,7 +675,7 @@ object MineStackMassCraftMenu {
         ),
         ChestSlotRef(3, 0) -> MassCraftRecipeBlock(
           MassCraftRecipe(
-            NonEmptyList.of(("wood_3", 4), ("stick", 2)),
+            NonEmptyList.of(("jungle_planks", 4), ("stick", 2)),
             NonEmptyList.of(("jungle_fence", 3))
           ),
           oneToThousand,
@@ -683,7 +683,7 @@ object MineStackMassCraftMenu {
         ),
         ChestSlotRef(4, 0) -> MassCraftRecipeBlock(
           MassCraftRecipe(
-            NonEmptyList.of(("wood_4", 4), ("stick", 2)),
+            NonEmptyList.of(("acacia_planks", 4), ("stick", 2)),
             NonEmptyList.of(("acacia_fence", 3))
           ),
           oneToThousand,
@@ -691,7 +691,7 @@ object MineStackMassCraftMenu {
         ),
         ChestSlotRef(0, 5) -> MassCraftRecipeBlock(
           MassCraftRecipe(
-            NonEmptyList.of(("wood_5", 4), ("stick", 2)),
+            NonEmptyList.of(("dark_oak_planks", 4), ("stick", 2)),
             NonEmptyList.of(("dark_oak_fence", 3))
           ),
           oneToThousand,
@@ -701,32 +701,32 @@ object MineStackMassCraftMenu {
       // 木材ハーフ
       List(
         ChestSlotRef(0, 0) -> MassCraftRecipeBlock(
-          MassCraftRecipe(NonEmptyList.of(("wood", 3)), NonEmptyList.of(("wood_step0", 6))),
+          MassCraftRecipe(NonEmptyList.of(("oak_planks", 3)), NonEmptyList.of(("wood_step0", 6))),
           oneToThousand,
           3
         ),
         ChestSlotRef(1, 0) -> MassCraftRecipeBlock(
-          MassCraftRecipe(NonEmptyList.of(("wood_1", 3)), NonEmptyList.of(("wood_step1", 6))),
+          MassCraftRecipe(NonEmptyList.of(("spruce_planks", 3)), NonEmptyList.of(("wood_step1", 6))),
           oneToThousand,
           3
         ),
         ChestSlotRef(2, 0) -> MassCraftRecipeBlock(
-          MassCraftRecipe(NonEmptyList.of(("wood_2", 3)), NonEmptyList.of(("wood_step2", 6))),
+          MassCraftRecipe(NonEmptyList.of(("birch_planks", 3)), NonEmptyList.of(("wood_step2", 6))),
           oneToThousand,
           3
         ),
         ChestSlotRef(3, 0) -> MassCraftRecipeBlock(
-          MassCraftRecipe(NonEmptyList.of(("wood_3", 3)), NonEmptyList.of(("wood_step3", 6))),
+          MassCraftRecipe(NonEmptyList.of(("jungle_planks", 3)), NonEmptyList.of(("wood_step3", 6))),
           oneToThousand,
           3
         ),
         ChestSlotRef(4, 0) -> MassCraftRecipeBlock(
-          MassCraftRecipe(NonEmptyList.of(("wood_4", 3)), NonEmptyList.of(("wood_step4", 6))),
+          MassCraftRecipe(NonEmptyList.of(("acacia_planks", 3)), NonEmptyList.of(("wood_step4", 6))),
           oneToThousand,
           3
         ),
         ChestSlotRef(0, 5) -> MassCraftRecipeBlock(
-          MassCraftRecipe(NonEmptyList.of(("wood_5", 3)), NonEmptyList.of(("wood_step5", 6))),
+          MassCraftRecipe(NonEmptyList.of(("dark_oak_planks", 3)), NonEmptyList.of(("wood_step5", 6))),
           oneToThousand,
           3
         )
@@ -734,32 +734,32 @@ object MineStackMassCraftMenu {
       //木材階段
       List(
         ChestSlotRef(0, 0) -> MassCraftRecipeBlock(
-          MassCraftRecipe(NonEmptyList.of(("wood", 6)), NonEmptyList.of(("oak_stairs", 4))),
+          MassCraftRecipe(NonEmptyList.of(("oak_planks", 6)), NonEmptyList.of(("oak_stairs", 4))),
           oneToThousand,
           3
         ),
         ChestSlotRef(1, 0) -> MassCraftRecipeBlock(
-          MassCraftRecipe(NonEmptyList.of(("wood_1", 6)), NonEmptyList.of(("spruce_stairs", 4))),
+          MassCraftRecipe(NonEmptyList.of(("spruce_planks", 6)), NonEmptyList.of(("spruce_stairs", 4))),
           oneToThousand,
           3
         ),
         ChestSlotRef(2, 0) -> MassCraftRecipeBlock(
-          MassCraftRecipe(NonEmptyList.of(("wood_2", 6)), NonEmptyList.of(("birch_stairs", 4))),
+          MassCraftRecipe(NonEmptyList.of(("birch_planks", 6)), NonEmptyList.of(("birch_stairs", 4))),
           oneToThousand,
           3
         ),
         ChestSlotRef(3, 0) -> MassCraftRecipeBlock(
-          MassCraftRecipe(NonEmptyList.of(("wood_3", 6)), NonEmptyList.of(("jungle_stairs", 4))),
+          MassCraftRecipe(NonEmptyList.of(("jungle_planks", 6)), NonEmptyList.of(("jungle_stairs", 4))),
           oneToThousand,
           3
         ),
         ChestSlotRef(4, 0) -> MassCraftRecipeBlock(
-          MassCraftRecipe(NonEmptyList.of(("wood_4", 6)), NonEmptyList.of(("acacia_stairs", 4))),
+          MassCraftRecipe(NonEmptyList.of(("acacia_planks", 6)), NonEmptyList.of(("acacia_stairs", 4))),
           oneToThousand,
           3
         ),
         ChestSlotRef(0, 5) -> MassCraftRecipeBlock(
-          MassCraftRecipe(NonEmptyList.of(("wood_5", 6)), NonEmptyList.of(("dark_oak_stairs", 4))),
+          MassCraftRecipe(NonEmptyList.of(("dark_oak_planks", 6)), NonEmptyList.of(("dark_oak_stairs", 4))),
           oneToThousand,
           3
         )

--- a/src/main/scala/com/github/unchama/buildassist/menu/MineStackMassCraftMenu.scala
+++ b/src/main/scala/com/github/unchama/buildassist/menu/MineStackMassCraftMenu.scala
@@ -617,32 +617,32 @@ object MineStackMassCraftMenu {
       // 原木->木材
       List(
         ChestSlotRef(0, 0) -> MassCraftRecipeBlock(
-          MassCraftRecipe(NonEmptyList.of(("log", 1)), NonEmptyList.of(("oak_planks", 4))),
+          MassCraftRecipe(NonEmptyList.of(("log", 4)), NonEmptyList.of(("oak_planks", 16))),
           oneToThousand,
           3
         ),
         ChestSlotRef(1, 0) -> MassCraftRecipeBlock(
-          MassCraftRecipe(NonEmptyList.of(("log1", 1)), NonEmptyList.of(("spruce_planks", 4))),
+          MassCraftRecipe(NonEmptyList.of(("log1", 4)), NonEmptyList.of(("spruce_planks", 16))),
           oneToThousand,
           3
         ),
         ChestSlotRef(2, 0) -> MassCraftRecipeBlock(
-          MassCraftRecipe(NonEmptyList.of(("log2", 1)), NonEmptyList.of(("birch_planks", 4))),
+          MassCraftRecipe(NonEmptyList.of(("log2", 4)), NonEmptyList.of(("birch_planks", 16))),
           oneToThousand,
           3
         ),
         ChestSlotRef(3, 0) -> MassCraftRecipeBlock(
-          MassCraftRecipe(NonEmptyList.of(("log3", 1)), NonEmptyList.of(("jungle_planks", 4))),
+          MassCraftRecipe(NonEmptyList.of(("log3", 4)), NonEmptyList.of(("jungle_planks", 16))),
           oneToThousand,
           3
         ),
         ChestSlotRef(4, 0) -> MassCraftRecipeBlock(
-          MassCraftRecipe(NonEmptyList.of(("log_2", 1)), NonEmptyList.of(("acacia_planks", 4))),
+          MassCraftRecipe(NonEmptyList.of(("log_2", 4)), NonEmptyList.of(("acacia_planks", 16))),
           oneToThousand,
           3
         ),
         ChestSlotRef(0, 5) -> MassCraftRecipeBlock(
-          MassCraftRecipe(NonEmptyList.of(("log_21", 1)), NonEmptyList.of(("dark_oak_planks", 4))),
+          MassCraftRecipe(NonEmptyList.of(("log_21", 4)), NonEmptyList.of(("dark_oak_planks", 16))),
           oneToThousand,
           3
         )
@@ -806,10 +806,7 @@ object MineStackMassCraftMenu {
           3
         ),
         ChestSlotRef(2, 0) -> MassCraftRecipeBlock(
-          MassCraftRecipe(
-            NonEmptyList.of(("sandstone", 1),("coal", 1)),
-            NonEmptyList.of(("sandstone1", 1))
-          ),
+          MassCraftRecipe(NonEmptyList.of(("sandstone", 4)), NonEmptyList.of(("sandstone1", 4))),
           oneToThousand,
           3
         )

--- a/src/main/scala/com/github/unchama/buildassist/menu/MineStackMassCraftMenu.scala
+++ b/src/main/scala/com/github/unchama/buildassist/menu/MineStackMassCraftMenu.scala
@@ -619,32 +619,32 @@ object MineStackMassCraftMenu {
         ChestSlotRef(0, 0) -> MassCraftRecipeBlock(
           MassCraftRecipe(NonEmptyList.of(("log", 4)), NonEmptyList.of(("oak_planks", 16))),
           oneToThousand,
-          3
+          1
         ),
         ChestSlotRef(1, 0) -> MassCraftRecipeBlock(
           MassCraftRecipe(NonEmptyList.of(("log1", 4)), NonEmptyList.of(("spruce_planks", 16))),
           oneToThousand,
-          3
+          1
         ),
         ChestSlotRef(2, 0) -> MassCraftRecipeBlock(
           MassCraftRecipe(NonEmptyList.of(("log2", 4)), NonEmptyList.of(("birch_planks", 16))),
           oneToThousand,
-          3
+          1
         ),
         ChestSlotRef(3, 0) -> MassCraftRecipeBlock(
           MassCraftRecipe(NonEmptyList.of(("log3", 4)), NonEmptyList.of(("jungle_planks", 16))),
           oneToThousand,
-          3
+          1
         ),
         ChestSlotRef(4, 0) -> MassCraftRecipeBlock(
           MassCraftRecipe(NonEmptyList.of(("log_2", 4)), NonEmptyList.of(("acacia_planks", 16))),
           oneToThousand,
-          3
+          1
         ),
         ChestSlotRef(0, 5) -> MassCraftRecipeBlock(
           MassCraftRecipe(NonEmptyList.of(("log_21", 4)), NonEmptyList.of(("dark_oak_planks", 16))),
           oneToThousand,
-          3
+          1
         )
       ),
       // 木材フェンス

--- a/src/main/scala/com/github/unchama/buildassist/menu/MineStackMassCraftMenu.scala
+++ b/src/main/scala/com/github/unchama/buildassist/menu/MineStackMassCraftMenu.scala
@@ -952,19 +952,11 @@ object MineStackMassCraftMenu {
           3
         ),
         ChestSlotRef(4, 0) -> MassCraftRecipeBlock(
-          MassCraftRecipe(
-            NonEmptyList.of(("oak_planks", 8), ("redstone", 1)),
-            NonEmptyList.of(("note_block", 1))
-          ),
-          oneToThousand,
-          3
-        ),
-        ChestSlotRef(0, 5) -> MassCraftRecipeBlock(
           MassCraftRecipe(NonEmptyList.of(("iron_ingot", 4)),NonEmptyList.of(("iron_trapdoor", 1))),
           oneToThousand,
           3
         ),
-        ChestSlotRef(1, 5) -> MassCraftRecipeBlock(
+        ChestSlotRef(0, 5) -> MassCraftRecipeBlock(
           MassCraftRecipe(
             NonEmptyList.of(("chest", 1), ("iron_ingot", 5)),
             NonEmptyList.of(("hopper", 1))
@@ -972,7 +964,7 @@ object MineStackMassCraftMenu {
           oneToThousand,
           3
         ),
-        ChestSlotRef(2, 5) -> MassCraftRecipeBlock(
+        ChestSlotRef(1, 5) -> MassCraftRecipeBlock(
           MassCraftRecipe(
             NonEmptyList.of(("slime_ball", 1), ("piston_base", 1)), 
             NonEmptyList.of(("piston_sticky_base", 1))
@@ -980,7 +972,7 @@ object MineStackMassCraftMenu {
           oneToThousand,
           3
         ),
-        ChestSlotRef(3, 5) -> MassCraftRecipeBlock(
+        ChestSlotRef(2, 5) -> MassCraftRecipeBlock(
           MassCraftRecipe(
             NonEmptyList.of(("sand", 4), ("sulphur", 5)), 
             NonEmptyList.of(("tnt", 1))
@@ -988,7 +980,7 @@ object MineStackMassCraftMenu {
           oneToThousand,
           3
         ),
-        ChestSlotRef(4, 5) -> MassCraftRecipeBlock(
+        ChestSlotRef(3, 5) -> MassCraftRecipeBlock(
           MassCraftRecipe(
             NonEmptyList.of(
               ("glass", 3), ("quartz", 3),

--- a/src/main/scala/com/github/unchama/buildassist/menu/MineStackMassCraftMenu.scala
+++ b/src/main/scala/com/github/unchama/buildassist/menu/MineStackMassCraftMenu.scala
@@ -767,12 +767,12 @@ object MineStackMassCraftMenu {
       //石材階段
       List(
         ChestSlotRef(0, 0) -> MassCraftRecipeBlock(
-          MassCraftRecipe(NonEmptyList.of(("stone", 6)), NonEmptyList.of(("stone_stairs", 4))),
+          MassCraftRecipe(NonEmptyList.of(("cobblestone", 6)), NonEmptyList.of(("stone_stairs", 4))),
           oneToThousand,
           3
         ),
         ChestSlotRef(1, 0) -> MassCraftRecipeBlock(
-          MassCraftRecipe(NonEmptyList.of(("granit", 6)), NonEmptyList.of(("granit_stairs", 4))),
+          MassCraftRecipe(NonEmptyList.of(("granite", 6)), NonEmptyList.of(("granite_stairs", 4))),
           oneToThousand,
           3
         ),
@@ -807,8 +807,9 @@ object MineStackMassCraftMenu {
         ),
         ChestSlotRef(2, 0) -> MassCraftRecipeBlock(
           MassCraftRecipe(
-          NonEmptyList.of(("sandstone", 1),("coal", 1)),
-          NonEmptyList.of(("sandstone1", 1))),
+            NonEmptyList.of(("sandstone", 1),("coal", 1)),
+            NonEmptyList.of(("sandstone1", 1))
+          ),
           oneToThousand,
           3
         )

--- a/src/main/scala/com/github/unchama/buildassist/menu/MineStackMassCraftMenu.scala
+++ b/src/main/scala/com/github/unchama/buildassist/menu/MineStackMassCraftMenu.scala
@@ -698,6 +698,72 @@ object MineStackMassCraftMenu {
           3
         )
       ),
+      //木材階段
+      List(
+        ChestSlotRef(0, 0) -> MassCraftRecipeBlock(
+          MassCraftRecipe(NonEmptyList.of(("wood", 6)), NonEmptyList.of(("oak_stairs", 4))),
+          oneToThousand,
+          3
+        ),
+        ChestSlotRef(1, 0) -> MassCraftRecipeBlock(
+          MassCraftRecipe(NonEmptyList.of(("wood_1", 6)), NonEmptyList.of(("spruce_stairs", 4))),
+          oneToThousand,
+          3
+        ),
+        ChestSlotRef(2, 0) -> MassCraftRecipeBlock(
+          MassCraftRecipe(NonEmptyList.of(("wood_2", 6)), NonEmptyList.of(("birch_stairs", 4))),
+          oneToThousand,
+          3
+        ),
+        ChestSlotRef(3, 0) -> MassCraftRecipeBlock(
+          MassCraftRecipe(NonEmptyList.of(("wood_3", 6)), NonEmptyList.of(("jungle_stairs", 4))),
+          oneToThousand,
+          3
+        ),
+        ChestSlotRef(4, 0) -> MassCraftRecipeBlock(
+          MassCraftRecipe(NonEmptyList.of(("wood_4", 6)), NonEmptyList.of(("acacia_stairs", 4))),
+          oneToThousand,
+          3
+        ),
+        ChestSlotRef(0, 5) -> MassCraftRecipeBlock(
+          MassCraftRecipe(NonEmptyList.of(("wood_5", 6)), NonEmptyList.of(("dark_oak_stairs", 4))),
+          oneToThousand,
+          3
+        )
+      ),
+      //石材階段
+      List(
+        ChestSlotRef(0, 0) -> MassCraftRecipeBlock(
+          MassCraftRecipe(NonEmptyList.of(("stone", 6)), NonEmptyList.of(("stone_stairs", 4))),
+          oneToThousand,
+          3
+        ),
+        ChestSlotRef(1, 0) -> MassCraftRecipeBlock(
+          MassCraftRecipe(NonEmptyList.of(("granit", 6)), NonEmptyList.of(("granit_stairs", 4))),
+          oneToThousand,
+          3
+        ),
+        ChestSlotRef(2, 0) -> MassCraftRecipeBlock(
+          MassCraftRecipe(NonEmptyList.of(("diorite", 6)), NonEmptyList.of(("diorite_stairs", 4))),
+          oneToThousand,
+          3
+        ),
+        ChestSlotRef(3, 0) -> MassCraftRecipeBlock(
+          MassCraftRecipe(NonEmptyList.of(("andesite", 6)), NonEmptyList.of(("andesite_stairs", 4))),
+          oneToThousand,
+          3
+        ),
+        ChestSlotRef(4, 0) -> MassCraftRecipeBlock(
+          MassCraftRecipe(NonEmptyList.of(("smooth_brick0", 6)), NonEmptyList.of(("stone_brick_stairs", 4))),
+          oneToThousand,
+          3
+        ),
+        ChestSlotRef(0, 5) -> MassCraftRecipeBlock(
+          MassCraftRecipe(NonEmptyList.of(("wood_5", 6)), NonEmptyList.of(("dark_oak_stairs", 4))),
+          oneToThousand,
+          3
+        )
+      )
     )
   }
 }

--- a/src/main/scala/com/github/unchama/buildassist/menu/MineStackMassCraftMenu.scala
+++ b/src/main/scala/com/github/unchama/buildassist/menu/MineStackMassCraftMenu.scala
@@ -617,27 +617,27 @@ object MineStackMassCraftMenu {
       // 原木->木材
       List(
         ChestSlotRef(0, 0) -> MassCraftRecipeBlock(
-          MassCraftRecipe(NonEmptyList.of(("oak_log", 1)), NonEmptyList.of(("oak_planks", 4))),
+          MassCraftRecipe(NonEmptyList.of(("log", 1)), NonEmptyList.of(("oak_planks", 4))),
           oneToThousand,
           3
         ),
         ChestSlotRef(1, 0) -> MassCraftRecipeBlock(
-          MassCraftRecipe(NonEmptyList.of(("spruce_log", 1)), NonEmptyList.of(("spruce_planks", 4))),
+          MassCraftRecipe(NonEmptyList.of(("log1", 1)), NonEmptyList.of(("spruce_planks", 4))),
           oneToThousand,
           3
         ),
         ChestSlotRef(2, 0) -> MassCraftRecipeBlock(
-          MassCraftRecipe(NonEmptyList.of(("birch_log", 1)), NonEmptyList.of(("birch_planks", 4))),
+          MassCraftRecipe(NonEmptyList.of(("log2", 1)), NonEmptyList.of(("birch_planks", 4))),
           oneToThousand,
           3
         ),
         ChestSlotRef(3, 0) -> MassCraftRecipeBlock(
-          MassCraftRecipe(NonEmptyList.of(("jungle_log", 1)), NonEmptyList.of(("jungle_planks", 4))),
+          MassCraftRecipe(NonEmptyList.of(("log3", 1)), NonEmptyList.of(("jungle_planks", 4))),
           oneToThousand,
           3
         ),
         ChestSlotRef(4, 0) -> MassCraftRecipeBlock(
-          MassCraftRecipe(NonEmptyList.of(("acacia_log", 1)), NonEmptyList.of(("acacia_planks", 4))),
+          MassCraftRecipe(NonEmptyList.of(("log4", 1)), NonEmptyList.of(("acacia_planks", 4))),
           oneToThousand,
           3
         ),
@@ -787,7 +787,7 @@ object MineStackMassCraftMenu {
           3
         ),
         ChestSlotRef(4, 0) -> MassCraftRecipeBlock(
-          MassCraftRecipe(NonEmptyList.of(("smooth_brick0", 6)), NonEmptyList.of(("stone_brick_stairs", 4))),
+          MassCraftRecipe(NonEmptyList.of(("smooth_brick0", 6)), NonEmptyList.of(("smooth_stairs", 4))),
           oneToThousand,
           3
         )


### PR DESCRIPTION
<!--
    このPRに関連し、マージ時に自動的にクローズしたいIssueの番号を入力してください。
    複数のIssueを紐付ける場合は、それに続いて "close #1, close #2 ..." と続けて記述してください。
    (Issueに関連するPRではない場合は、このセクションを削除してください。)
    参考: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

close #2322 , close #1002

----

### このPRの変更点と理由:
一括クラフトに以下のレシピを追加
- 水入りバケツ
- 原木->板材、木材系階段・ハーフ、フェンスゲート、ドア
→オーク、トウヒ、シラカバ、ジャングル、アカシア、ダークオーク
- 石材系階段
→丸石、花崗岩、安山岩、閃緑岩、石レンガ
- 石材系ハーフ
→丸石、石、花崗岩、安山岩、閃緑岩、石レンガ
- 砂岩->砂岩階段、ハーフ、模様入り砂岩
- レッドストーン系
→レバー、石の感圧板、木の感圧板、トラップドア、音符ブロック、
石のボタン、レッドストーントーチ、レッドストーンランプ、トリップワイヤーフック、ジュークボックス、ドロッパー、ピストン、トラップチェスト、鉄のドア、鉄のトラップドア、ホッパー、粘着ピストン、TNT、日照センサ、パワードレール、ディテクターレール、アクティベーターレール、レッドストーンリピーター、レッドストーンコンパレータ


<!--
    このPRであなたが行った変更、なぜそれを行ったのかを簡潔に記述してください。
    自明な場合は省略しても良いですが、なるべく書くようにしてください。
-->

### 補足情報:
- 石の階段と丸石の階段のクラフトにおいて、MineStackアイテムIDが"stone_stairs"で重複している状態のため、石の階段は実装できていません。
→順番としては先勝ちになっており、丸石の階段に指定が吸われる状態

#### BukkitMineStackObjectList

丸石の階段
https://github.com/GiganticMinecraft/SeichiAssist/blob/d895377f66f5bfd02553a6c58b02babeebdef455/src/main/scala/com/github/unchama/seichiassist/subsystems/minestack/bukkit/BukkitMineStackObjectList.scala#L581

石の階段
https://github.com/GiganticMinecraft/SeichiAssist/blob/d895377f66f5bfd02553a6c58b02babeebdef455/src/main/scala/com/github/unchama/seichiassist/subsystems/minestack/bukkit/BukkitMineStackObjectList.scala#L607
<!--
    他にこのPRのことについてメンテナに伝えたいことがあれば記述してください。
    (なければ、このセクションを削除してください。)
-->
