### PR TITLE
GiganticBerserkのMob討伐数の不具合を修正

### DIFF
--- a/src/main/scala/com/github/unchama/seichiassist/data/player/GiganticBerserk.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/data/player/GiganticBerserk.scala
@@ -50,7 +50,7 @@ case class GiganticBerserk(
    */
   def totalNumberOfKilledEnemies: Int = {
     val currentStage = stage * 10
-    val previousLevel = level - 1
+    val previousLevel = level
     val previousStageLevel = currentStage + previousLevel
     LevelThresholds.giganticBerserkLevelList.take(previousStageLevel).sum + exp
   }

--- a/src/main/scala/com/github/unchama/seichiassist/task/GiganticBerserkTask.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/task/GiganticBerserkTask.scala
@@ -48,17 +48,18 @@ class GiganticBerserkTask {
       player.playSound(player.getLocation, Sound.ENTITY_WITHER_SHOOT, 1, 0.5f)
     }
 
-    // 最大レベルの場合終了
-    if (playerdata.giganticBerserk.reachedLimit()) return
-
     // 進化待機状態の場合終了
     if (playerdata.giganticBerserk.canEvolve) return
+
+    playerdata.GBexp = playerdata.giganticBerserk.exp + 1
+
+    // 最大レベルの場合終了
+    if (playerdata.giganticBerserk.reachedLimit()) return
 
     // stage * level
     val level = playerdata.giganticBerserk.level
     val n = (playerdata.giganticBerserk.stage * 10) + level
 
-    playerdata.GBexp = playerdata.giganticBerserk.exp + 1
 
     // レベルアップするかどうか判定
     if (


### PR DESCRIPTION
<!--
    このPRに関連し、マージ時に自動的にクローズしたいIssueの番号を入力してください。
    複数のIssueを紐付ける場合は、それに続いて "close #1, close #2 ..." と続けて記述してください。
    (Issueに関連するPRではない場合は、このセクションを削除してください。)
    参考: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

close #2604 

----

### このPRの変更点と理由:

<!--
    このPRであなたが行った変更、なぜそれを行ったのかを簡潔に記述してください。
    自明な場合は省略しても良いですが、なるべく書くようにしてください。
-->

GBが最大レベルの場合、`playerdata.GBexp`に加算する処理を行う前にreturnしていたので修正。
また、[`totalNumberOfKilledEnemies`](https://github.com/GiganticMinecraft/SeichiAssist/blob/db50854eb5581a0852a06fb694a7607f27f9f40b/src/main/scala/com/github/unchama/seichiassist/data/player/GiganticBerserk.scala#L51)にてlevelから1引いて総数を計算しているため、1レベル前の状態の総数+expが表示されてしまうので修正。

これによりレベルアップ時にMOB討伐総数が減ってしまう不具合も修正されます。


### 補足情報:

<!--
    他にこのPRのことについてメンテナに伝えたいことがあれば記述してください。
    (なければ、このセクションを削除してください。)
-->
![image](https://github.com/user-attachments/assets/141393c3-916a-4e30-9e6d-a71c189889dd)
<br>
![image](https://github.com/user-attachments/assets/1c9ed443-4f41-4f58-97a8-3acbe51f3cec)


