### PR TITLE
ARTHUR を MineStack に投入したとき、常に一番最初のガチャ ID を持つアイテムとして認識されてしまう不具合を修正

### DIFF
--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/minestack/bukkit/BukkitMineStackObjectList.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/minestack/bukkit/BukkitMineStackObjectList.scala
@@ -19,6 +19,8 @@ import org.bukkit.inventory.ItemStack
 import org.bukkit.inventory.meta.{PotionMeta, Damageable}
 import org.bukkit.potion.{PotionData, PotionType}
 import com.github.unchama.seichiassist.items.ExchangeTicket
+import org.bukkit.inventory.meta.BlockStateMeta
+import org.bukkit.block.Banner
 
 class BukkitMineStackObjectList[F[_]: Sync](
   implicit gachaPrizeAPI: GachaPrizeAPI[F, ItemStack, Player],
@@ -1205,6 +1207,22 @@ class BukkitMineStackObjectList[F[_]: Sync](
         val leftHandItemStackEnchantments = leftHandItemStackMeta.getEnchants
 
         if (!rightHandItemStackEnchantments.equals(leftHandItemStackEnchantments)) return false
+
+        if (rightHand.getType == Material.SHIELD) {
+          (rightHandItemStackMeta, leftHandItemStackMeta) match {
+            case (rightBanner: BlockStateMeta, leftBanner: BlockStateMeta) =>
+              val rightState = rightBanner.getBlockState()
+              val leftState = leftBanner.getBlockState()
+
+              (rightState, leftState) match {
+                case (rightBanner: Banner, leftBanner: Banner)
+                    if !rightBanner.getPatterns().equals(leftBanner.getPatterns()) =>
+                  return false
+                case _ =>
+              }
+            case _ =>
+          }
+        }
 
         (leftHandItemStackMeta, rightHandItemStackMeta) match {
           case (left: Damageable, right: Damageable) => left.getDamage == right.getDamage


### PR DESCRIPTION
<!--
    このPRに関連し、マージ時に自動的にクローズしたいIssueの番号を入力してください。
    複数のIssueを紐付ける場合は、それに続いて "close #1, close #2 ..." と続けて記述してください。
    (Issueに関連するPRではない場合は、このセクションを削除してください。)
    参考: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

### このPRの変更点と理由:

<!--
    このPRであなたが行った変更、なぜそれを行ったのかを簡潔に記述してください。
    自明な場合は省略しても良いですが、なるべく書くようにしてください。
-->

MineStack にアイテムを投入した場合、アイテムの比較で盾の柄が考慮されていない不具合を修正しました

### 補足情報:

<!--
    他にこのPRのことについてメンテナに伝えたいことがあれば記述してください。
    (なければ、このセクションを削除してください。)
-->
