### PR TITLE
feat: GBの表示内容にモブ討伐総数欄を追加

### DIFF
--- a/src/main/scala/com/github/unchama/seichiassist/data/player/GiganticBerserk.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/data/player/GiganticBerserk.scala
@@ -44,4 +44,16 @@ case class GiganticBerserk(
     val current = stage * 10 + level
     LevelThresholds.giganticBerserkLevelList(current)
   }
+
+  /**
+   * 現在の `level` と `stage` において、倒した敵の総数(= `toatlExp`)を返します。
+   * 
+   * @return
+   *   倒した敵の総数(= `totalExp`)
+   */
+  def totalExpToCurrentLevel(exp: Int ): Int = {
+    val total = (stage * 10 + level) - 1
+    LevelThresholds.giganticBerserkLevelList.take(total).sum + exp
+  }
+  
 }

--- a/src/main/scala/com/github/unchama/seichiassist/data/player/GiganticBerserk.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/data/player/GiganticBerserk.scala
@@ -46,14 +46,13 @@ case class GiganticBerserk(
   }
 
   /**
-   * 現在の `level` と `stage` において、倒した敵の総数(= `toatlExp`)を返します。
-   * 
-   * @return
-   *   倒した敵の総数(= `totalExp`)
+   * @return 今までに倒した敵の総数
    */
-  def totalExpToCurrentLevel(exp: Int ): Int = {
-    val total = (stage * 10 + level) - 1
-    LevelThresholds.giganticBerserkLevelList.take(total).sum + exp
+  def totalNumberOfKilledEnemies: Int = {
+    val currentStage = stage * 10
+    val previousLevel = level - 1
+    val previousStageLevel = currentStage + previousLevel
+    LevelThresholds.giganticBerserkLevelList.take(previousStageLevel).sum + exp
   }
-  
+
 }

--- a/src/main/scala/com/github/unchama/seichiassist/menus/skill/PassiveSkillMenu.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/menus/skill/PassiveSkillMenu.scala
@@ -262,7 +262,9 @@ object PassiveSkillMenu extends Menu {
             } else {
               List(
                 s"${GRAY}MOBの魂を${openerData.giganticBerserk.requiredExpToNextLevel()}回吸収すると更なる力が得られる",
-                s"$GRAY${openerData.giganticBerserk.exp}/${openerData.giganticBerserk.requiredExpToNextLevel()}"
+                s"$GRAY${openerData.giganticBerserk.exp}/${openerData.giganticBerserk.requiredExpToNextLevel()}",
+                s"$GRAY${openerData.giganticBerserk.exp}/${openerData.giganticBerserk.requiredExpToNextLevel()}",
+                s"${GRAY}MOB討伐総数:${openerData.giganticBerserk.totalExpToCurrentLevel(openerData.giganticBerserk.exp)}"
               )
             }
             val probability = 100 * openerData.giganticBerserk.manaRegenerationProbability()

--- a/src/main/scala/com/github/unchama/seichiassist/menus/skill/PassiveSkillMenu.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/menus/skill/PassiveSkillMenu.scala
@@ -263,7 +263,6 @@ object PassiveSkillMenu extends Menu {
               List(
                 s"${GRAY}MOBの魂を${openerData.giganticBerserk.requiredExpToNextLevel()}回吸収すると更なる力が得られる",
                 s"$GRAY${openerData.giganticBerserk.exp}/${openerData.giganticBerserk.requiredExpToNextLevel()}",
-                s"$GRAY${openerData.giganticBerserk.exp}/${openerData.giganticBerserk.requiredExpToNextLevel()}",
                 s"${GRAY}MOB討伐総数:${openerData.giganticBerserk.totalExpToCurrentLevel(openerData.giganticBerserk.exp)}"
               )
             }

--- a/src/main/scala/com/github/unchama/seichiassist/menus/skill/PassiveSkillMenu.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/menus/skill/PassiveSkillMenu.scala
@@ -263,7 +263,7 @@ object PassiveSkillMenu extends Menu {
               List(
                 s"${GRAY}MOBの魂を${openerData.giganticBerserk.requiredExpToNextLevel()}回吸収すると更なる力が得られる",
                 s"$GRAY${openerData.giganticBerserk.exp}/${openerData.giganticBerserk.requiredExpToNextLevel()}",
-                s"${GRAY}MOB討伐総数:${openerData.giganticBerserk.totalExpToCurrentLevel(openerData.giganticBerserk.exp)}"
+                s"${GRAY}MOB討伐総数:${openerData.giganticBerserk.totalNumberOfKilledEnemies}"
               )
             }
             val probability = 100 * openerData.giganticBerserk.manaRegenerationProbability()


### PR DESCRIPTION
<!--
    このPRに関連し、マージ時に自動的にクローズしたいIssueの番号を入力してください。
    複数のIssueを紐付ける場合は、それに続いて "close #1, close #2 ..." と続けて記述してください。
    (Issueに関連するPRではない場合は、このセクションを削除してください。)
    参考: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

close #2326

----

### このPRの変更点と理由:
- GBのLoreにモブ討伐総数を表示する機能を追加

<!--
    このPRであなたが行った変更、なぜそれを行ったのかを簡潔に記述してください。
    自明な場合は省略しても良いですが、なるべく書くようにしてください。
-->

### 補足情報:
- 表示イメージ：
![image](https://github.com/user-attachments/assets/3592fa05-c2f4-46b4-9c83-aeac34f5d65a)


<!--
    他にこのPRのことについてメンテナに伝えたいことがあれば記述してください。
    (なければ、このセクションを削除してください。)
-->
