### PR TITLE
アサルトアーマーで乗り物エンティティが破壊されない不具合の修正

### DIFF
--- a/src/main/scala/com/github/unchama/seichiassist/seichiskill/assault/AssaultRoutine.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/seichiskill/assault/AssaultRoutine.scala
@@ -43,8 +43,9 @@ object AssaultRoutine {
 
   private def destroyVehicleAsPlayer(vehicle: Vehicle, player: Player): IO[Unit] =
     IO {
+      val lethalDamage = 1000.0
       vehicle match {
-        case damageable: DamageableEntity => damageable.damage(1000.0, player)
+        case damageable: DamageableEntity => damageable.damage(lethalDamage, player)
         case _                            => vehicle.remove()
       }
     }


### PR DESCRIPTION
<!--
    このPRに関連し、マージ時に自動的にクローズしたいIssueの番号を入力してください。
    複数のIssueを紐付ける場合は、それに続いて "close #1, close #2 ..." と続けて記述してください。
    (Issueに関連するPRではない場合は、このセクションを削除してください。)
    参考: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

close #2605

----

### 補足情報:

<!--
    他にこのPRのことについてメンテナに伝えたいことがあれば記述してください。
    (なければ、このセクションを削除してください。)
-->
issue 内容ではトロッコが破壊されないという内容でしたが、トロッコだけではなく乗り物類(ボートなど)を含めて破壊されるようにしました。