### PR TITLE
refactor: Simulacrumを除去し手書きのsummonerへ置き換え

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -62,10 +62,7 @@ val providedDependencies = Seq(
   // https://maven.enginehub.org/repo/com/sk89q/worldedit/worldedit-bukkit/
   "com.sk89q.worldguard" % "worldguard-bukkit" % "7.0.7",
   "net.coreprotect" % "coreprotect" % "21.3",
-  "com.mojang" % "authlib" % "6.0.59",
-
-  // no runtime
-  "org.typelevel" %% "simulacrum" % "1.0.1"
+  "com.mojang" % "authlib" % "6.0.59"
 ).map(_ % "provided")
 
 val scalafixCoreDep =
@@ -216,7 +213,6 @@ lazy val root = (project in file(".")).settings(
     "-Xsource-features:case-apply-copy-access",
     "-Ypatmat-exhaust-depth",
     "320",
-    "-Ymacro-annotations",
     "-Ywarn-unused"
   ),
   javacOptions ++= Seq("-encoding", "utf8"),

--- a/src/main/scala/com/github/unchama/generic/algebra/typeclasses/HasSuccessor.scala
+++ b/src/main/scala/com/github/unchama/generic/algebra/typeclasses/HasSuccessor.scala
@@ -1,7 +1,6 @@
 package com.github.unchama.generic.algebra.typeclasses
 
 import cats.Order
-import simulacrum.typeclass
 
 /**
  * 後者関数 `successor` を兼ね揃えた全順序集合の型クラス。
@@ -9,7 +8,7 @@ import simulacrum.typeclass
  * この型クラスのインスタンスは、任意の `x: T` と `y: T` について
  *   - `x < y` ならば `x < x.successor <= y` を満たす。
  */
-@typeclass trait HasSuccessor[T] extends AnyRef {
+trait HasSuccessor[T] extends AnyRef {
 
   import cats.implicits._
 
@@ -53,6 +52,8 @@ import simulacrum.typeclass
 }
 
 object HasSuccessor {
+
+  def apply[T](implicit instance: HasSuccessor[T]): HasSuccessor[T] = instance
 
   implicit def positiveIntHasSuccessor[T: PositiveInt]: HasSuccessor[T] =
     new HasSuccessor[T] {

--- a/src/main/scala/com/github/unchama/generic/algebra/typeclasses/PositiveInt.scala
+++ b/src/main/scala/com/github/unchama/generic/algebra/typeclasses/PositiveInt.scala
@@ -1,7 +1,6 @@
 package com.github.unchama.generic.algebra.typeclasses
 
 import cats.Order
-import simulacrum.typeclass
 
 /**
  * 正のIntと同型な型のクラス。
@@ -12,7 +11,7 @@ import simulacrum.typeclass
  *
  * を満たす。
  */
-@typeclass trait PositiveInt[T] {
+trait PositiveInt[T] {
 
   /**
    * 正整数を包む。非正整数については例外を投げる。
@@ -27,6 +26,8 @@ import simulacrum.typeclass
 }
 
 object PositiveInt {
+
+  def apply[T](implicit instance: PositiveInt[T]): PositiveInt[T] = instance
 
   implicit def positiveIntHasOrder[T: PositiveInt]: Order[T] = Order.by(PositiveInt[T].asInt)
 


### PR DESCRIPTION
### このPRの変更点と理由:

Scala 3.3 LTS への移行準備（Phase 0）の3番目のPRです。#2928 の上にスタックしています（#2928 のマージ後にベースを develop へ変更します）。

Simulacrum の `@typeclass` マクロアノテーションは Scala 3 に存在しないため、移行前に除去します。

- `PositiveInt` と `HasSuccessor` の `@typeclass` を外し、companion へ手書きの summoner（`def apply[T](implicit instance: ...)`）を追加
- 利用箇所はすべて summoner 構文（`PositiveInt[T]` など）のみで、Simulacrum が生成する ops/syntax 構文は未使用だったため、呼び出し側の変更は不要です
- `simulacrum` 依存と、他に利用者のない `-Ymacro-annotations` フラグを削除

### 補足情報:

ローカル（Temurin JDK 17）でテスト134件全通過、`scalafmtCheckAll`・`scalafix --check`・`assembly` を確認済みです。

🤖 Generated with [Claude Code](https://claude.com/claude-code)