### PR TITLE
直列設置スキル使用時に、メインハンドに持っているアイテムがブロックではない場合が考慮されていないのを修正

### DIFF
--- a/src/main/scala/com/github/unchama/buildassist/listener/BlockLineUpTriggerListener.scala
+++ b/src/main/scala/com/github/unchama/buildassist/listener/BlockLineUpTriggerListener.scala
@@ -59,6 +59,8 @@ class BlockLineUpTriggerListener[
     val pl = player.getLocation
     val mainHandItemType = mainHandItem.getType
 
+    if (!mainHandItemType.isBlock()) return
+
     // 仰角は下向きがプラスで上向きがマイナス
     val pitch = pl.getPitch
     val yaw = (pl.getYaw + 360) % 360


### PR DESCRIPTION
<!--
    このPRに関連し、マージ時に自動的にクローズしたいIssueの番号を入力してください。
    複数のIssueを紐付ける場合は、それに続いて "close #1, close #2 ..." と続けて記述してください。
    (Issueに関連するPRではない場合は、このセクションを削除してください。)
    参考: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

close #2568 

----

### このPRの変更点と理由:

<!--
    このPRであなたが行った変更、なぜそれを行ったのかを簡潔に記述してください。
    自明な場合は省略しても良いですが、なるべく書くようにしてください。
-->

### 補足情報:

<!--
    他にこのPRのことについてメンテナに伝えたいことがあれば記述してください。
    (なければ、このセクションを削除してください。)
-->
