### PR TITLE
ci: master release ワークフローの checkout action を v6 で固定する

### DIFF
--- a/.github/workflows/create-pr-to-release.yml
+++ b/.github/workflows/create-pr-to-release.yml
@@ -22,7 +22,7 @@ jobs:
       new_version: ${{ steps.bump.outputs.new_version }}
     steps:
       - name: Checkout
-        uses: actions/checkout@61b9e3751b92087fd0b06925ba6dd6314e06f089 # master
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
           fetch-depth: 0


### PR DESCRIPTION
### このPRの変更点と理由:

<!--
    このPRであなたが行った変更、なぜそれを行ったのかを簡潔に記述してください。
    自明な場合は省略しても良いですが、なるべく書くようにしてください。
-->

https://github.com/GiganticMinecraft/SeichiAssist/actions/runs/25303995101/job/74176859713

これで落ちたので

### 補足情報:

<!--
    他にこのPRのことについてメンテナに伝えたいことがあれば記述してください。
    (なければ、このセクションを削除してください。)
-->
