### PR TITLE
fix: 一括クラフトの石材階段レシピの修正

### DIFF
--- a/src/main/scala/com/github/unchama/buildassist/menu/MineStackMassCraftMenu.scala
+++ b/src/main/scala/com/github/unchama/buildassist/menu/MineStackMassCraftMenu.scala
@@ -848,7 +848,7 @@ object MineStackMassCraftMenu {
         ChestSlotRef(0, 0) -> MassCraftRecipeBlock(
           MassCraftRecipe(
             NonEmptyList.of(("cobblestone", 6)),
-            NonEmptyList.of(("stone_stairs", 4))
+            NonEmptyList.of(("cobblestone_stairs", 4))
           ),
           oneToThousand,
           3

--- a/src/main/scala/com/github/unchama/buildassist/menu/MineStackMassCraftMenu.scala
+++ b/src/main/scala/com/github/unchama/buildassist/menu/MineStackMassCraftMenu.scala
@@ -855,13 +855,21 @@ object MineStackMassCraftMenu {
         ),
         ChestSlotRef(1, 0) -> MassCraftRecipeBlock(
           MassCraftRecipe(
+            NonEmptyList.of(("stone", 6)),
+            NonEmptyList.of(("stone_stairs", 4))
+          ),
+          oneToThousand,
+          3
+        ),
+        ChestSlotRef(2, 0) -> MassCraftRecipeBlock(
+          MassCraftRecipe(
             NonEmptyList.of(("granite", 6)),
             NonEmptyList.of(("granite_stairs", 4))
           ),
           oneToThousand,
           3
         ),
-        ChestSlotRef(2, 0) -> MassCraftRecipeBlock(
+        ChestSlotRef(3, 0) -> MassCraftRecipeBlock(
           MassCraftRecipe(
             NonEmptyList.of(("diorite", 6)),
             NonEmptyList.of(("diorite_stairs", 4))
@@ -869,7 +877,7 @@ object MineStackMassCraftMenu {
           oneToThousand,
           3
         ),
-        ChestSlotRef(3, 0) -> MassCraftRecipeBlock(
+        ChestSlotRef(4, 0) -> MassCraftRecipeBlock(
           MassCraftRecipe(
             NonEmptyList.of(("andesite", 6)),
             NonEmptyList.of(("andesite_stairs", 4))
@@ -877,7 +885,7 @@ object MineStackMassCraftMenu {
           oneToThousand,
           3
         ),
-        ChestSlotRef(4, 0) -> MassCraftRecipeBlock(
+        ChestSlotRef(0, 5) -> MassCraftRecipeBlock(
           MassCraftRecipe(
             NonEmptyList.of(("smooth_brick0", 6)),
             NonEmptyList.of(("smooth_stairs", 4))


### PR DESCRIPTION
<!--
    このPRに関連し、マージ時に自動的にクローズしたいIssueの番号を入力してください。
    複数のIssueを紐付ける場合は、それに続いて "close #1, close #2 ..." と続けて記述してください。
    (Issueに関連するPRではない場合は、このセクションを削除してください。)
    参考: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

close #2458

----

### このPRの変更点と理由:
- Minestack一括クラフトの石材階段レシピを修正
  - 丸石の階段レシピを修正
  - 石の階段レシピを追加
  - レシピ位置の修正
<!--
    このPRであなたが行った変更、なぜそれを行ったのかを簡潔に記述してください。
    自明な場合は省略しても良いですが、なるべく書くようにしてください。
-->
