### PR TITLE
present grantコマンドでプレゼント配布対象が記録されない不具合を修正

### DIFF
--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/present/infrastructure/JdbcBackedPresentPersistence.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/present/infrastructure/JdbcBackedPresentPersistence.scala
@@ -58,12 +58,12 @@ class JdbcBackedPresentPersistence[F[_]: Sync] extends PresentPersistence[F, Ite
 
           val initialValues = players.map { uuid => Seq(presentID, uuid.toString, false) }.toSeq
 
-          DB.localTx { _ =>
+          DB.localTx { implicit session =>
             // upsert - これによってfilterなしで整合性違反を起こすことはなくなる
             sql"""
                   INSERT INTO present_state VALUES (?, ?, ?)
                   ON DUPLICATE KEY UPDATE present_id=present_id, uuid=uuid
-                 """.batch(initialValues: _*)
+                 """.batch(initialValues: _*).apply[List]()
           }
 
           // 型推論


### PR DESCRIPTION
<!--
    このPRに関連し、マージ時に自動的にクローズしたいIssueの番号を入力してください。
    複数のIssueを紐付ける場合は、それに続いて "close #1, close #2 ..." と続けて記述してください。
    (Issueに関連するPRではない場合は、このセクションを削除してください。)
    参考: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

close #2864

----

### このPRの変更点と理由:

`/present grant` コマンドで配布対象を追加しても `present_state` テーブルにINSERTが実行されず、プレイヤーがプレゼントを受け取れない不具合を修正しました。

`JdbcBackedPresentPersistence.scala` の `grant` メソッドに2つの問題がありました：

1. `DB.localTx { _ =>` でセッションが implicit で渡されていなかった
2. `.batch(initialValues: _*)` に `.apply[List]()` が欠落しており、バッチSQLがビルドされるだけで実際にDBへ実行されていなかった

コードベース内の他の全6箇所の `.batch()` 使用箇所では `DB.localTx { implicit session =>` と `.apply[List]()` が正しく付与されています。

### 補足情報:

バッチSQLが実行されなくても例外は発生しないため、コマンド実行者には成功メッセージが表示され、不具合に気づきにくい状態でした。