### PR TITLE
feat: 1.18.2で追加されるブロックを一括クラフトのレシピとして追加

### DIFF
--- a/src/main/scala/com/github/unchama/buildassist/menu/MineStackMassCraftMenu.scala
+++ b/src/main/scala/com/github/unchama/buildassist/menu/MineStackMassCraftMenu.scala
@@ -1215,6 +1215,66 @@ object MineStackMassCraftMenu {
           oneToThousand,
           3
         )
+      ),
+      // 1.18.2 追加ブロック(1)
+      List(
+        ChestSlotRef(0, 0) -> MassCraftRecipeBlock(
+          MassCraftRecipe(
+            NonEmptyList.of(("raw_copper", 9)),
+            NonEmptyList.of(("raw_copper_block", 1))
+          ),
+          oneToThousand,
+          1
+        ),
+        ChestSlotRef(1, 0) -> MassCraftRecipeBlock(
+          MassCraftRecipe(
+            NonEmptyList.of(("raw_iron", 9)),
+            NonEmptyList.of(("raw_iron_block", 1))
+          ),
+          oneToThousand,
+          1
+        ),
+        ChestSlotRef(2, 0) -> MassCraftRecipeBlock(
+          MassCraftRecipe(
+            NonEmptyList.of(("raw_gold", 9)),
+            NonEmptyList.of(("raw_gold_block", 1))
+          ),
+          oneToThousand,
+          1
+        ),
+        ChestSlotRef(3, 0) -> MassCraftRecipeBlock(
+          MassCraftRecipe(
+            NonEmptyList.of(("copper_ingot", 9)),
+            NonEmptyList.of(("copper_block", 1))
+          ),
+          oneToThousand,
+          1
+        ),
+        ChestSlotRef(4, 0) -> MassCraftRecipeBlock(
+          MassCraftRecipe(
+            NonEmptyList.of(("netherite_ingot", 9)),
+            NonEmptyList.of(("netherite_block", 1))
+          ),
+          oneToThousand,
+          1
+        ),
+        ChestSlotRef(0, 5) -> MassCraftRecipeBlock(
+          MassCraftRecipe(
+            NonEmptyList.of(("netherite_scrap", 4),("gold_ingot", 4)),
+            NonEmptyList.of(("netherite_ingot", 1))
+          ),
+          oneToThousand,
+          1
+        ),
+        ChestSlotRef(1, 5) -> MassCraftRecipeBlock(
+          MassCraftRecipe(
+            NonEmptyList.of(("ancient_debris", 4), ("coal", 1)),
+            NonEmptyList.of(("netherite_scrap", 4))
+          ),
+          oneToThousand,
+          3
+        ),
+      ),
       )
     )
   }

--- a/src/main/scala/com/github/unchama/buildassist/menu/MineStackMassCraftMenu.scala
+++ b/src/main/scala/com/github/unchama/buildassist/menu/MineStackMassCraftMenu.scala
@@ -1257,7 +1257,7 @@ object MineStackMassCraftMenu {
         ),
         ChestSlotRef(0, 5) -> MassCraftRecipeBlock(
           MassCraftRecipe(
-            NonEmptyList.of(("netherite_scrap", 4),("gold_ingot", 4)),
+            NonEmptyList.of(("netherite_scrap", 4), ("gold_ingot", 4)),
             NonEmptyList.of(("netherite_ingot", 1))
           ),
           oneToThousand,
@@ -1270,13 +1270,13 @@ object MineStackMassCraftMenu {
           ),
           oneToThousand,
           3
-        ),
+        )
       ),
       // 1.18.2 追加ブロック(2)
       List(
         ChestSlotRef(0, 0) -> MassCraftRecipeBlock(
           MassCraftRecipe(
-            NonEmptyList.of(("stone", 4), ("coal",1)),
+            NonEmptyList.of(("stone", 4), ("coal", 1)),
             NonEmptyList.of(("smooth_stone", 4))
           ),
           oneToThousand,
@@ -1297,7 +1297,7 @@ object MineStackMassCraftMenu {
           ),
           oneToThousand,
           1
-        ),
+        )
       )
     )
   }

--- a/src/main/scala/com/github/unchama/buildassist/menu/MineStackMassCraftMenu.scala
+++ b/src/main/scala/com/github/unchama/buildassist/menu/MineStackMassCraftMenu.scala
@@ -1275,6 +1275,32 @@ object MineStackMassCraftMenu {
           3
         ),
       ),
+      // 1.18.2 追加ブロック(2)
+      List(
+        ChestSlotRef(0, 0) -> MassCraftRecipeBlock(
+          MassCraftRecipe(
+            NonEmptyList.of(("stone", 4), ("coal",1)),
+            NonEmptyList.of(("smooth_stone", 4))
+          ),
+          oneToThousand,
+          3
+        ),
+        ChestSlotRef(1, 0) -> MassCraftRecipeBlock(
+          MassCraftRecipe(
+            NonEmptyList.of(("smooth_stone", 3)),
+            NonEmptyList.of(("smooth_stone_slab", 6))
+          ),
+          oneToThousand,
+          1
+        ),
+        ChestSlotRef(2, 0) -> MassCraftRecipeBlock(
+          MassCraftRecipe(
+            NonEmptyList.of(("step0", 1)),
+            NonEmptyList.of(("smooth_stone_slab", 1))
+          ),
+          oneToThousand,
+          1
+        ),
       )
     )
   }


### PR DESCRIPTION
<!--
    このPRに関連し、マージ時に自動的にクローズしたいIssueの番号を入力してください。
    複数のIssueを紐付ける場合は、それに続いて "close #1, close #2 ..." と続けて記述してください。
    (Issueに関連するPRではない場合は、このセクションを削除してください。)
    参考: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

close #2486 

----

### このPRの変更点と理由:

以下の一括クラフトレシピを追加した。
```
- 銅ブロック
- 銅の原石ブロック
- 鉄の原石ブロック
- 金の原石ブロック
- ネザライトブロック
- ネザライトインゴット
- ネザライトの欠片
- 石→滑石
- 滑石→滑石ハーフ
- 石ハーフ→滑石ハーフ
```
<!--
    このPRであなたが行った変更、なぜそれを行ったのかを簡潔に記述してください。
    自明な場合は省略しても良いですが、なるべく書くようにしてください。
-->
