### PR TITLE
fix: MineStack に格納できなかったアイテムをドロップするとき、空気ブロックをドロップしようとすることがあるのを修正

### DIFF
--- a/src/main/scala/com/github/unchama/seichiassist/listener/PlayerBlockBreakListener.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/listener/PlayerBlockBreakListener.scala
@@ -359,6 +359,7 @@ class PlayerBlockBreakListener(
           event.setDropItems(false)
           intoMineStackResult
             ._1
+            .filterNot(_.getType == Material.AIR)
             .foreach(player.getWorld.dropItemNaturally(player.getLocation, _))
         })
     } yield ()


### PR DESCRIPTION
<!--
    このPRに関連し、マージ時に自動的にクローズしたいIssueの番号を入力してください。
    複数のIssueを紐付ける場合は、それに続いて "close #1, close #2 ..." と続けて記述してください。
    (Issueに関連するPRではない場合は、このセクションを削除してください。)
    参考: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

----

### このPRの変更点と理由:

<!--
    このPRであなたが行った変更、なぜそれを行ったのかを簡潔に記述してください。
    自明な場合は省略しても良いですが、なるべく書くようにしてください。
-->

空気をドロップしようとしている例外が出ていた

### 補足情報:

<!--
    他にこのPRのことについてメンテナに伝えたいことがあれば記述してください。
    (なければ、このセクションを削除してください。)
-->
