### PR TITLE
Add playerdata index reconciliation migrations

### DIFF
--- a/src/main/resources/db/migration/V2.0.1__Reconcile_playerdata_indexes.sql
+++ b/src/main/resources/db/migration/V2.0.1__Reconcile_playerdata_indexes.sql
@@ -1,30 +1,16 @@
 USE seichiassist;
 
--- playerdata の index 構成が歴史的に drift しており、
--- live DB には migration 定義に無い重複 index / 未使用 index が残っている。
+-- 既存 Flyway migration / baseline に含まれているが、
+-- 現行クエリ実態では未使用な index を明示的に削除する。
 --
--- 現行クエリ実態では playerdata で index 利用されているのは name lookup と PRIMARY(uuid) だけで、
--- totalbreaknum/build_count/playtick/lastquit の単列 index はランキング全件走査には効いていない。
--- そのため、まずは重複・未使用 index を落として最小構成へ正規化する。
--- ランキング向けに試す covering index は後続 migration で追加する。
---
--- - PRIMARY KEY (uuid)
--- - KEY name_index (name)
---
--- 補足:
---   name は live data 上で重複が存在するため UNIQUE には戻さない。
+-- 対象:
+-- - playerdata.index_playerdata_on_lastquit
+-- - playerdata.index_playerdata_playtick
+-- - player_break_preference.index_player_break_preference_on_uuid
 
 ALTER TABLE playerdata
-    DROP INDEX IF EXISTS `name`,
-    DROP INDEX IF EXISTS `uuid`,
-    DROP INDEX IF EXISTS `uuid_index`,
-    DROP INDEX IF EXISTS `ranking_index`,
     DROP INDEX IF EXISTS `index_playerdata_on_lastquit`,
-    DROP INDEX IF EXISTS `index_playerdata_playtick`,
-    DROP INDEX IF EXISTS `pd_uid_idx`,
-    DROP INDEX IF EXISTS `pd_name_idx`,
-    DROP INDEX IF EXISTS `pd_lc_idx`,
-    DROP INDEX IF EXISTS `pd_name_pv_idx`,
-    DROP INDEX IF EXISTS `pd_bc_idx`,
-    DROP INDEX IF EXISTS `name_index`,
-    ADD INDEX IF NOT EXISTS `name_index` (`name`);
+    DROP INDEX IF EXISTS `index_playerdata_playtick`;
+
+ALTER TABLE player_break_preference
+    DROP INDEX IF EXISTS `index_player_break_preference_on_uuid`;

--- a/src/main/resources/db/migration/V2.0.1__Reconcile_playerdata_indexes.sql
+++ b/src/main/resources/db/migration/V2.0.1__Reconcile_playerdata_indexes.sql
@@ -1,0 +1,30 @@
+USE seichiassist;
+
+-- playerdata の index 構成が歴史的に drift しており、
+-- live DB には migration 定義に無い重複 index / 未使用 index が残っている。
+--
+-- 現行クエリ実態では playerdata で index 利用されているのは name lookup と PRIMARY(uuid) だけで、
+-- totalbreaknum/build_count/playtick/lastquit の単列 index はランキング全件走査には効いていない。
+-- そのため、まずは重複・未使用 index を落として最小構成へ正規化する。
+-- ランキング向けに試す covering index は後続 migration で追加する。
+--
+-- - PRIMARY KEY (uuid)
+-- - KEY name_index (name)
+--
+-- 補足:
+--   name は live data 上で重複が存在するため UNIQUE には戻さない。
+
+ALTER TABLE playerdata
+    DROP INDEX IF EXISTS `name`,
+    DROP INDEX IF EXISTS `uuid`,
+    DROP INDEX IF EXISTS `uuid_index`,
+    DROP INDEX IF EXISTS `ranking_index`,
+    DROP INDEX IF EXISTS `index_playerdata_on_lastquit`,
+    DROP INDEX IF EXISTS `index_playerdata_playtick`,
+    DROP INDEX IF EXISTS `pd_uid_idx`,
+    DROP INDEX IF EXISTS `pd_name_idx`,
+    DROP INDEX IF EXISTS `pd_lc_idx`,
+    DROP INDEX IF EXISTS `pd_name_pv_idx`,
+    DROP INDEX IF EXISTS `pd_bc_idx`,
+    DROP INDEX IF EXISTS `name_index`,
+    ADD INDEX IF NOT EXISTS `name_index` (`name`);

--- a/src/main/resources/db/migration/V2.0.2__Add_playerdata_ranking_covering_indexes.sql
+++ b/src/main/resources/db/migration/V2.0.2__Add_playerdata_ranking_covering_indexes.sql
@@ -1,0 +1,15 @@
+USE seichiassist;
+
+-- ランキング更新で使う以下の全件読み取りを、wide row 本体ではなく
+-- より細い secondary index 側で処理できるようにするための covering index。
+--
+--   SELECT name, uuid, build_count FROM playerdata
+--   SELECT name, uuid, totalbreaknum FROM playerdata
+--
+-- 現状のクエリは WHERE / ORDER BY を持たないため、optimizer が常にこの index を
+-- 自動採用するとは限らないが、FORCE INDEX を含む後続のアプリ側調整と組み合わせて
+-- playerdata 全件走査コストを下げる土台として追加する。
+
+ALTER TABLE playerdata
+    ADD INDEX IF NOT EXISTS `idx_playerdata_build_rank` (`build_count`, `uuid`, `name`),
+    ADD INDEX IF NOT EXISTS `idx_playerdata_break_rank` (`totalbreaknum`, `uuid`, `name`);


### PR DESCRIPTION
## Summary
- add a Flyway migration to reconcile drifted and unused indexes on `playerdata`
- add a Flyway migration for ranking covering indexes on `playerdata`
- keep existing migration files untouched and add only new versioned migrations

## Verification
- inspected live production index usage via `performance_schema`
- temporarily added the candidate ranking indexes on production MariaDB and confirmed both ranking queries switched from `ALL` to `type=index` with `Using index` in `EXPLAIN`
- dropped the temporary indexes after verification