### PR TITLE
feat: 新しい二つ名の追加

### DIFF
--- a/src/main/scala/com/github/unchama/seichiassist/achievement/Nicknames.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/achievement/Nicknames.scala
@@ -240,6 +240,10 @@ object Nicknames {
     9831 -> HeadTail(s"襲来", s"襲来"),
     9832 -> HeadTail(s"撃退", s"撃退"),
     9833 -> HeadTail(s"脚", s"脚"),
+    9834 -> HeadTail(s"何", s"何"),
+    9835 -> HeadTail(s"おじさん", s"おじさん"),
+    9836 -> HeadTail(s"様", s"様"),
+    9837 -> HeadTail(s"教", s"教"),
     // 中パーツ(初期開放)
     9901 -> MiddleOnly(s"は"),
     9902 -> MiddleOnly(s"な"),

--- a/src/main/scala/com/github/unchama/seichiassist/data/MenuInventoryData.java
+++ b/src/main/scala/com/github/unchama/seichiassist/data/MenuInventoryData.java
@@ -359,7 +359,7 @@ public final class MenuInventoryData {
         playerdata.samepageflag_$eq(false);
         int inventoryIndex = 1;
         int forNextI = 0;
-        for (int i = shopIndex.get(uuid).get(); i <= 9833; i++) {
+        for (int i = shopIndex.get(uuid).get(); i <= 9837; i++) {
             final List<String> lore;
             final ItemStack itemstack;
             if (inventoryIndex < 27) {


### PR DESCRIPTION
Blocked: #759, #1489, #2071

close #2333, close #1720, close #1003

----

### このPRの変更点と理由:

特に条件が指定されていない二つ名のパーツを追加します．

- おじさん
- 何
- 様
- 教

二つ名メニューが壊れているためテストができていません，上記3つの Issue が解決してからマージできます．