### PR TITLE
fix: Paper Docker image update compatibility

### DIFF
--- a/docker/paper/Dockerfile
+++ b/docker/paper/Dockerfile
@@ -3,13 +3,13 @@ FROM ghcr.io/giganticminecraft/chunk-search-rs:latest@sha256:e80b9442523852965fd
 FROM ghcr.io/giganticminecraft/seichiassist-runner-v2:latest@sha256:31a6bbbd31b21f51f262a5753e17ded8bdac3903ffe14e0480407fdf1b3c4243
 FROM mikefarah/yq:4.52.5 as yq
 
-FROM itzg/minecraft-server:java17-jdk
+FROM itzg/minecraft-server:stable-java17
 
-# nkfをインストール
+# nkf と zip 展開ツールをインストール
 RUN \
     --mount=type=cache,target=/var/lib/apt,sharing=locked \
     --mount=type=cache,target=/var/cache/apt,sharing=locked \
-    apt-get update && apt-get install -y nkf
+    apt-get update && apt-get install -y nkf unzip
 
 #yqをインストール
 COPY --from=yq /usr/bin/yq /usr/bin/yq
@@ -17,12 +17,13 @@ COPY --from=yq /usr/bin/yq /usr/bin/yq
 # chunk-search-rsをインストール
 COPY --link --from=chunk-search-provider /build/chunk-search-rs /usr/bin/chunk-search-rs
 
-# プラグインとスクリプトをローカルからコピーする
+# プラグインをローカルからコピーする
 COPY --link ./target/build/ /SeichiAssist/
-COPY --link ./docker/paper/ /data/
 ADD ./localDependencies/ /data/plugins/
 
-RUN chmod a+x /data/update-seichiassist.sh
-RUN nkf -Lu --overwrite /data/update-seichiassist.sh
+COPY --link ./docker/paper/update-seichiassist.sh /usr/local/bin/update-seichiassist.sh
 
-ENTRYPOINT ["/data/update-seichiassist.sh"]
+RUN chmod a+x /usr/local/bin/update-seichiassist.sh
+RUN nkf -Lu --overwrite /usr/local/bin/update-seichiassist.sh
+
+ENTRYPOINT ["/usr/local/bin/update-seichiassist.sh"]

--- a/docker/paper/Dockerfile
+++ b/docker/paper/Dockerfile
@@ -3,7 +3,7 @@ FROM ghcr.io/giganticminecraft/chunk-search-rs:latest@sha256:e80b9442523852965fd
 FROM ghcr.io/giganticminecraft/seichiassist-runner-v2:latest@sha256:31a6bbbd31b21f51f262a5753e17ded8bdac3903ffe14e0480407fdf1b3c4243
 FROM mikefarah/yq:4.52.5 as yq
 
-FROM itzg/minecraft-server:stable-java17
+FROM itzg/minecraft-server:stable-java17@sha256:5cc640a32d042f5e07e2fb381c0351aac3cf82bf512afa408240bde5c2358899
 
 # nkf と zip 展開ツールをインストール
 RUN \
@@ -21,9 +21,7 @@ COPY --link --from=chunk-search-provider /build/chunk-search-rs /usr/bin/chunk-s
 COPY --link ./target/build/ /SeichiAssist/
 ADD ./localDependencies/ /data/plugins/
 
-COPY --link ./docker/paper/update-seichiassist.sh /usr/local/bin/update-seichiassist.sh
-
-RUN chmod a+x /usr/local/bin/update-seichiassist.sh
+COPY --link --chmod=755 ./docker/paper/update-seichiassist.sh /usr/local/bin/update-seichiassist.sh
 RUN nkf -Lu --overwrite /usr/local/bin/update-seichiassist.sh
 
 ENTRYPOINT ["/usr/local/bin/update-seichiassist.sh"]

--- a/docker/paper/update-seichiassist.sh
+++ b/docker/paper/update-seichiassist.sh
@@ -13,7 +13,7 @@ cd SeichiAssist
 
 rm -f config.yml || true
 
-jar xf ../SeichiAssist.jar config.yml
+unzip -o ../SeichiAssist.jar config.yml
 
 config_update_expr="\
   .servernum = \"$SERVER_NUM\" |\


### PR DESCRIPTION
## 概要
- Paper 開発用 Docker イメージを `itzg/minecraft-server:stable-java17` ベースで動く構成に更新します
- `update-seichiassist.sh` の `jar` 依存を外し、`unzip` で `config.yml` を展開するようにします
- entrypoint スクリプトを永続 volume の `/data` ではなくイメージ内の `/usr/local/bin` に置き、古い volume 内容が起動時に再利用される問題を防ぎます

## テスト計画
- [ ] `./prepare-docker.sh` を実行し、`papera` / `paperb` が `jar: not found` で落ちないことを確認する
- [ ] `docker compose down -v --remove-orphans` 後の再作成でも同じく起動できることを確認する
- [ ] SeichiAssist の設定値が `config.yml` に反映されることを確認する

🤖 Generated with [Claude Code](https://claude.com/claude-code)