### PR TITLE
fix: 死神の鎌がプレイヤー以外の頭を刈り取ったときに頭をドロップしないのを修正

### DIFF
--- a/src/main/scala/com/github/unchama/seichiassist/listener/PlayerClickListener.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/listener/PlayerClickListener.scala
@@ -240,24 +240,9 @@ class PlayerClickListener(
       return
     }
 
-    val targetBlocks = Set(
-      Material.PLAYER_WALL_HEAD,
-      Material.PLAYER_HEAD,
-      Material.DRAGON_HEAD,
-      Material.DRAGON_WALL_HEAD,
-      Material.ZOMBIE_HEAD,
-      Material.ZOMBIE_WALL_HEAD,
-      Material.CREEPER_HEAD,
-      Material.CREEPER_WALL_HEAD,
-      Material.SKELETON_SKULL,
-      Material.SKELETON_WALL_SKULL,
-      Material.WITHER_SKELETON_SKULL,
-      Material.WITHER_SKELETON_WALL_SKULL
-    )
-
     val clickedBlock = e.getClickedBlock
-    // 頭じゃない場合無視
-    if (!targetBlocks.contains(clickedBlock.getType)) {
+    val skullData = ItemInformation.getSkullDataFromBlock(clickedBlock).getOrElse {
+      // 頭じゃない場合無視
       return
     }
 
@@ -273,10 +258,9 @@ class PlayerClickListener(
     }
 
     // 頭を付与
-    ItemInformation.getSkullDataFromBlock(clickedBlock) match {
-      case Some(itemStack) => p.getInventory.addItem(itemStack)
-      case None            =>
-    }
+    p.getInventory.addItem(skullData)
+
+    // ブロックを空気で置き換える
     if (!ExternalPlugins.getCoreProtectWrapper.queueBlockRemoval(p, clickedBlock)) {
       SeichiAssist
         .instance
@@ -285,8 +269,8 @@ class PlayerClickListener(
           s"Logging in skull break: Failed Location: ${clickedBlock.getLocation}, Player:$p"
         )
     }
-    // ブロックを空気で置き換える
     clickedBlock.setType(Material.AIR)
+
     // 音を鳴らしておく
     p.playSound(p.getLocation, Sound.ENTITY_ITEM_PICKUP, 2.0f, 1.0f)
   }

--- a/src/main/scala/com/github/unchama/seichiassist/util/ItemInformation.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/util/ItemInformation.scala
@@ -60,9 +60,7 @@ object ItemInformation {
       Material.WITHER_SKELETON_WALL_SKULL
     )
 
-    if (!headMaterials.contains(block.getType)) return None
-
-    Some(block.getDrops.asScala.head)
+    Option.when(headMaterials.contains(block.getType))(block.getDrops.asScala.head)
   }
 
   /**

--- a/src/main/scala/com/github/unchama/seichiassist/util/ItemInformation.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/util/ItemInformation.scala
@@ -62,7 +62,6 @@ object ItemInformation {
 
     if (!headMaterials.contains(block.getType)) return None
 
-    // プレイヤーの頭の場合，ドロップアイテムからItemStackを取得．データ値をPLAYERにして返す
     Some(block.getDrops.asScala.head)
   }
 

--- a/src/main/scala/com/github/unchama/seichiassist/util/ItemInformation.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/util/ItemInformation.scala
@@ -45,7 +45,22 @@ object ItemInformation {
   }
 
   def getSkullDataFromBlock(block: Block): Option[ItemStack] = {
-    if (block.getType != Material.PLAYER_HEAD) return None
+    val headMaterials = Set(
+      Material.PLAYER_WALL_HEAD,
+      Material.PLAYER_HEAD,
+      Material.DRAGON_HEAD,
+      Material.DRAGON_WALL_HEAD,
+      Material.ZOMBIE_HEAD,
+      Material.ZOMBIE_WALL_HEAD,
+      Material.CREEPER_HEAD,
+      Material.CREEPER_WALL_HEAD,
+      Material.SKELETON_SKULL,
+      Material.SKELETON_WALL_SKULL,
+      Material.WITHER_SKELETON_SKULL,
+      Material.WITHER_SKELETON_WALL_SKULL
+    )
+
+    if (!headMaterials.contains(block.getType)) return None
 
     // プレイヤーの頭の場合，ドロップアイテムからItemStackを取得．データ値をPLAYERにして返す
     Some(block.getDrops.asScala.head)


### PR DESCRIPTION
<!--
    このPRに関連し、マージ時に自動的にクローズしたいIssueの番号を入力してください。
    複数のIssueを紐付ける場合は、それに続いて "close #1, close #2 ..." と続けて記述してください。
    (Issueに関連するPRではない場合は、このセクションを削除してください。)
    参考: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

----

### このPRの変更点と理由:

<!--
    このPRであなたが行った変更、なぜそれを行ったのかを簡潔に記述してください。
    自明な場合は省略しても良いですが、なるべく書くようにしてください。
-->

### 補足情報:

- `getSkullDataFromBlock`が頭の即時回収関数以外から呼ばれていないことは確認済み

<!--
    他にこのPRのことについてメンテナに伝えたいことがあれば記述してください。
    (なければ、このセクションを削除してください。)
-->
