### PR TITLE
マナ妖精のベース回復量ががちゃりんご1つ分に満たない場合、マナ妖精が回復を行わない不具合を修正

### DIFF
--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/vote/subsystems/fairy/domain/FairyManaRecovery.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/vote/subsystems/fairy/domain/FairyManaRecovery.scala
@@ -80,7 +80,8 @@ object FairyManaRecovery {
     val manaBeforeDragonNightMultiplier =
       if (isLessThanSingleAppleRecovery) baseAmount
       else if (pureAppleConsumeAmount == 0) 0.0
-      else (baseAmount * (consumedGachaAppleCount.toDouble / pureAppleConsumeAmount)) + bonusAmount
+      else
+        (baseAmount * (consumedGachaAppleCount.toDouble / pureAppleConsumeAmount)) + bonusAmount
 
     val multiplier = if (isDragonNight) dragonNightMultiplier else 1.0
     val finalRecoveredMana = manaBeforeDragonNightMultiplier * multiplier

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/vote/subsystems/fairy/domain/FairyManaRecovery.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/vote/subsystems/fairy/domain/FairyManaRecovery.scala
@@ -68,25 +68,25 @@ object FairyManaRecovery {
     val dragonNightMultiplier = 2.0
 
     val pureAppleConsumeAmount = recoveryMana.amount / manaPerApple
-    val isLessThanSingleAppleRecovery = recoveryMana.amount > 0 && recoveryMana.amount < manaPerApple
+    val isLessThanSingleAppleRecovery =
+      recoveryMana.amount > 0 && recoveryMana.amount < manaPerApple
     val consumedGachaAppleCount =
       if (isLessThanSingleAppleRecovery) 0
       else Math.min(pureAppleConsumeAmount, mineStackedAmount).toInt
     val baseAmount = recoveryMana.amount * baseManaRecoveryRatio
     val bonusAmount =
       if (bonusRoll <= bonusRollThreshold) consumedGachaAppleCount * bonusManaPerApple else 0.0
-    val totalBase = baseAmount + bonusAmount
 
     val manaBeforeDragonNightMultiplier =
-      if (isLessThanSingleAppleRecovery) totalBase
+      if (isLessThanSingleAppleRecovery) baseAmount
       else if (pureAppleConsumeAmount == 0) 0.0
-      else totalBase * (consumedGachaAppleCount.toDouble / pureAppleConsumeAmount)
+      else (baseAmount * (consumedGachaAppleCount.toDouble / pureAppleConsumeAmount)) + bonusAmount
 
     val multiplier = if (isDragonNight) dragonNightMultiplier else 1.0
     val finalRecoveredMana = manaBeforeDragonNightMultiplier * multiplier
 
     val state =
-      if (isLessThanSingleAppleRecovery && manaBeforeDragonNightMultiplier > 0.0)
+      if (isLessThanSingleAppleRecovery)
         FairyManaRecoveryState.RecoverWithoutAppleButLessThanAApple
       else if (manaBeforeDragonNightMultiplier == 0.0)
         FairyManaRecoveryState.RecoveredWithoutApple

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/vote/subsystems/fairy/domain/FairyManaRecovery.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/vote/subsystems/fairy/domain/FairyManaRecovery.scala
@@ -39,6 +39,7 @@ object FairyManaRecovery {
    * - 回復量は、通常のがちゃりんごの回復量の70%を基本とする
    * - 3%の確率で、がちゃりんご1個あたり0.3マナのボーナス回復が発生する
    * - ドラゲナイタイムのときはマナ回復量が2倍になる
+   * - 回復量ががちゃりんご1個分(300)に満たない場合は、がちゃりんごを消費せずに回復する
    *
    * @param recoveryMana
    *   妖精の回復マナ設定値
@@ -67,21 +68,25 @@ object FairyManaRecovery {
     val dragonNightMultiplier = 2.0
 
     val pureAppleConsumeAmount = recoveryMana.amount / manaPerApple
-    val consumedGachaAppleCount = Math.min(pureAppleConsumeAmount, mineStackedAmount).toInt
+    val isLessThanSingleAppleRecovery = recoveryMana.amount > 0 && recoveryMana.amount < manaPerApple
+    val consumedGachaAppleCount =
+      if (isLessThanSingleAppleRecovery) 0
+      else Math.min(pureAppleConsumeAmount, mineStackedAmount).toInt
     val baseAmount = recoveryMana.amount * baseManaRecoveryRatio
     val bonusAmount =
       if (bonusRoll <= bonusRollThreshold) consumedGachaAppleCount * bonusManaPerApple else 0.0
     val totalBase = baseAmount + bonusAmount
 
     val manaBeforeDragonNightMultiplier =
-      if (pureAppleConsumeAmount == 0) 0.0
+      if (isLessThanSingleAppleRecovery) totalBase
+      else if (pureAppleConsumeAmount == 0) 0.0
       else totalBase * (consumedGachaAppleCount.toDouble / pureAppleConsumeAmount)
 
     val multiplier = if (isDragonNight) dragonNightMultiplier else 1.0
     val finalRecoveredMana = manaBeforeDragonNightMultiplier * multiplier
 
     val state =
-      if (totalBase == 0.0 && manaBeforeDragonNightMultiplier < manaPerApple.toDouble)
+      if (isLessThanSingleAppleRecovery && manaBeforeDragonNightMultiplier > 0.0)
         FairyManaRecoveryState.RecoverWithoutAppleButLessThanAApple
       else if (manaBeforeDragonNightMultiplier == 0.0)
         FairyManaRecoveryState.RecoveredWithoutApple

--- a/src/test/scala/com/github/unchama/seichiassist/subsystems/fairy/domain/FairyManaRecoverySpec.scala
+++ b/src/test/scala/com/github/unchama/seichiassist/subsystems/fairy/domain/FairyManaRecoverySpec.scala
@@ -40,6 +40,16 @@ class FairyManaRecoverySpec extends AnyWordSpec with ScalaCheckPropertyChecks wi
       withBonus.finalRecoveredMana should be > withoutBonus.finalRecoveredMana
     }
 
+    "在庫不足時でもボーナス回復量は実際に消費したがちゃりんご分だけ減衰しない" in {
+      val mana = FairyBaseRecoveryMana(600) // pureAppleConsumeAmount = 2
+      val baseManaRecoveryRatio = 0.7
+      val bonusManaPerApple = 0.3
+      val result = FairyManaRecovery.compute(mana, 1L, 0.03, isDragonNight = false)
+
+      result.manaBeforeDragonNightMultiplier shouldBe
+        ((mana.amount * baseManaRecoveryRatio) * 0.5 + bonusManaPerApple) +- 0.001
+    }
+
     "bonusRoll > 0.03 のときボーナスなし" in {
       val mana = FairyBaseRecoveryMana(600)
       val result = FairyManaRecovery.compute(mana, 10L, 0.5, isDragonNight = false)

--- a/src/test/scala/com/github/unchama/seichiassist/subsystems/fairy/domain/FairyManaRecoverySpec.scala
+++ b/src/test/scala/com/github/unchama/seichiassist/subsystems/fairy/domain/FairyManaRecoverySpec.scala
@@ -93,11 +93,5 @@ class FairyManaRecoverySpec extends AnyWordSpec with ScalaCheckPropertyChecks wi
       val result = FairyManaRecovery.compute(mana, 0L, 0.5, isDragonNight = false)
       result.state shouldBe FairyManaRecoveryState.RecoveredWithoutApple
     }
-
-    "state: recoveryMana == 0 のとき RecoveredWithoutApple" in {
-      val mana = FairyBaseRecoveryMana(0)
-      val result = FairyManaRecovery.compute(mana, 10L, 0.5, isDragonNight = false)
-      result.state shouldBe FairyManaRecoveryState.RecoveredWithoutApple
-    }
   }
 }

--- a/src/test/scala/com/github/unchama/seichiassist/subsystems/fairy/domain/FairyManaRecoverySpec.scala
+++ b/src/test/scala/com/github/unchama/seichiassist/subsystems/fairy/domain/FairyManaRecoverySpec.scala
@@ -13,11 +13,24 @@ class FairyManaRecoverySpec extends AnyWordSpec with ScalaCheckPropertyChecks wi
 
   "FairyManaRecovery.compute" should {
 
-    "recoveryMana < 300 のとき (pureAppleConsumeAmount == 0) finalRecoveredMana == 0.0 を返す" in {
+    "recoveryMana < 300 のとき、がちゃりんごを消費せずに回復する" in {
+      val mana = FairyBaseRecoveryMana(299)
+      val baseManaRecoveryRatio = 0.7
       val result =
-        FairyManaRecovery.compute(FairyBaseRecoveryMana(299), 100L, 0.5, isDragonNight = false)
-      result.finalRecoveredMana shouldBe 0.0
+        FairyManaRecovery.compute(mana, 100L, 0.5, isDragonNight = false)
+      result.finalRecoveredMana shouldBe mana.amount * baseManaRecoveryRatio +- 0.001
       result.consumedGachaAppleCount shouldBe 0
+      result.state shouldBe FairyManaRecoveryState.RecoverWithoutAppleButLessThanAApple
+    }
+
+    "recoveryMana < 300 のとき、がちゃりんご在庫が0でも無消費で回復する" in {
+      val mana = FairyBaseRecoveryMana(299)
+      val baseManaRecoveryRatio = 0.7
+      val result =
+        FairyManaRecovery.compute(mana, 0L, 0.5, isDragonNight = false)
+      result.finalRecoveredMana shouldBe mana.amount * baseManaRecoveryRatio +- 0.001
+      result.consumedGachaAppleCount shouldBe 0
+      result.state shouldBe FairyManaRecoveryState.RecoverWithoutAppleButLessThanAApple
     }
 
     "bonusRoll <= 0.03 のときボーナスが適用される" in {
@@ -71,10 +84,10 @@ class FairyManaRecoverySpec extends AnyWordSpec with ScalaCheckPropertyChecks wi
       result.state shouldBe FairyManaRecoveryState.RecoveredWithoutApple
     }
 
-    "state: recoveryMana == 0 かつ manaBeforeDragonNightMultiplier < 300 のとき RecoverWithoutAppleButLessThanAApple" in {
+    "state: recoveryMana == 0 のとき RecoveredWithoutApple" in {
       val mana = FairyBaseRecoveryMana(0)
       val result = FairyManaRecovery.compute(mana, 10L, 0.5, isDragonNight = false)
-      result.state shouldBe FairyManaRecoveryState.RecoverWithoutAppleButLessThanAApple
+      result.state shouldBe FairyManaRecoveryState.RecoveredWithoutApple
     }
   }
 }


### PR DESCRIPTION
## 概要
- マナ妖精の回復量が300未満のとき、がちゃりんごを消費せずに回復するよう修正
- 300未満回復時の状態判定を専用表示に合わせて整理
- 仕様とずれていた FairyManaRecovery の単体テストを更新

## テスト計画
- [x] sbt "testOnly com.github.unchama.seichiassist.subsystems.fairy.domain.FairyManaRecoverySpec"

close #2831

🤖 Generated with Codex