### PR TITLE
build: -Xsource:3を有効化しScala 3非互換の構文とアクセスパターンを解消

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -212,6 +212,8 @@ lazy val root = (project in file(".")).settings(
     "-unchecked",
     "-language:higherKinds",
     "-deprecation",
+    "-Xsource:3",
+    "-Xsource-features:case-apply-copy-access",
     "-Ypatmat-exhaust-depth",
     "320",
     "-Ymacro-annotations",

--- a/src/main/scala/com/github/unchama/buildassist/listener/BlockLineUpTriggerListener.scala
+++ b/src/main/scala/com/github/unchama/buildassist/listener/BlockLineUpTriggerListener.scala
@@ -192,7 +192,7 @@ class BlockLineUpTriggerListener[
     // 建築量を足す
     import cats.effect.implicits._
     IncrementBuildExpWhenBuiltWithSkill[F, Player]
-      .of(player, BuildExpAmount(placedBlockCount))
+      .of(player, BuildExpAmount.ofNonNegative(placedBlockCount))
       .runSync[SyncIO]
       .unsafeRunSync()
 

--- a/src/main/scala/com/github/unchama/buildassist/listener/TilingSkillTriggerListener.scala
+++ b/src/main/scala/com/github/unchama/buildassist/listener/TilingSkillTriggerListener.scala
@@ -232,7 +232,7 @@ class TilingSkillTriggerListener[G[_]: ConcurrentEffect, F[
 
     import cats.effect.implicits._
     IncrementBuildExpWhenBuiltWithSkill[F, Player]
-      .of(player, BuildExpAmount(placementCount))
+      .of(player, BuildExpAmount.ofNonNegative(placementCount))
       .runSync[SyncIO]
       .unsafeRunSync()
   }

--- a/src/main/scala/com/github/unchama/buildassist/menu/MineStackMassCraftMenu.scala
+++ b/src/main/scala/com/github/unchama/buildassist/menu/MineStackMassCraftMenu.scala
@@ -186,7 +186,7 @@ object MineStackMassCraftMenu {
       } yield {
         val effect =
           if (!isLowerBuildLevel && allIngredientsAvailable)
-            Kleisli { _: Player => craftEffect }
+            Kleisli { (_: Player) => craftEffect }
           else errorEffect
 
         LeftClickButtonEffect(

--- a/src/main/scala/com/github/unchama/contextualexecutor/builder/ContextualExecutorBuilder.scala
+++ b/src/main/scala/com/github/unchama/contextualexecutor/builder/ContextualExecutorBuilder.scala
@@ -192,7 +192,7 @@ object ContextualExecutorBuilder {
   }
 
   private val defaultSenderValidation: SenderTypeValidation[CommandSender] = {
-    sender: CommandSender => IO.pure(Some(sender))
+    (sender: CommandSender) => IO.pure(Some(sender))
   }
 
   def beginConfiguration: ContextualExecutorBuilder[CommandSender, HNil] =

--- a/src/main/scala/com/github/unchama/seichiassist/Config.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/Config.scala
@@ -194,9 +194,8 @@ final class Config private (val config: FileConfiguration) {
 
   def getAnywhereEnderConfiguration: AnywhereEnderConfiguration =
     new AnywhereEnderConfiguration {
-      override val requiredMinimumLevel: SeichiLevel = SeichiLevel(
-        getIntFailFast("dokodemoenderlevel")
-      )
+      override val requiredMinimumLevel: SeichiLevel =
+        SeichiLevel.ofPositive(getIntFailFast("dokodemoenderlevel"))
     }
 
   def getAutoSaveSystemConfiguration: AutoSaveConfiguration = new AutoSaveConfiguration {
@@ -214,6 +213,6 @@ final class Config private (val config: FileConfiguration) {
       override val whenInSeichiWorld: BigDecimal = scala.math.BigDecimal.decimal(0.1)
     }
     override val oneMinuteBuildExpLimit: BuildExpAmount =
-      BuildExpAmount(BigDecimal(config.getString("BuildNum1minLimit")))
+      BuildExpAmount.ofNonNegative(BigDecimal(config.getString("BuildNum1minLimit")))
   }
 }

--- a/src/main/scala/com/github/unchama/seichiassist/achievement/AchievementConditions.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/achievement/AchievementConditions.scala
@@ -38,7 +38,7 @@ object AchievementConditions {
   }
 
   def brokenBlockRankingPosition_<=(n: Int): AchievementCondition[Int] = {
-    val predicate: PlayerPredicate = { player: Player =>
+    val predicate: PlayerPredicate = { (player: Player) =>
       SeichiAssist
         .instance
         .rankingSystemApi
@@ -56,7 +56,7 @@ object AchievementConditions {
     amount: BigDecimal,
     localizedAmount: String
   ): AchievementCondition[String] = {
-    val predicate: PlayerPredicate = { player: Player =>
+    val predicate: PlayerPredicate = { (player: Player) =>
       BuildAssist
         .instance
         .buildAmountDataRepository(player)

--- a/src/main/scala/com/github/unchama/seichiassist/menus/achievement/group/AchievementGroupMenuButtons.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/menus/achievement/group/AchievementGroupMenuButtons.scala
@@ -116,7 +116,7 @@ object AchievementGroupMenuButtons {
                 case achievement: ManuallyUnlocked =>
                   achievement match {
                     case achievement: Normal[_] =>
-                      Kleisli { player: Player =>
+                      Kleisli { (player: Player) =>
                         for {
                           shouldUnlock <- achievement.condition.shouldUnlock(player)
                           _ <-

--- a/src/main/scala/com/github/unchama/seichiassist/menus/trade/GachaTradeFromMineStack.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/menus/trade/GachaTradeFromMineStack.scala
@@ -191,7 +191,7 @@ case class GachaTradeFromMineStackMenu(
     private def tradeEffect(
       mineStackObject: MineStackObject[ItemStack],
       tradeAmount: Int
-    ): TargetedEffect[Player] = Kleisli { player: Player =>
+    ): TargetedEffect[Player] = Kleisli { (player: Player) =>
       for {
         tradeResult <- gachaTradeAPI.tryTradeFromMineStack(player, mineStackObject, tradeAmount)
         name <- IO.pure {

--- a/src/main/scala/com/github/unchama/seichiassist/seichiskill/SkillRange.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/seichiskill/SkillRange.scala
@@ -64,8 +64,8 @@ object AssaultSkillRange {
     case (width, height, depth) => f(XYZTuple(width, height, depth))
   }
 
-  val armor: AssaultRangeBuilder = build(Armor)
-  val condenseWater: AssaultRangeBuilder = build(Water)
-  val condenseLava: AssaultRangeBuilder = build(Lava)
-  val condenseLiquid: AssaultRangeBuilder = build(Liquid)
+  val armor: AssaultRangeBuilder = build(Armor.apply)
+  val condenseWater: AssaultRangeBuilder = build(Water.apply)
+  val condenseLava: AssaultRangeBuilder = build(Lava.apply)
+  val condenseLiquid: AssaultRangeBuilder = build(Liquid.apply)
 }

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/breakcount/domain/level/SeichiLevel.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/breakcount/domain/level/SeichiLevel.scala
@@ -15,10 +15,7 @@ private[level] abstract class SeichiLevelInstances {
   import cats.implicits._
 
   implicit lazy val positiveInt: PositiveInt[SeichiLevel] = new PositiveInt[SeichiLevel] {
-    override def wrapPositive(rawLevel: Int): SeichiLevel = {
-      require(rawLevel >= 1)
-      SeichiLevel(rawLevel)
-    }
+    override def wrapPositive(rawLevel: Int): SeichiLevel = SeichiLevel.ofPositive(rawLevel)
 
     override def asInt(t: SeichiLevel): Int = t.level
   }
@@ -31,6 +28,9 @@ private[level] abstract class SeichiLevelInstances {
 
 object SeichiLevel extends SeichiLevelInstances {
 
-  def ofPositive(rawLevel: Int): SeichiLevel = positiveInt.wrapPositive(rawLevel)
+  def ofPositive(rawLevel: Int): SeichiLevel = {
+    require(rawLevel >= 1)
+    new SeichiLevel(rawLevel)
+  }
 
 }

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/buildcount/application/actions/IncrementBuildExpWhenBuiltByHand.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/buildcount/application/actions/IncrementBuildExpWhenBuiltByHand.scala
@@ -16,7 +16,7 @@ import com.github.unchama.seichiassist.subsystems.buildcount.domain.playerdata.B
  */
 trait IncrementBuildExpWhenBuiltByHand[F[_], Player] {
 
-  def of(player: Player): F[Unit] = of(player, BuildExpAmount(1))
+  def of(player: Player): F[Unit] = of(player, BuildExpAmount.ofNonNegative(1))
 
   def of(player: Player, by: BuildExpAmount): F[Unit]
 
@@ -49,7 +49,7 @@ object IncrementBuildExpWhenBuiltByHand {
               by.mapAmount(_ * multiplier.whenInSeichiWorld),
               by
             ),
-            F.pure(BuildExpAmount(0))
+            F.pure(BuildExpAmount.ofNonNegative(0))
           )
 
         // レートリミッターで制限しないと当然無制限になるので注意！！！

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/buildcount/application/actions/IncrementBuildExpWhenBuiltWithSkill.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/buildcount/application/actions/IncrementBuildExpWhenBuiltWithSkill.scala
@@ -5,7 +5,7 @@ import com.github.unchama.seichiassist.subsystems.buildcount.domain.explevel.Bui
 
 trait IncrementBuildExpWhenBuiltWithSkill[F[_], Player] {
 
-  def of(player: Player): F[Unit] = of(player, BuildExpAmount(1))
+  def of(player: Player): F[Unit] = of(player, BuildExpAmount.ofNonNegative(1))
 
   def of(player: Player, by: BuildExpAmount): F[Unit]
 

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/buildcount/domain/explevel/BuildLevel.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/buildcount/domain/explevel/BuildLevel.scala
@@ -12,10 +12,7 @@ private[explevel] abstract class SeichiLevelInstances {
   import cats.implicits._
 
   implicit val positiveInt: PositiveInt[BuildLevel] = new PositiveInt[BuildLevel] {
-    override def wrapPositive(int: Int): BuildLevel = {
-      require(int >= 1)
-      BuildLevel(int)
-    }
+    override def wrapPositive(int: Int): BuildLevel = BuildLevel.ofPositive(int)
 
     override def asInt(t: BuildLevel): Int = t.level
   }
@@ -27,6 +24,9 @@ private[explevel] abstract class SeichiLevelInstances {
 
 object BuildLevel extends SeichiLevelInstances {
 
-  def ofPositive(rawLevel: Int): BuildLevel = positiveInt.wrapPositive(rawLevel)
+  def ofPositive(rawLevel: Int): BuildLevel = {
+    require(rawLevel >= 1)
+    new BuildLevel(rawLevel)
+  }
 
 }

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/buildcount/domain/playerdata/BuildAmountData.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/buildcount/domain/playerdata/BuildAmountData.scala
@@ -51,7 +51,7 @@ case class BuildAmountData(expAmount: BuildExpAmount) {
 
 object BuildAmountData {
 
-  val initial: BuildAmountData = BuildAmountData(BuildExpAmount(BigDecimal(0)))
+  val initial: BuildAmountData = BuildAmountData(BuildExpAmount.ofNonNegative(BigDecimal(0)))
 
   implicit val order: Order[BuildAmountData] = Order.by(_.expAmount)
 

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/buildcount/infrastructure/JdbcBuildAmountDataPersistence.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/buildcount/infrastructure/JdbcBuildAmountDataPersistence.scala
@@ -19,7 +19,7 @@ class JdbcBuildAmountDataPersistence[F[_]](implicit F: Sync[F])
         sql"select build_count from playerdata where uuid = ${key.toString}"
           .stripMargin
           .map { rs =>
-            val exp = BuildExpAmount(BigDecimal(rs.string("build_count")))
+            val exp = BuildExpAmount.ofNonNegative(BigDecimal(rs.string("build_count")))
 
             BuildAmountData(exp)
           }

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/buildcount/infrastructure/JdbcBuildAmountRateLimitPersistence.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/buildcount/infrastructure/JdbcBuildAmountRateLimitPersistence.scala
@@ -18,7 +18,7 @@ class JdbcBuildAmountRateLimitPersistence[SyncContext[_]](
         sql"select available_permission, record_date from build_count_rate_limit where uuid = ${key.toString}"
           .stripMargin
           .map { rs =>
-            val exp = BuildExpAmount(rs.bigDecimal("available_permission"))
+            val exp = BuildExpAmount.ofNonNegative(rs.bigDecimal("available_permission"))
             val ldt = rs.localDateTime("record_date")
 
             BuildAmountRateLimiterSnapshot(exp, ldt)

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/chatratelimiter/domain/ObtainChatPermission.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/chatratelimiter/domain/ObtainChatPermission.scala
@@ -15,7 +15,7 @@ class ObtainChatPermission[F[_], G[_]: Monad, Player](
     for {
       playerLevel <- breakCountReadAPI.seichiLevelRepository(player).read
       result <-
-        if (playerLevel > SeichiLevel(1)) {
+        if (playerLevel > SeichiLevel.ofPositive(1)) {
           Monad[G].pure(ChatPermissionRequestResult.Success)
         } else {
           rateLimiterRepository(player).requestPermission(ChatCount.One).map {

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/gacha/bukkit/GachaCommand.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/gacha/bukkit/GachaCommand.scala
@@ -225,7 +225,7 @@ class GachaCommand[F[_]: OnMinecraftServerThread: ConcurrentEffect](
 
         val player = context.sender
         val probability :: HNil = context.args.parsed
-        val eventName = context.args.yetToBeParsed.headOption.map(GachaEventName)
+        val eventName = context.args.yetToBeParsed.headOption.map(GachaEventName.apply)
         val mainHandItem = player.getInventory.getItemInMainHand
 
         Kleisli
@@ -248,7 +248,7 @@ class GachaCommand[F[_]: OnMinecraftServerThread: ConcurrentEffect](
 
     val list: ContextualExecutor =
       ContextualExecutorBuilder.beginConfiguration.buildWithExecutionCSEffect { context =>
-        val eventName = context.args.yetToBeParsed.headOption.map(GachaEventName)
+        val eventName = context.args.yetToBeParsed.headOption.map(GachaEventName.apply)
         Kleisli.liftF(gachaPrizeAPI.allGachaPrizeList).flatMap { gachaPrizes =>
           val eventGachaPrizes = gachaPrizes.filter { gachaPrize =>
             if (eventName.isEmpty) gachaPrize.nonGachaEventItem

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/gachapoint/System.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/gachapoint/System.scala
@@ -96,7 +96,7 @@ object System {
           }
 
           override def addGachaPoint(point: GachaPoint): Kleisli[F, Player, Unit] =
-            Kleisli { player: Player =>
+            Kleisli { (player: Player) =>
               ContextCoercion(
                 gachaPointRepositoryControlsRepository
                   .lift(player)
@@ -106,7 +106,7 @@ object System {
             }
 
           override def subtractGachaPoint(point: GachaPoint): Kleisli[F, Player, Unit] =
-            Kleisli { player: Player =>
+            Kleisli { (player: Player) =>
               ContextCoercion(
                 gachaPointRepositoryControlsRepository
                   .lift(player)

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/lastquit/infrastructure/JdbcLastQuitPersistence.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/lastquit/infrastructure/JdbcLastQuitPersistence.scala
@@ -25,7 +25,7 @@ class JdbcLastQuitPersistence[F[_]: Sync] extends LastQuitPersistence[F] {
             .map(_.localDateTime("lastquit"))
             .toList()
             .headOption
-        lastQuitDateTime.map(LastQuitDateTime)
+        lastQuitDateTime.map(LastQuitDateTime.apply)
       }
     }
 }

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/managedfly/application/ActiveSessionFactory.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/managedfly/application/ActiveSessionFactory.scala
@@ -58,13 +58,13 @@ class ActiveSessionFactory[AsyncContext[_]: Timer: Concurrent, Player](
       currentRemainingDurationRef <-
         Ref.in[KleisliAsyncContext, SyncContext, RemainingFlyDuration](totalDuration)
 
-      kleisliAsyncUpdateRef = { duration: RemainingFlyDuration =>
+      kleisliAsyncUpdateRef = { (duration: RemainingFlyDuration) =>
         Kleisli.liftF {
           currentRemainingDurationRef.set(duration).coerceTo[AsyncContext]
         }
       }
 
-      fiber <- Kleisli { player: Player =>
+      fiber <- Kleisli { (player: Player) =>
         AsymmetricTryableFiber.start[AsyncContext, Nothing] {
           {
             ensurePlayerExp >>

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/managedfly/bukkit/BukkitPlayerFlyStatusManipulation.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/managedfly/bukkit/BukkitPlayerFlyStatusManipulation.scala
@@ -60,7 +60,7 @@ class BukkitPlayerFlyStatusManipulation[AsyncContext[_]: Concurrent: OnMinecraft
    * プレーヤーがアイドル状態であるかを判定するアクション。
    */
   override val isPlayerIdle: Kleisli[AsyncContext, Player, IdleStatus] = Kleisli {
-    player: Player =>
+    (player: Player) =>
       for {
         currentIdleMinute <- idleTimeAPI.currentIdleMinute(player)
       } yield {

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/mebius/bukkit/codec/BukkitMebiusItemStackCodec.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/mebius/bukkit/codec/BukkitMebiusItemStackCodec.scala
@@ -99,7 +99,7 @@ object BukkitMebiusItemStackCodec {
     val mebiusName = nbtItem.getString(nameTag)
 
     Some(
-      MebiusProperty(
+      MebiusProperty.of(
         mebiusType,
         ownerName,
         ownerUuid,

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/mebius/bukkit/command/MebiusCommandExecutorProvider.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/mebius/bukkit/command/MebiusCommandExecutorProvider.scala
@@ -86,7 +86,7 @@ class MebiusCommandExecutorProvider(
 
         MebiusInteractionTemplate(
           MessageEffect(s"${RED}命名はMEBIUSを装着して行ってください."),
-          _.copy(mebiusName = newName),
+          _.withMebiusName(newName),
           newProperty => {
             val newDisplayName =
               BukkitMebiusItemStackCodec.displayNameOfMaterializedItem(newProperty)
@@ -180,7 +180,7 @@ class MebiusCommandExecutorProvider(
 
         MebiusInteractionTemplate(
           MessageEffect(errorMessage),
-          _.copy(ownerNicknameOverride = Some(name)),
+          _.withOwnerNicknameOverride(name),
           newProperty =>
             SequentialEffect(
               MessageEffect(successMessage(name)),

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/mebius/domain/property/MebiusProperty.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/mebius/domain/property/MebiusProperty.scala
@@ -79,11 +79,38 @@ case class MebiusProperty private (
     loop(forcedMaterial.next)
   }
 
+  def withMebiusName(newName: String): MebiusProperty = this.copy(mebiusName = newName)
+
+  def withOwnerNicknameOverride(newNickname: String): MebiusProperty =
+    this.copy(ownerNicknameOverride = Some(newNickname))
+
   lazy val ownerNickname: String = ownerNicknameOverride.getOrElse(ownerPlayerId)
 
 }
 
 object MebiusProperty {
+
+  def of(
+    mebiusType: MebiusType,
+    ownerPlayerId: String,
+    ownerUuid: String,
+    enchantmentLevels: MebiusEnchantmentLevels,
+    forcedMaterial: MebiusForcedMaterial = MebiusForcedMaterial.None,
+    level: MebiusLevel = MebiusLevel(1),
+    ownerNicknameOverride: Option[String] = None,
+    mebiusName: String = "MEBIUS"
+  ): MebiusProperty =
+    MebiusProperty(
+      mebiusType,
+      ownerPlayerId,
+      ownerUuid,
+      enchantmentLevels,
+      forcedMaterial,
+      level,
+      ownerNicknameOverride,
+      mebiusName
+    )
+
   def initialProperty(
     mebiusType: MebiusType,
     ownerPlayerId: String,

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/mebius/domain/resources/MebiusMessages.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/mebius/domain/resources/MebiusMessages.scala
@@ -25,7 +25,7 @@ object MebiusMessages {
         "あとちょっと掘ろうよ！",
         "僕もスキルでバーっと掘ってみたいなー"
       )
-      .map(MebiusPlayerMessage)
+      .map(MebiusPlayerMessage.apply)
   )
 
   val onMebiusBreak: RandomizedCollection[MebiusPlayerMessage] = new RandomizedCollection(
@@ -39,7 +39,7 @@ object MebiusMessages {
         "もし生まれ変わっても、また[str1]と…",
         "ごめんね…[str1]とずっと一緒でいたかったけど、僕がついていけなかったよ…"
       )
-      .map(MebiusPlayerMessage)
+      .map(MebiusPlayerMessage.apply)
   )
 
   val onDamageBreaking: RandomizedCollection[MebiusPlayerMessage] = new RandomizedCollection(
@@ -53,7 +53,7 @@ object MebiusMessages {
         "まだ平気…壊れるまでは、[str1]のことを守るんだ…",
         "僕のこと、大事にしてね？"
       )
-      .map(MebiusPlayerMessage)
+      .map(MebiusPlayerMessage.apply)
   )
 
   val onDamageWarnEnemy: RandomizedCollection[MebiusCombatMessage] = new RandomizedCollection(
@@ -67,7 +67,7 @@ object MebiusMessages {
         "いてっ！やめろよー！僕を怒らせたら怖いぞー！",
         "うわぁっ！飲み物がこぼれちゃったじゃないかー！"
       )
-      .map(MebiusCombatMessage)
+      .map(MebiusCombatMessage.apply)
   )
 
   val onMonsterKill: RandomizedCollection[MebiusCombatMessage] = new RandomizedCollection(
@@ -81,7 +81,7 @@ object MebiusMessages {
         "[str2]なんて僕の力を出すまでもなかったね！",
         "やるね！僕も負けてらんないぞー！"
       )
-      .map(MebiusCombatMessage)
+      .map(MebiusCombatMessage.apply)
   )
 
   val tips: List[String] = List(

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/present/bukkit/command/PresentCommand.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/present/bukkit/command/PresentCommand.scala
@@ -45,7 +45,7 @@ class PresentCommand {
     Parsers.integer(MessageEffect("presentコマンドに与えるプレゼントIDは整数である必要があります。"))
 
   private val presentScopeModeParser = Parsers.fromOptionParser(
-    { arg1: String =>
+    { (arg1: String) =>
       arg1 match {
         // enum match
         case "player" | "all" => Some(arg1)

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/ranking/infrastructure/JdbcBuildRankingRecordPersistence.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/ranking/infrastructure/JdbcBuildRankingRecordPersistence.scala
@@ -21,7 +21,7 @@ class JdbcBuildRankingRecordPersistence[F[_]: Sync]
           RankingRecord(
             rs.string("name"),
             UUID.fromString(rs.string("uuid")),
-            BuildAmountData(BuildExpAmount(BigDecimal(rs.string("build_count"))))
+            BuildAmountData(BuildExpAmount.ofNonNegative(BigDecimal(rs.string("build_count"))))
           )
         }
         .list()

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/sharedinventory/bukkit/command/ShareInventoryCommand.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/sharedinventory/bukkit/command/ShareInventoryCommand.scala
@@ -80,7 +80,7 @@ class ShareInventoryCommand[F[_]: ConcurrentEffect: OnMinecraftServerThread](
 
     (for {
       oldSharedFlag <- Kleisli.liftF(sharedInventoryAPI.sharedFlag(player))
-      _ <- Kleisli.liftF(sharedInventoryAPI.save(uuid, InventoryContents(inventoryContents)))
+      _ <- Kleisli.liftF(sharedInventoryAPI.save(uuid, InventoryContents.of(inventoryContents)))
       newSharedFlag <- Kleisli.liftF(sharedInventoryAPI.sharedFlag(player))
       _ <- Kleisli.liftF(
         Sync[F]

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/sharedinventory/domain/bukkit/InventoryContents.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/sharedinventory/domain/bukkit/InventoryContents.scala
@@ -10,4 +10,7 @@ object InventoryContents {
 
   def ofNonEmpty(inventoryContents: NonEmptyList[ItemStack]): InventoryContents =
     InventoryContents(inventoryContents.toList)
+
+  def of(inventoryContents: List[ItemStack]): InventoryContents =
+    InventoryContents(inventoryContents)
 }

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/vote/subsystems/fairy/infrastructure/JdbcFairyPersistence.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/vote/subsystems/fairy/infrastructure/JdbcFairyPersistence.scala
@@ -117,7 +117,7 @@ class JdbcFairyPersistence[F[_]: Sync] extends FairyPersistence[F] {
       val dateOpt = sql"SELECT fairy_end_time FROM vote_fairy WHERE uuid = ${player.toString}"
         .map(_.localDateTime("fairy_end_time"))
         .single()
-      dateOpt.map(FairyEndTime)
+      dateOpt.map(FairyEndTime.apply)
     }
   }
 
@@ -139,7 +139,7 @@ class JdbcFairyPersistence[F[_]: Sync] extends FairyPersistence[F] {
           sql"SELECT given_apple_amount FROM vote_fairy WHERE uuid = ${player.toString}"
             .map(_.int("given_apple_amount"))
             .single()
-        appleAmountOpt.map(AppleAmount)
+        appleAmountOpt.map(AppleAmount.apply)
       }
     }
 

--- a/src/main/scala/com/github/unchama/seichiassist/task/PlayerDataLoading.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/task/PlayerDataLoading.scala
@@ -64,7 +64,7 @@ object PlayerDataLoading {
 
       stmt
         .executeQuery(unlockedSkillEffectQuery)
-        .recordIteration { resultSet: ResultSet =>
+        .recordIteration { (resultSet: ResultSet) =>
           val effectName = resultSet.getString("effect_name")
           val effect =
             ActiveSkillNormalEffect
@@ -87,7 +87,7 @@ object PlayerDataLoading {
 
       statement
         .executeQuery(unlockedSkillQuery)
-        .recordIteration { resultSet: ResultSet =>
+        .recordIteration { (resultSet: ResultSet) =>
           val skillName = resultSet.getString("skill_name")
           val skill = SeichiSkill.withNameOption(skillName)
           if (skill.isEmpty) {
@@ -109,7 +109,7 @@ object PlayerDataLoading {
       val command = ("select * from " + db + "." + DatabaseConstants.PLAYERDATA_TABLENAME
         + " where uuid = '" + stringUuid + "'")
 
-      stmt.executeQuery(command).recordIteration { rs: ResultSet =>
+      stmt.executeQuery(command).recordIteration { (rs: ResultSet) =>
         playerData.settings.shouldDisplayDeathMessages = rs.getBoolean("killlogflag")
         playerData.settings.shouldDisplayWorldGuardLogs = rs.getBoolean("worldguardlogflag")
 
@@ -229,7 +229,7 @@ object PlayerDataLoading {
           val Titlenums =
             rs.getString("TitleFlags").split(",").reverse.dropWhile(_.isEmpty).reverse
 
-          val Titlearray = Titlenums.map { x: String =>
+          val Titlearray = Titlenums.map { (x: String) =>
             java.lang.Long.parseUnsignedLong(x, 16)
           }
           val TitleFlags = mutable.BitSet.fromBitMask(Titlearray)

--- a/src/test/scala/com/github/unchama/generic/effect/concurrent/AsymmetricSignallingRefSpec.scala
+++ b/src/test/scala/com/github/unchama/generic/effect/concurrent/AsymmetricSignallingRefSpec.scala
@@ -38,7 +38,7 @@ class AsymmetricSignallingRefSpec
     "signal all the changes" in {
       val initialValue: Value = 0
 
-      forAll(minSuccessful(10000)) { updates: List[Value] =>
+      forAll(minSuccessful(10000)) { (updates: List[Value]) =>
         val task = for {
           ref <- AsymmetricSignallingRef.in[Task, Task, Task, Value](initialValue)
           updateResult <-

--- a/src/test/scala/com/github/unchama/generic/effect/stream/ReorderingPipeSpec.scala
+++ b/src/test/scala/com/github/unchama/generic/effect/stream/ReorderingPipeSpec.scala
@@ -32,7 +32,7 @@ class ReorderingPipeSpec
     type TestInputType = Long
 
     "Reorder scrambled inputs as long as they are timestamped" in {
-      forAll(minSuccessful(100)) { input: List[TestInputType] =>
+      forAll(minSuccessful(100)) { (input: List[TestInputType]) =>
         whenever(input.nonEmpty) {
           val timeStamped: Vector[TimeStamped[TestInputType]] = {
             val withCurrentStamps = input.map(input => (new Token, input))

--- a/src/test/scala/com/github/unchama/generic/effect/stream/StreamExtraSpec.scala
+++ b/src/test/scala/com/github/unchama/generic/effect/stream/StreamExtraSpec.scala
@@ -21,7 +21,7 @@ class StreamExtraSpec
 
       val n = 3
 
-      forAll { vector: Vector[Int] =>
+      forAll { (vector: Vector[Int]) =>
         val expected = (vector.indices by n).map(vector.apply)
         val result = StreamExtra.takeEvery(n)(fs2.Stream(vector: _*)).compile.toList
 

--- a/src/test/scala/com/github/unchama/seichiassist/subsystems/breakcount/domain/level/SeichiStarLevelTableSpec.scala
+++ b/src/test/scala/com/github/unchama/seichiassist/subsystems/breakcount/domain/level/SeichiStarLevelTableSpec.scala
@@ -13,8 +13,8 @@ class SeichiStarLevelTableSpec extends AnyWordSpec with ScalaCheckPropertyChecks
     "satisfy the contract" in {
       import SeichiStarLevelTable.{expAt, levelAt}
 
-      forAll { l: SeichiStarLevel => levelAt(expAt(l)) == l }
-      forAll { e: SeichiExpAmount =>
+      forAll { (l: SeichiStarLevel) => levelAt(expAt(l)) == l }
+      forAll { (e: SeichiExpAmount) =>
         expAt(levelAt(e)) <= e && e <= expAt(levelAt(e).increment)
       }
     }

--- a/src/test/scala/com/github/unchama/seichiassist/subsystems/managedfly/application/Mock.scala
+++ b/src/test/scala/com/github/unchama/seichiassist/subsystems/managedfly/application/Mock.scala
@@ -77,7 +77,7 @@ private[managedfly] class Mock[AsyncContext[_]: Concurrent, SyncContext[
   ): PlayerFlyStatusManipulation[PlayerAsyncKleisli] = {
     new PlayerFlyStatusManipulation[PlayerAsyncKleisli] {
       override val ensurePlayerExp: PlayerAsyncKleisli[Unit] = Kleisli {
-        player: PlayerMockReference =>
+        (player: PlayerMockReference) =>
           player
             .experienceMutex
             .lockAndUpdate { experience =>
@@ -90,7 +90,7 @@ private[managedfly] class Mock[AsyncContext[_]: Concurrent, SyncContext[
       }
 
       override val consumePlayerExp: PlayerAsyncKleisli[Unit] = Kleisli {
-        player: PlayerMockReference =>
+        (player: PlayerMockReference) =>
           player
             .experienceMutex
             .lockAndUpdate { experience =>
@@ -103,7 +103,7 @@ private[managedfly] class Mock[AsyncContext[_]: Concurrent, SyncContext[
       }
 
       override val isPlayerIdle: PlayerAsyncKleisli[IdleStatus] = Kleisli {
-        player: PlayerMockReference =>
+        (player: PlayerMockReference) =>
           player.isIdleMutex.readLatest.coerceTo[AsyncContext].map {
             if (_) Idle else HasMovedRecently
           }
@@ -111,25 +111,25 @@ private[managedfly] class Mock[AsyncContext[_]: Concurrent, SyncContext[
 
       override val synchronizeFlyStatus: PlayerFlyStatus => PlayerAsyncKleisli[Unit] = {
         case Flying(_) =>
-          Kleisli { player: PlayerMockReference =>
+          Kleisli { (player: PlayerMockReference) =>
             player.isFlyingMutex.lockAndUpdate(_ => Monad[AsyncContext].pure(true)).as(())
           }
         case NotFlying =>
-          Kleisli { player: PlayerMockReference =>
+          Kleisli { (player: PlayerMockReference) =>
             player.isFlyingMutex.lockAndUpdate(_ => Monad[AsyncContext].pure(false)).as(())
           }
       }
 
       override val sendNotificationsOnInterruption
         : InternalInterruption => PlayerAsyncKleisli[Unit] = { interruption =>
-        Kleisli { player: PlayerMockReference =>
+        Kleisli { (player: PlayerMockReference) =>
           player.sendMessage(InterruptionMessageMock(interruption))
         }
       }
 
       override val notifyRemainingDuration
         : (IdleStatus, RemainingFlyDuration) => PlayerAsyncKleisli[Unit] = { (i, d) =>
-        Kleisli { player: PlayerMockReference => player.sendMessage(StatusMessageMock(i, d)) }
+        Kleisli { (player: PlayerMockReference) => player.sendMessage(StatusMessageMock(i, d)) }
       }
     }
   }

--- a/src/test/scala/com/github/unchama/seichiassist/subsystems/managedfly/domain/RemainingFlyDurationSpec.scala
+++ b/src/test/scala/com/github/unchama/seichiassist/subsystems/managedfly/domain/RemainingFlyDurationSpec.scala
@@ -7,7 +7,7 @@ import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 class RemainingFlyDurationSpec extends AnyWordSpec with ScalaCheckPropertyChecks with Matchers {
   "RemainingFlyDuration#tickOneMinute" should {
     "decrement remaining minute if greater than 1" in {
-      forAll { minute: Int =>
+      forAll { (minute: Int) =>
         whenever(minute > 1) {
           RemainingFlyDuration
             .PositiveMinutes


### PR DESCRIPTION
### このPRの変更点と理由:

Scala 3.3 LTS への移行準備（Phase 0）の2番目のPRです（#2925 の続き）。

- `scalacOptions` へ `-Xsource:3` と `-Xsource-features:case-apply-copy-access` を追加
- コンパイラの `-quickfix:cat=scala3-migration` による機械的修正（フラグ自体はコミットに含めていません）:
  - ラムダ引数への括弧付与（main 16箇所、test 5箇所）
  - case companion の関数としての使用を明示的な `.apply` 呼び出しへ（14箇所）
- private コンストラクタを持つ case class の synthetic apply/copy への外部アクセス18箇所を解消。Scala 3 では apply/copy がコンストラクタと同じ可視性になるため、放置すると Scala 3 切替時にコンパイルエラーになります:
  - **BuildExpAmount**: 9箇所を `ofNonNegative` へ。対象はブロック設置数・DB蓄積値・設定値で、いずれも非負が保証される文脈です
  - **SeichiLevel / BuildLevel**: バリデーションを instances クラスから companion の `ofPositive` へ移動（instances クラスは companion ではないため Scala 3 では private apply を呼べません）。外部2箇所（Config、ObtainChatPermission）も `ofPositive` へ
  - **MebiusProperty**: `withMebiusName` / `withOwnerNicknameOverride` を追加してコマンドの `.copy` を置換。NBTデコード用に全項目ファクトリ `of` を追加。class 本体の `require` により不変条件は全構築経路で維持されます
  - **InventoryContents**: 現行動作を保つ素通しファクトリ `of` を追加

### 補足情報:

- 従来 synthetic apply で無検証構築されていた `BuildExpAmount` / `SeichiLevel` に `require` 検証が入ります。不正値（負の建築量など）は従来「不正なドメイン値が黙って生成」でしたが、今後は例外になります。これは Scala 3 移行後の正規経路と同じ挙動です。
- `-Xsource:3` 診断は main・test ともゼロ。ローカル（Temurin JDK 17)でテスト134件全通過、`scalafmtCheckAll`・`scalafix --check`・`assembly` を確認済みです。

🤖 Generated with [Claude Code](https://claude.com/claude-code)