### PR TITLE
build: Scala 3移行準備としてログ系依存を更新し不要依存を削除

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -78,7 +78,7 @@ val scalafixCoreDep =
 val testDependencies = Seq(
   "org.scalamock" %% "scalamock" % "6.2.0",
   "org.scalatest" %% "scalatest" % "3.2.20",
-  "org.scalatestplus" %% "scalacheck-1-14" % "3.2.2.0",
+  "org.scalatestplus" %% "scalacheck-1-19" % "3.2.20.0",
   // テスト用のTestSchedulerを使うため
   "io.monix" %% "monix" % "3.4.1"
 ).map(_ % "test")
@@ -101,14 +101,13 @@ val dependenciesToEmbed = Seq(
   "co.fs2" %% "fs2-core" % "2.5.13",
 
   // algebra
-  "io.chrisdavenport" %% "log4cats-core" % "1.1.1",
-  "io.chrisdavenport" %% "log4cats-slf4j" % "1.1.1",
-  "io.chrisdavenport" %% "cats-effect-time" % "0.1.2",
+  "org.typelevel" %% "log4cats-core" % "1.7.0",
+  "org.typelevel" %% "log4cats-slf4j" % "1.7.0",
+  "io.chrisdavenport" %% "cats-effect-time" % "0.1.3",
 
   // logging
   "org.slf4j" % "slf4j-api" % "1.7.36",
   "org.slf4j" % "slf4j-jdk14" % "1.7.36",
-  "com.typesafe.scala-logging" % "scala-logging-slf4j_2.10" % "2.1.2",
 
   // type-safety utils
   "eu.timepit" %% "refined" % "0.11.4",

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.12.13
+sbt.version=1.12.14

--- a/src/main/scala/com/github/unchama/concurrent/RepeatingRoutine.scala
+++ b/src/main/scala/com/github/unchama/concurrent/RepeatingRoutine.scala
@@ -3,8 +3,8 @@ package com.github.unchama.concurrent
 import cats.effect.{Sync, Timer}
 import cats.{Monad, MonadError}
 import com.github.unchama.generic.{ApplicativeErrorThrowableExtra}
-import io.chrisdavenport.log4cats.ErrorLogger
-import io.chrisdavenport.log4cats.slf4j.Slf4jLogger
+import org.typelevel.log4cats.ErrorLogger
+import org.typelevel.log4cats.slf4j.Slf4jLogger
 
 import scala.concurrent.duration.FiniteDuration
 

--- a/src/main/scala/com/github/unchama/datarepository/definitions/SignallingRepositoryDefinition.scala
+++ b/src/main/scala/com/github/unchama/datarepository/definitions/SignallingRepositoryDefinition.scala
@@ -10,7 +10,7 @@ import com.github.unchama.generic.effect.concurrent.AsymmetricSignallingRef
 import com.github.unchama.generic.effect.stream.StreamExtra
 import com.github.unchama.minecraft.algebra.HasUuid
 import fs2.Pipe
-import io.chrisdavenport.log4cats.ErrorLogger
+import org.typelevel.log4cats.ErrorLogger
 
 object SignallingRepositoryDefinition {
 

--- a/src/main/scala/com/github/unchama/generic/ApplicativeErrorThrowableExtra.scala
+++ b/src/main/scala/com/github/unchama/generic/ApplicativeErrorThrowableExtra.scala
@@ -1,7 +1,7 @@
 package com.github.unchama.generic
 
 import cats.ApplicativeError
-import io.chrisdavenport.log4cats.ErrorLogger
+import org.typelevel.log4cats.ErrorLogger
 
 object ApplicativeErrorThrowableExtra {
 

--- a/src/main/scala/com/github/unchama/generic/effect/stream/StreamExtra.scala
+++ b/src/main/scala/com/github/unchama/generic/effect/stream/StreamExtra.scala
@@ -6,7 +6,7 @@ import cats.{Eq, Monad}
 import com.github.unchama.generic.Diff
 import com.github.unchama.minecraft.algebra.HasUuid
 import fs2.{Chunk, Pull, Stream}
-import io.chrisdavenport.log4cats.ErrorLogger
+import org.typelevel.log4cats.ErrorLogger
 
 object StreamExtra {
 

--- a/src/main/scala/com/github/unchama/seichiassist/SeichiAssist.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/SeichiAssist.scala
@@ -99,7 +99,7 @@ import com.github.unchama.seichiassist.subsystems.vote.subsystems.fairyspeech.Fa
 import com.github.unchama.seichiassist.task.PlayerDataSaveTask
 import com.github.unchama.seichiassist.task.global._
 import com.github.unchama.util.{ActionStatus, ClassUtils}
-import io.chrisdavenport.log4cats.slf4j.Slf4jLogger
+import org.typelevel.log4cats.slf4j.Slf4jLogger
 import io.sentry.Sentry
 import io.sentry.SentryLevel
 import org.bukkit.ChatColor._
@@ -145,7 +145,7 @@ class SeichiAssist extends JavaPlugin() {
     new JDK14LoggerFactory().getLogger(newLogger.getName)
   }
 
-  implicit val loggerF: io.chrisdavenport.log4cats.Logger[IO] =
+  implicit val loggerF: org.typelevel.log4cats.Logger[IO] =
     Slf4jLogger.getLoggerFromSlf4j(logger)
 
   // endregion

--- a/src/main/scala/com/github/unchama/seichiassist/infrastructure/redisbungee/RedisBungeeNetworkConnectionCount.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/infrastructure/redisbungee/RedisBungeeNetworkConnectionCount.scala
@@ -4,7 +4,7 @@ import org.apache.pekko.actor.ActorSystem
 import cats.effect.{ContextShift, Effect, IO}
 import com.github.unchama.seichiassist.domain.actions.GetNetworkConnectionCount
 import com.github.unchama.seichiassist.domain.configuration.RedisBungeeRedisConfiguration
-import io.chrisdavenport.log4cats.ErrorLogger
+import org.typelevel.log4cats.ErrorLogger
 import redis.RedisClient
 import redis.api.scripting.RedisScript
 import redis.protocol.{Bulk, MultiBulk}

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/breakcount/System.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/breakcount/System.scala
@@ -21,7 +21,7 @@ import com.github.unchama.seichiassist.subsystems.breakcount.domain.{
 }
 import com.github.unchama.seichiassist.subsystems.breakcount.infrastructure.JdbcSeichiAmountDataPersistence
 import com.github.unchama.seichiassist.subsystems.discordnotification.DiscordNotificationAPI
-import io.chrisdavenport.log4cats.ErrorLogger
+import org.typelevel.log4cats.ErrorLogger
 import org.bukkit.entity.Player
 
 import java.util.UUID

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/breakcount/subsystems/notification/System.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/breakcount/subsystems/notification/System.scala
@@ -7,7 +7,7 @@ import com.github.unchama.seichiassist.subsystems.breakcount.BreakCountReadAPI
 import com.github.unchama.seichiassist.subsystems.breakcount.subsystems.notification.application.actions.NotifyLevelUp
 import com.github.unchama.seichiassist.subsystems.breakcount.subsystems.notification.bukkit.actions.BukkitNotifyLevelUp
 import com.github.unchama.seichiassist.subsystems.discordnotification.DiscordNotificationAPI
-import io.chrisdavenport.log4cats.ErrorLogger
+import org.typelevel.log4cats.ErrorLogger
 import org.bukkit.entity.Player
 
 object System {

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/breakcountbar/System.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/breakcountbar/System.scala
@@ -19,7 +19,7 @@ import com.github.unchama.seichiassist.subsystems.breakcountbar.domain.{
   BreakCountBarVisibilityPersistence
 }
 import com.github.unchama.seichiassist.subsystems.breakcountbar.infrastructure.JdbcBreakCountBarVisibilityPersistence
-import io.chrisdavenport.log4cats.ErrorLogger
+import org.typelevel.log4cats.ErrorLogger
 import org.bukkit.entity.Player
 
 trait System[F[_], G[_], Player] extends Subsystem[F] {

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/breakcountbar/application/BreakCountBarVisibilityRepositoryDefinition.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/breakcountbar/application/BreakCountBarVisibilityRepositoryDefinition.scala
@@ -14,7 +14,7 @@ import com.github.unchama.seichiassist.subsystems.breakcountbar.domain.{
   BreakCountBarVisibilityPersistence
 }
 import fs2.Pipe
-import io.chrisdavenport.log4cats.ErrorLogger
+import org.typelevel.log4cats.ErrorLogger
 
 object BreakCountBarVisibilityRepositoryDefinition {
 

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/breakcountbar/application/ExpBarSynchronizationRepositoryTemplate.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/breakcountbar/application/ExpBarSynchronizationRepositoryTemplate.scala
@@ -11,7 +11,7 @@ import com.github.unchama.minecraft.algebra.HasUuid
 import com.github.unchama.minecraft.objects.MinecraftBossBar
 import com.github.unchama.seichiassist.subsystems.breakcount.BreakCountReadAPI
 import com.github.unchama.seichiassist.subsystems.breakcountbar.domain.BreakCountBarVisibility
-import io.chrisdavenport.log4cats.ErrorLogger
+import org.typelevel.log4cats.ErrorLogger
 
 object ExpBarSynchronizationRepositoryTemplate {
 

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/buildcount/System.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/buildcount/System.scala
@@ -33,7 +33,7 @@ import com.github.unchama.seichiassist.subsystems.buildcount.infrastructure.{
 }
 import com.github.unchama.seichiassist.subsystems.discordnotification.DiscordNotificationAPI
 import io.chrisdavenport.cats.effect.time.JavaTime
-import io.chrisdavenport.log4cats.ErrorLogger
+import org.typelevel.log4cats.ErrorLogger
 import org.bukkit.entity.Player
 import org.bukkit.event.Listener
 

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/buildcount/subsystems/notification/System.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/buildcount/subsystems/notification/System.scala
@@ -13,7 +13,7 @@ import com.github.unchama.seichiassist.subsystems.buildcount.subsystems.notifica
   BukkitNotifyLevelUp
 }
 import com.github.unchama.seichiassist.subsystems.discordnotification.DiscordNotificationAPI
-import io.chrisdavenport.log4cats.ErrorLogger
+import org.typelevel.log4cats.ErrorLogger
 import org.bukkit.entity.Player
 
 object System {

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/fastdiggingeffect/System.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/fastdiggingeffect/System.scala
@@ -49,7 +49,7 @@ import com.github.unchama.seichiassist.subsystems.fastdiggingeffect.infrastructu
   JdbcFastDiggingEffectStatsSettingsPersistence,
   JdbcFastDiggingEffectSuppressionStatePersistence
 }
-import io.chrisdavenport.log4cats.ErrorLogger
+import org.typelevel.log4cats.ErrorLogger
 import org.bukkit.Bukkit
 import org.bukkit.entity.Player
 

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/fastdiggingeffect/application/repository/EffectListRepositoryDefinitions.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/fastdiggingeffect/application/repository/EffectListRepositoryDefinitions.scala
@@ -14,7 +14,7 @@ import com.github.unchama.generic.effect.EffectExtra
 import com.github.unchama.generic.effect.concurrent.Mutex
 import com.github.unchama.generic.effect.stream.StreamExtra
 import com.github.unchama.seichiassist.subsystems.fastdiggingeffect.domain.effect.FastDiggingEffectList
-import io.chrisdavenport.log4cats.ErrorLogger
+import org.typelevel.log4cats.ErrorLogger
 
 object EffectListRepositoryDefinitions {
 

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/fastdiggingeffect/application/repository/EffectStatsSettingsRepositoryDefinition.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/fastdiggingeffect/application/repository/EffectStatsSettingsRepositoryDefinition.scala
@@ -19,7 +19,7 @@ import com.github.unchama.seichiassist.subsystems.fastdiggingeffect.domain.stats
 }
 import fs2.Pipe
 import io.chrisdavenport.cats.effect.time.JavaTime
-import io.chrisdavenport.log4cats.ErrorLogger
+import org.typelevel.log4cats.ErrorLogger
 
 object EffectStatsSettingsRepositoryDefinition {
 

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/fourdimensionalpocket/System.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/fourdimensionalpocket/System.scala
@@ -30,7 +30,7 @@ import com.github.unchama.seichiassist.subsystems.fourdimensionalpocket.domain.{
 }
 import com.github.unchama.seichiassist.subsystems.fourdimensionalpocket.infrastructure.JdbcBukkitPocketInventoryPersistence
 import com.github.unchama.seichiassist.subsystems.itemmigration.domain.minecraft.UuidRepository
-import io.chrisdavenport.log4cats.ErrorLogger
+import org.typelevel.log4cats.ErrorLogger
 import org.bukkit.Sound
 import org.bukkit.command.TabExecutor
 import org.bukkit.entity.Player

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/fourdimensionalpocket/application/PocketInventoryRepositoryDefinition.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/fourdimensionalpocket/application/PocketInventoryRepositoryDefinition.scala
@@ -22,7 +22,7 @@ import com.github.unchama.seichiassist.subsystems.fourdimensionalpocket.domain.{
   PocketInventoryPersistence,
   PocketSizeTable
 }
-import io.chrisdavenport.log4cats.ErrorLogger
+import org.typelevel.log4cats.ErrorLogger
 
 object PocketInventoryRepositoryDefinition {
 

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/gachapoint/System.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/gachapoint/System.scala
@@ -20,7 +20,7 @@ import com.github.unchama.seichiassist.subsystems.gachapoint.bukkit.GrantBukkitG
 import com.github.unchama.seichiassist.subsystems.gachapoint.domain.GrantGachaTicketToAPlayer
 import com.github.unchama.seichiassist.subsystems.gachapoint.domain.gachapoint.GachaPoint
 import com.github.unchama.seichiassist.subsystems.gachapoint.infrastructure.JdbcGachaPointPersistence
-import io.chrisdavenport.log4cats.ErrorLogger
+import org.typelevel.log4cats.ErrorLogger
 import org.bukkit.entity.Player
 
 trait System[F[_], G[_], Player] extends Subsystem[F] {

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/halfhourranking/System.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/halfhourranking/System.scala
@@ -13,7 +13,7 @@ import com.github.unchama.minecraft.bukkit.actions.{BroadcastBukkitMessage, Send
 import com.github.unchama.seichiassist.subsystems.breakcount.BreakCountReadAPI
 import com.github.unchama.seichiassist.subsystems.halfhourranking.application.AnnounceRankingRecord
 import com.github.unchama.seichiassist.subsystems.halfhourranking.domain.RankingRecord
-import io.chrisdavenport.log4cats.ErrorLogger
+import org.typelevel.log4cats.ErrorLogger
 import org.bukkit.entity.Player
 
 object System {

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/mana/System.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/mana/System.scala
@@ -21,7 +21,7 @@ import com.github.unchama.seichiassist.subsystems.mana.domain.{
   ManaMultiplier
 }
 import com.github.unchama.seichiassist.subsystems.mana.infrastructure.JdbcManaAmountPersistence
-import io.chrisdavenport.log4cats.ErrorLogger
+import org.typelevel.log4cats.ErrorLogger
 import org.bukkit.entity.Player
 
 trait System[F[_], G[_], Player] extends Subsystem[F] {

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/mana/application/ManaRepositoryDefinition.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/mana/application/ManaRepositoryDefinition.scala
@@ -16,7 +16,7 @@ import com.github.unchama.seichiassist.subsystems.mana.domain.{
   ManaAmount,
   ManaAmountPersistence
 }
-import io.chrisdavenport.log4cats.ErrorLogger
+import org.typelevel.log4cats.ErrorLogger
 
 object ManaRepositoryDefinition {
 

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/manabar/System.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/manabar/System.scala
@@ -6,7 +6,7 @@ import com.github.unchama.seichiassist.meta.subsystem.Subsystem
 import com.github.unchama.seichiassist.subsystems.mana.ManaReadApi
 import com.github.unchama.seichiassist.subsystems.manabar.application.ManaBarSynchronizationRepository
 import com.github.unchama.seichiassist.subsystems.manabar.bukkit.CreateFreshBossBar
-import io.chrisdavenport.log4cats.ErrorLogger
+import org.typelevel.log4cats.ErrorLogger
 import org.bukkit.entity.Player
 
 object System {

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/manabar/application/ManaBarSynchronizationRepository.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/manabar/application/ManaBarSynchronizationRepository.scala
@@ -9,7 +9,7 @@ import com.github.unchama.generic.effect.stream.StreamExtra
 import com.github.unchama.minecraft.algebra.HasUuid
 import com.github.unchama.minecraft.objects.MinecraftBossBar
 import com.github.unchama.seichiassist.subsystems.mana.ManaReadApi
-import io.chrisdavenport.log4cats.ErrorLogger
+import org.typelevel.log4cats.ErrorLogger
 
 object ManaBarSynchronizationRepository {
 

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/ranking/System.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/ranking/System.scala
@@ -10,7 +10,7 @@ import com.github.unchama.seichiassist.subsystems.ranking.api.{
 import com.github.unchama.seichiassist.subsystems.ranking.application.GenericRefreshingRankingCache
 import com.github.unchama.seichiassist.subsystems.ranking.domain.values.{LoginTime, VoteCount}
 import com.github.unchama.seichiassist.subsystems.ranking.infrastructure._
-import io.chrisdavenport.log4cats.ErrorLogger
+import org.typelevel.log4cats.ErrorLogger
 
 import scala.concurrent.duration.DurationInt
 

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/ranking/application/GenericRefreshingRankingCache.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/ranking/application/GenericRefreshingRankingCache.scala
@@ -9,7 +9,7 @@ import cats.kernel.Monoid
 import com.github.unchama.generic.effect.concurrent.ReadOnlyRef
 import com.github.unchama.generic.effect.stream.StreamExtra
 import com.github.unchama.seichiassist.subsystems.ranking.domain._
-import io.chrisdavenport.log4cats.ErrorLogger
+import org.typelevel.log4cats.ErrorLogger
 
 import scala.concurrent.duration.FiniteDuration
 

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/seichilevelupgift/System.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/seichilevelupgift/System.scala
@@ -10,7 +10,7 @@ import com.github.unchama.seichiassist.subsystems.gachapoint.GachaPointApi
 import com.github.unchama.seichiassist.subsystems.seichilevelupgift.bukkit.BukkitGrantLevelUpGift
 import com.github.unchama.seichiassist.subsystems.seichilevelupgift.domain.GrantLevelUpGiftAlgebra
 import com.github.unchama.seichiassist.subsystems.seichilevelupgift.usecases.GrantGiftOnSeichiLevelDiff
-import io.chrisdavenport.log4cats.ErrorLogger
+import org.typelevel.log4cats.ErrorLogger
 import org.bukkit.entity.Player
 import org.bukkit.inventory.ItemStack
 

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/seichilevelupmessage/System.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/seichilevelupmessage/System.scala
@@ -5,7 +5,7 @@ import com.github.unchama.generic.effect.stream.StreamExtra
 import com.github.unchama.minecraft.actions.SendMinecraftMessage
 import com.github.unchama.seichiassist.subsystems.breakcount.BreakCountReadAPI
 import com.github.unchama.seichiassist.subsystems.seichilevelupmessage.domain.MessageTable
-import io.chrisdavenport.log4cats.ErrorLogger
+import org.typelevel.log4cats.ErrorLogger
 
 object System {
 

--- a/src/main/scala/com/github/unchama/util/logging/log4cats/PrefixedLogger.scala
+++ b/src/main/scala/com/github/unchama/util/logging/log4cats/PrefixedLogger.scala
@@ -1,6 +1,6 @@
 package com.github.unchama.util.logging.log4cats
 
-import io.chrisdavenport.log4cats.Logger
+import org.typelevel.log4cats.Logger
 
 object PrefixedLogger {
 

--- a/src/main/scala/com/github/unchama/util/logging/log4cats/TransformingLogger.scala
+++ b/src/main/scala/com/github/unchama/util/logging/log4cats/TransformingLogger.scala
@@ -1,6 +1,6 @@
 package com.github.unchama.util.logging.log4cats
 
-import io.chrisdavenport.log4cats.Logger
+import org.typelevel.log4cats.Logger
 
 class TransformingLogger[F[_]: Logger](f: String => String) extends Logger[F] {
   override def error(t: Throwable)(message: => String): F[Unit] = Logger[F].error(t)(f(message))


### PR DESCRIPTION
### このPRの変更点と理由:

Scala 3.3 LTS への移行準備（Phase 0）の最初のPRです。アプリケーションコードの動作を変えず、Scala 3 対応アーティファクトが存在しない依存を対応版へ置き換えます。

- sbt 1.12.13 → 1.12.14
- log4cats を `io.chrisdavenport` 1.1.1 から `org.typelevel` 1.7.0 へ移行（30ファイルの import を `org.typelevel.log4cats` へ変更。API 互換のためコード変更は import のみ）
- cats-effect-time 0.1.2 → 0.1.3（Scala 3 クロスビルドあり。cats-effect 2 系のまま）
- scalatestplus scalacheck-1-14 3.2.2.0 → scalacheck-1-19 3.2.20.0（ScalaTest 3.2.20 / ScalaCheck 1.19.0 対応、Scala 3 クロスビルドあり）
- 未使用の `scala-logging-slf4j_2.10` を削除（ソース中に参照なし）

### 補足情報:

- ローカル（Temurin JDK 17）で `Test/compile`・`test`（134件全通過）・`scalafmtCheckAll`・`scalafix --check`・`assembly` を確認済みです。
- 後続PRで `-Xsource:3` の有効化、Simulacrum の除去などを予定しています。cats-effect 3 への移行はこの計画には含めません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)