### PR TITLE
Remove scalafixversion

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -15,8 +15,6 @@ ThisBuild / description := "ギガンティック☆整地鯖の独自要素を�
 // Scalafixが要求するため、semanticdbは有効化する
 ThisBuild / semanticdbEnabled := true
 ThisBuild / semanticdbVersion := scalafixSemanticdb.revision
-ThisBuild / scalafixScalaBinaryVersion :=
-  CrossVersion.binaryScalaVersion(scalaVersion.value)
 
 // endregion
 


### PR DESCRIPTION
```
SeichiAssist/build.sbt:18: warning: value scalafixScalaBinaryVersion in object autoImport is deprecated (since 0.12.1): scalafixScalaBinaryVersion now follows scalaVersion by default ThisBuild / scalafixScalaBinaryVersion :=
```