### PR TITLE
feat: 実績を解除した際に実績の小区分を表示する機能

### DIFF
--- a/src/main/scala/com/github/unchama/seichiassist/achievement/hierarchy/AchievementGroup.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/achievement/hierarchy/AchievementGroup.scala
@@ -28,4 +28,24 @@ object AchievementGroup {
   case object VoteCounts extends AchievementGroup("JMS投票数", Specials)
 
   case object Secrets extends AchievementGroup("極秘任務", Specials)
+
+  val entryIdToGroup: Map[Int, AchievementGroup] = 
+    (1001 to 1012).map(id => id -> BrokenBlockRanking).toMap ++
+    (2001 to 2014).map(id => id -> PlacedBlockAmount).toMap ++
+    (3001 to 3019).map(id => id -> BrokenBlockAmount).toMap ++
+    (4001 to 4023).map(id => id -> PlayTime).toMap ++
+    (5101 to 5125).map(id => id -> TotalLogins).toMap ++
+    (5001 to 5008).map(id => id -> ConsecutiveLogins).toMap ++
+    (6001 to 6008).map(id => id -> VoteCounts).toMap ++
+    (7001 to 7027).map(id => id -> OfficialEvent).toMap ++
+    (7901 to 7906).map(id => id -> OfficialEvent).toMap ++
+    (8001 to 8003).map(id => id -> Secrets).toMap ++
+    (9001 to 9047).map(id => id -> Anniversaries).toMap
+
+  def getGroupNameByEntryId(entryId: Int): Option[String] = {
+    entryIdToGroup.get(entryId) match {
+      case Some(group) => Some(group.name)
+      case None => None
+    }
+  }
 }

--- a/src/main/scala/com/github/unchama/seichiassist/menus/achievement/group/AchievementGroupMenuButtons.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/menus/achievement/group/AchievementGroupMenuButtons.scala
@@ -129,7 +129,7 @@ object AchievementGroupMenuButtons {
                                 case Some(name) => name
                                 case None       => "未実装"
                               }
-                              player.sendMessage(s"実績No${achievement.id}[${displayGroupName}]を解除しました！おめでとうございます！")
+                              player.sendMessage(s"[${displayGroupName}]実績No${achievement.id}を解除しました！おめでとうございます！")
                             }
                             else {
                               MessageEffect(s"${RED}実績No${achievement.id}は条件を満たしていません。")(player)

--- a/src/main/scala/com/github/unchama/seichiassist/menus/achievement/group/AchievementGroupMenuButtons.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/menus/achievement/group/AchievementGroupMenuButtons.scala
@@ -19,6 +19,7 @@ import com.github.unchama.seichiassist.achievement.{
   NicknameMapping,
   SeichiAchievement
 }
+import com.github.unchama.seichiassist.achievement.hierarchy.AchievementGroup
 import com.github.unchama.seichiassist.menus.ColorScheme
 import com.github.unchama.targetedeffect.commandsender.MessageEffect
 import com.github.unchama.targetedeffect.player.FocusedSoundEffect
@@ -124,7 +125,11 @@ object AchievementGroupMenuButtons {
                                 .playermap(player.getUniqueId)
                                 .TitleFlags
                                 .addOne(achievement.id)
-                              player.sendMessage(s"実績No${achievement.id}を解除しました！おめでとうございます！")
+                              val displayGroupName = AchievementGroup.getGroupNameByEntryId(achievement.id) match{
+                                case Some(name) => name
+                                case None       => "未実装"
+                              }
+                              player.sendMessage(s"実績No${achievement.id}[${displayGroupName}]を解除しました！おめでとうございます！")
                             }
                             else {
                               MessageEffect(s"${RED}実績No${achievement.id}は条件を満たしていません。")(player)

--- a/src/main/scala/com/github/unchama/seichiassist/task/global/PlayerDataRecalculationRoutine.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/task/global/PlayerDataRecalculationRoutine.scala
@@ -59,7 +59,7 @@ object PlayerDataRecalculationRoutine {
               val achievementIds = unlockTargets.map(_._1)
               playerData.TitleFlags.addAll(achievementIds)
               unlockTargets.foreach { case(achievementId, displayGroupName) =>
-                player.sendMessage(s"実績No$achievementId[$displayGroupName]が解除されました！おめでとうございます！")
+                player.sendMessage(s"[$displayGroupName]実績No$achievementIdが解除されました！おめでとうございます！")
               }
             }
           )


### PR DESCRIPTION
<!--
    このPRに関連し、マージ時に自動的にクローズしたいIssueの番号を入力してください。
    複数のIssueを紐付ける場合は、それに続いて "close #1, close #2 ..." と続けて記述してください。
    (Issueに関連するPRではない場合は、このセクションを削除してください。)
    参考: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

close #920 

----

### このPRの変更点と理由:
- 実績解除時の表示内容に小区分を同時に表示するようにした。
- 自動解禁・手動解禁の両方に対応
<!--
    このPRであなたが行った変更、なぜそれを行ったのかを簡潔に記述してください。
    自明な場合は省略しても良いですが、なるべく書くようにしてください。
-->

### 補足情報:

<!--
    他にこのPRのことについてメンテナに伝えたいことがあれば記述してください。
    (なければ、このセクションを削除してください。)
-->
