### PR TITLE
chore: 連続ログイン・投票の日数を1ヶ月に延長する

### DIFF
--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/vote/infrastructure/JdbcVotePersistence.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/vote/infrastructure/JdbcVotePersistence.scala
@@ -9,7 +9,7 @@ import java.util.UUID
 class JdbcVotePersistence[F[_]: Sync] extends VotePersistence[F] {
 
   // NOTE: 連続投票日数許容幅を変更する場合はここを変更してください。
-  private val consecutiveVoteStreakDaysThreshold = 14
+  private val consecutiveVoteStreakDaysThreshold = 30
 
   override def createPlayerData(uuid: UUID): F[Unit] = Sync[F].delay {
     DB.localTx { implicit session =>

--- a/src/main/scala/com/github/unchama/seichiassist/task/PlayerDataLoading.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/task/PlayerDataLoading.scala
@@ -205,7 +205,7 @@ object PlayerDataLoading {
           if (dateDiff >= 1L) {
             val newTotalLoginDay = playerData.loginStatus.totalLoginDay + 1
             val newConsecutiveLoginDays =
-              if (dateDiff <= 15L)
+              if (dateDiff <= 31L)
                 playerData.loginStatus.consecutiveLoginDays + 1
               else
                 1


### PR DESCRIPTION
## Summary
- 連続ログイン日数の許容幅を15日→31日に延長
- 連続投票日数の許容幅を14日→30日に延長

## 変更内容
以前のPR #2215 では保証期間を2週間に延長しましたが、今回は更に1ヶ月に延長します。

### 変更ファイル
- `JdbcVotePersistence.scala`: `consecutiveVoteStreakDaysThreshold` を 14 → 30 に変更
- `PlayerDataLoading.scala`: 連続ログイン判定の閾値を 15L → 31L に変更

🤖 Generated with [Claude Code](https://claude.com/claude-code)