### PR TITLE
chore: DB が Docker 再起動時に勝手に上がってこないようにする

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -118,7 +118,7 @@ services:
     ]
     networks:
       - seichi
-    restart: always
+    restart: unless-stopped
     volumes:
       - db-data:/var/lib/mysql
       - ./docker/config/mysql:/etc/mysql/conf.d


### PR DESCRIPTION
### このPRの変更点と理由:

<!--
    このPRであなたが行った変更、なぜそれを行ったのかを簡潔に記述してください。
    自明な場合は省略しても良いですが、なるべく書くようにしてください。
-->

`restart: always` にすると Docker を再起動するタイミングで毎回上がってきていた

### 補足情報:

<!--
    他にこのPRのことについてメンテナに伝えたいことがあれば記述してください。
    (なければ、このセクションを削除してください。)
-->
