### PR TITLE
test: コマンド引数DSLとrefinedリテラル構築の回帰テストを追加

### DIFF
--- a/src/test/scala/com/github/unchama/contextualexecutor/builder/ContextualExecutorBuilderSpec.scala
+++ b/src/test/scala/com/github/unchama/contextualexecutor/builder/ContextualExecutorBuilderSpec.scala
@@ -1,0 +1,196 @@
+package com.github.unchama.contextualexecutor.builder
+
+import cats.effect.IO
+import cats.implicits._
+import com.github.unchama.contextualexecutor.{
+  ContextualExecutor,
+  ExecutedCommand,
+  RawCommandContext
+}
+import com.github.unchama.targetedeffect.TargetedEffect
+import com.github.unchama.targetedeffect.commandsender.MessageEffect
+import org.bukkit.command.{Command, CommandSender}
+import org.bukkit.entity.Player
+import org.scalamock.scalatest.MockFactory
+import org.scalatest.wordspec.AnyWordSpec
+import shapeless.{HList, HNil}
+
+/**
+ * コマンド引数DSL ([[ContextualExecutorBuilder]]) の回帰テスト。
+ *
+ * Scala 3移行の際にShapeless HListによる引数型の蓄積をScala 3のTupleへ置き換える予定であるため、
+ * 引数のパース順序、エラー通知、送信者の絞り込みといった外部から観測できる挙動をここで固定する。
+ */
+class ContextualExecutorBuilderSpec extends AnyWordSpec with MockFactory {
+
+  private val dummyCommand: Command = new Command("dummy") {
+    override def execute(sender: CommandSender, label: String, args: Array[String]): Boolean =
+      true
+  }
+
+  private def contextWith(sender: CommandSender, args: List[String]): RawCommandContext =
+    RawCommandContext(sender, ExecutedCommand(dummyCommand, "dummy"), args)
+
+  private class RecordingExecutor extends ContextualExecutor {
+    var recordedContext: Option[RawCommandContext] = None
+
+    override def executionWith(context: RawCommandContext): IO[Unit] =
+      IO { recordedContext = Some(context) }
+  }
+
+  "引数を取らないビルダー" should {
+    "空のHListと未パース引数をそのまま実行部へ渡す" in {
+      val sender = stub[CommandSender]
+      var capturedParsed: Option[HList] = None
+      var capturedYetToBeParsed: Option[List[String]] = None
+
+      val executor = ContextualExecutorBuilder.beginConfiguration.buildWith { context =>
+        IO {
+          capturedParsed = Some(context.args.parsed)
+          capturedYetToBeParsed = Some(context.args.yetToBeParsed)
+        }.as(TargetedEffect.emptyEffect)
+      }
+
+      executor.executionWith(contextWith(sender, List("raw1", "raw2"))).unsafeRunSync()
+
+      assert(capturedParsed.contains(HNil))
+      assert(capturedYetToBeParsed.contains(List("raw1", "raw2")))
+    }
+  }
+
+  "thenParseを使ったビルダー" should {
+    "正常な引数をパースしてHListとして実行部へ渡す" in {
+      val sender = stub[CommandSender]
+      var captured: Option[HList] = None
+
+      val executor =
+        ContextualExecutorBuilder.beginConfiguration.thenParse(Parsers.integer()).buildWith {
+          context => IO { captured = Some(context.args.parsed) }.as(TargetedEffect.emptyEffect)
+        }
+
+      executor.executionWith(contextWith(sender, List("42"))).unsafeRunSync()
+
+      assert(captured.contains(42 :: HNil))
+    }
+
+    "複数の引数を宣言順にパースし、余剰引数はyetToBeParsedに残す" in {
+      val sender = stub[CommandSender]
+      var capturedParsed: Option[HList] = None
+      var capturedYetToBeParsed: Option[List[String]] = None
+
+      val executor = ContextualExecutorBuilder
+        .beginConfiguration
+        .thenParse(Parsers.identity)
+        .thenParse(Parsers.integer())
+        .buildWith { context =>
+          IO {
+            capturedParsed = Some(context.args.parsed)
+            capturedYetToBeParsed = Some(context.args.yetToBeParsed)
+          }.as(TargetedEffect.emptyEffect)
+        }
+
+      executor
+        .executionWith(contextWith(sender, List("name", "7", "rest1", "rest2")))
+        .unsafeRunSync()
+
+      assert(capturedParsed.contains("name" :: 7 :: HNil))
+      assert(capturedYetToBeParsed.contains(List("rest1", "rest2")))
+    }
+
+    "パースに失敗した場合、実行部を呼ばず失敗エフェクトを送信者へ送る" in {
+      val sender = stub[CommandSender]
+      var executed = false
+
+      val executor = ContextualExecutorBuilder
+        .beginConfiguration
+        .thenParse(Parsers.integer(MessageEffect("整数を指定してください。")))
+        .buildWith { _ => IO { executed = true }.as(TargetedEffect.emptyEffect) }
+
+      executor.executionWith(contextWith(sender, List("abc"))).unsafeRunSync()
+
+      assert(!executed)
+      (sender.sendMessage(_: String)).verify("整数を指定してください。")
+    }
+
+    "引数が不足した場合、既定では何もせず実行部も呼ばない" in {
+      val sender = stub[CommandSender]
+      var executed = false
+
+      val executor =
+        ContextualExecutorBuilder.beginConfiguration.thenParse(Parsers.integer()).buildWith {
+          _ => IO { executed = true }.as(TargetedEffect.emptyEffect)
+        }
+
+      executor.executionWith(contextWith(sender, List())).unsafeRunSync()
+
+      assert(!executed)
+      (sender.sendMessage(_: String)).verify(*).never()
+    }
+
+    "引数が不足した場合、ifArgumentsMissingで指定したExecutorが元のコンテキストで実行される" in {
+      val sender = stub[CommandSender]
+      val missingArgumentsHandler = new RecordingExecutor
+      var executed = false
+
+      val executor = ContextualExecutorBuilder
+        .beginConfiguration
+        .ifArgumentsMissing(missingArgumentsHandler)
+        .thenParse(Parsers.integer())
+        .buildWith { _ => IO { executed = true }.as(TargetedEffect.emptyEffect) }
+
+      val rawContext = contextWith(sender, List())
+      executor.executionWith(rawContext).unsafeRunSync()
+
+      assert(!executed)
+      assert(missingArgumentsHandler.recordedContext.contains(rawContext))
+    }
+  }
+
+  "refineSenderWithErrorを使ったビルダー" should {
+    "送信者が要求された型であれば実行部を呼ぶ" in {
+      val playerSender = stub[Player]
+      var executed = false
+
+      val executor = ContextualExecutorBuilder
+        .beginConfiguration
+        .refineSenderWithError[Player]("このコマンドはゲーム内から実行してください。")
+        .buildWith { _ => IO { executed = true }.as(TargetedEffect.emptyEffect) }
+
+      executor.executionWith(contextWith(playerSender, List())).unsafeRunSync()
+
+      assert(executed)
+    }
+
+    "送信者が要求された型でなければエラーメッセージを送り、実行部を呼ばない" in {
+      val consoleSender = stub[CommandSender]
+      var executed = false
+
+      val executor = ContextualExecutorBuilder
+        .beginConfiguration
+        .refineSenderWithError[Player]("このコマンドはゲーム内から実行してください。")
+        .buildWith { _ => IO { executed = true }.as(TargetedEffect.emptyEffect) }
+
+      executor.executionWith(contextWith(consoleSender, List())).unsafeRunSync()
+
+      assert(!executed)
+      (consoleSender.sendMessage(_: String)).verify("このコマンドはゲーム内から実行してください。")
+    }
+
+    "型の絞り込みと引数パースを組み合わせられる" in {
+      val playerSender = stub[Player]
+      var captured: Option[HList] = None
+
+      val executor = ContextualExecutorBuilder
+        .beginConfiguration
+        .refineSenderWithError[Player]("このコマンドはゲーム内から実行してください。")
+        .thenParse(Parsers.identity)
+        .buildWith { context =>
+          IO { captured = Some(context.args.parsed) }.as(TargetedEffect.emptyEffect)
+        }
+
+      executor.executionWith(contextWith(playerSender, List("arg"))).unsafeRunSync()
+
+      assert(captured.contains("arg" :: HNil))
+    }
+  }
+}

--- a/src/test/scala/com/github/unchama/contextualexecutor/builder/ParsersSpec.scala
+++ b/src/test/scala/com/github/unchama/contextualexecutor/builder/ParsersSpec.scala
@@ -1,0 +1,204 @@
+package com.github.unchama.contextualexecutor.builder
+
+import com.github.unchama.targetedeffect.TargetedEffect
+import com.github.unchama.targetedeffect.commandsender.MessageEffect
+import eu.timepit.refined.api.{Refined, Validate}
+import eu.timepit.refined.numeric.{Interval, NonNegative, Positive}
+import eu.timepit.refined.refineV
+import org.bukkit.command.CommandSender
+import org.scalatest.wordspec.AnyWordSpec
+
+import java.lang.reflect.Proxy
+import java.time.LocalDate
+import scala.collection.mutable
+
+/**
+ * コマンド引数パーサの回帰テスト。
+ *
+ * Scala 3移行の際、コマンドDSLの内部実装(Shapeless HList)がTupleへ置き換えられ、
+ * refinedの利用方法も変更される予定であるため、現行のパース挙動をここで固定する。
+ *
+ * 注意: [[Parsers.closedRangeInt]] は、refinedの述語検証に失敗した場合には引数で渡した
+ * 失敗エフェクトではなく、refineVが生成する英語のエラーメッセージ
+ * (例: `Predicate (-1 < 0) did not fail.`) をそのまま送信者へ送る。
+ * 引数の失敗エフェクトが使われるのは、整数としてパースできない場合と、
+ * 述語検証には通るが指定範囲外である場合のみである。このテストはその現行挙動を固定する。
+ */
+class ParsersSpec extends AnyWordSpec {
+
+  /**
+   * [[CommandSender]] へ送られたメッセージを記録しながらeffectを実行し、記録を返す。
+   */
+  private def messagesSentBy(effect: TargetedEffect[CommandSender]): List[String] = {
+    val messages = mutable.ListBuffer[String]()
+    val recordingSender = Proxy
+      .newProxyInstance(
+        classOf[CommandSender].getClassLoader,
+        Array(classOf[CommandSender]),
+        (_, method, args) => {
+          if (method.getName == "sendMessage" && args != null && args.length == 1) {
+            args(0) match {
+              case message: String                 => messages += message
+              case lines: Array[String @unchecked] => messages ++= lines
+              case _                               =>
+            }
+          }
+          null
+        }
+      )
+      .asInstanceOf[CommandSender]
+
+    effect.run(recordingSender).unsafeRunSync()
+    messages.toList
+  }
+
+  private def assertFailureEffectSends(
+    result: ResponseEffectOrResult[CommandSender, _],
+    expectedMessage: String
+  ): Unit = {
+    val effect = result.swap.getOrElse(fail("パース結果はLeftであるべきです"))
+    assert(messagesSentBy(effect) == List(expectedMessage))
+    ()
+  }
+
+  /**
+   * refineVが失敗時に生成するエラーメッセージ。
+   */
+  private def refinedErrorMessageOf[P](int: Int)(implicit validate: Validate[Int, P]): String =
+    refineV[P](int).swap.getOrElse(fail(s"refineVが${int}の検証に成功してしまいました"))
+
+  "Parsers.identity" should {
+    "入力文字列をそのまま返す" in {
+      assert(Parsers.identity("abc") == Right("abc"))
+      assert(Parsers.identity("") == Right(""))
+      assert(Parsers.identity("日本語の引数") == Right("日本語の引数"))
+    }
+  }
+
+  "Parsers.integer" should {
+    "整数をパースできる" in {
+      assert(Parsers.integer()("42") == Right(42))
+      assert(Parsers.integer()("-1") == Right(-1))
+      assert(Parsers.integer()("0") == Right(0))
+    }
+
+    "Intの境界値をパースできる" in {
+      assert(Parsers.integer()(Int.MaxValue.toString) == Right(Int.MaxValue))
+      assert(Parsers.integer()(Int.MinValue.toString) == Right(Int.MinValue))
+    }
+
+    "Intの範囲外や非数値の入力では失敗し、指定した失敗エフェクトを返す" in {
+      val parser = Parsers.integer(MessageEffect("整数を指定してください。"))
+
+      assertFailureEffectSends(parser("abc"), "整数を指定してください。")
+      assertFailureEffectSends(parser("3.5"), "整数を指定してください。")
+      assertFailureEffectSends(parser((Int.MaxValue.toLong + 1).toString), "整数を指定してください。")
+      assertFailureEffectSends(parser(""), "整数を指定してください。")
+    }
+  }
+
+  "Parsers.double" should {
+    "小数をパースできる" in {
+      assert(Parsers.double()("3.5") == Right(3.5))
+      assert(Parsers.double()("-0.25") == Right(-0.25))
+      assert(Parsers.double()("10") == Right(10.0))
+    }
+
+    "非数値の入力では失敗する" in {
+      assertFailureEffectSends(
+        Parsers.double(MessageEffect("小数を指定してください。"))("abc"),
+        "小数を指定してください。"
+      )
+    }
+  }
+
+  "Parsers.nonNegativeInteger" should {
+    "0と正数を受理し、refinedの値として返す" in {
+      val parser = Parsers.nonNegativeInteger()
+
+      assert(parser("0").map(_.value) == Right(0))
+      assert(parser("15").map(_.value) == Right(15))
+      assert(parser(Int.MaxValue.toString).map(_.value) == Right(Int.MaxValue))
+    }
+
+    "負数は述語検証で拒否され、refinedのエラーメッセージが送られる" in {
+      val parser = Parsers.nonNegativeInteger(MessageEffect("非負整数を指定してください。"))
+
+      assertFailureEffectSends(parser("-1"), refinedErrorMessageOf[NonNegative](-1))
+    }
+  }
+
+  "Parsers.closedRangeInt" should {
+    // 本体コードで実際に使われている3種のrefined型で挙動を固定する
+    "Int Refined Positive: 範囲内の値を受理する" in {
+      val parser =
+        Parsers.closedRangeInt[Int Refined Positive](1, 100, MessageEffect("範囲外です。"))
+
+      assert(parser("1").map(_.value) == Right(1))
+      assert(parser("100").map(_.value) == Right(100))
+    }
+
+    "Int Refined Positive: 述語違反はrefinedのエラー、述語成立かつ範囲外は指定エフェクトで拒否する" in {
+      val parser =
+        Parsers.closedRangeInt[Int Refined Positive](1, 100, MessageEffect("範囲外です。"))
+
+      // 0はPositive述語の検証で失敗するため、refinedのメッセージが送られる
+      assertFailureEffectSends(parser("0"), refinedErrorMessageOf[Positive](0))
+      // 101はPositive述語を通過し、範囲チェックで失敗するため、指定したメッセージが送られる
+      assertFailureEffectSends(parser("101"), "範囲外です。")
+    }
+
+    "Int Refined NonNegative: 0を受理し、負数を拒否する" in {
+      val parser = Parsers
+        .closedRangeInt[Int Refined NonNegative](0, Int.MaxValue, MessageEffect("範囲外です。"))
+
+      assert(parser("0").map(_.value) == Right(0))
+      assertFailureEffectSends(parser("-1"), refinedErrorMessageOf[NonNegative](-1))
+    }
+
+    "Int Refined Interval.Closed: 区間の両端を受理し、区間外を拒否する" in {
+      val parser = Parsers.closedRangeInt[Int Refined Interval.Closed[1, 64]](
+        1,
+        64,
+        MessageEffect("スタック数は1から64で指定してください。")
+      )
+
+      assert(parser("1").map(_.value) == Right(1))
+      assert(parser("64").map(_.value) == Right(64))
+      // 区間外の値は範囲チェックより先に述語検証で失敗するため、refinedのメッセージが送られる
+      assertFailureEffectSends(parser("0"), refinedErrorMessageOf[Interval.Closed[1, 64]](0))
+      assertFailureEffectSends(parser("65"), refinedErrorMessageOf[Interval.Closed[1, 64]](65))
+    }
+  }
+
+  "Parsers.fromOptionParser" should {
+    "Someを返す関数からRightを得る" in {
+      val parser = Parsers.fromOptionParser((s: String) => Option.when(s == "give")(s))
+
+      assert(parser("give") == Right("give"))
+    }
+
+    "Noneを返す関数から失敗エフェクトを得る" in {
+      val parser = Parsers.fromOptionParser(
+        (s: String) => Option.when(s == "give")(s),
+        MessageEffect("操作が不正です。")
+      )
+
+      assertFailureEffectSends(parser("take"), "操作が不正です。")
+    }
+  }
+
+  "Parsers.hyphenatedDate" should {
+    "yyyy-MM-dd形式の日付をパースできる" in {
+      assert(Parsers.hyphenatedDate()("2026-07-20") == Right(LocalDate.of(2026, 7, 20)))
+    }
+
+    "不正な形式の日付では失敗する" in {
+      val parser = Parsers.hyphenatedDate(MessageEffect("日付はyyyy-MM-dd形式で指定してください。"))
+
+      assertFailureEffectSends(parser("2026/07/20"), "日付はyyyy-MM-dd形式で指定してください。")
+      assertFailureEffectSends(parser("2026-13-01"), "日付はyyyy-MM-dd形式で指定してください。")
+      assertFailureEffectSends(parser("not-a-date"), "日付はyyyy-MM-dd形式で指定してください。")
+    }
+  }
+}

--- a/src/test/scala/com/github/unchama/contextualexecutor/executors/BranchedExecutorSpec.scala
+++ b/src/test/scala/com/github/unchama/contextualexecutor/executors/BranchedExecutorSpec.scala
@@ -1,0 +1,125 @@
+package com.github.unchama.contextualexecutor.executors
+
+import cats.effect.IO
+import com.github.unchama.contextualexecutor.{
+  ContextualExecutor,
+  ExecutedCommand,
+  RawCommandContext
+}
+import org.bukkit.command.{Command, CommandSender}
+import org.scalamock.scalatest.MockFactory
+import org.scalatest.wordspec.AnyWordSpec
+
+/**
+ * サブコマンドの分岐とタブ補完を担う [[BranchedExecutor]] の回帰テスト。
+ *
+ * ほぼすべてのコマンドがサブコマンドのルーティングにこのExecutorを利用しているため、
+ * Scala 3移行前に分岐解決とタブ補完候補の挙動を固定する。
+ */
+class BranchedExecutorSpec extends AnyWordSpec with MockFactory {
+
+  private val dummyCommand: Command = new Command("dummy") {
+    override def execute(sender: CommandSender, label: String, args: Array[String]): Boolean =
+      true
+  }
+
+  private def contextWith(args: List[String]): RawCommandContext =
+    RawCommandContext(stub[CommandSender], ExecutedCommand(dummyCommand, "dummy"), args)
+
+  private class RecordingExecutor(tabCandidates: List[String] = Nil)
+      extends ContextualExecutor {
+    var recordedExecutionContext: Option[RawCommandContext] = None
+    var recordedTabContext: Option[RawCommandContext] = None
+
+    override def executionWith(context: RawCommandContext): IO[Unit] =
+      IO { recordedExecutionContext = Some(context) }
+
+    override def tabCandidatesFor(context: RawCommandContext): List[String] = {
+      recordedTabContext = Some(context)
+      tabCandidates
+    }
+  }
+
+  "executionWith" should {
+    "第一引数に対応する分岐を、その引数を除いたコンテキストで実行する" in {
+      val giveBranch = new RecordingExecutor
+      val listBranch = new RecordingExecutor
+      val executor = BranchedExecutor(Map("give" -> giveBranch, "list" -> listBranch))
+
+      executor.executionWith(contextWith(List("give", "player1", "3"))).unsafeRunSync()
+
+      assert(giveBranch.recordedExecutionContext.exists(_.args == List("player1", "3")))
+      assert(listBranch.recordedExecutionContext.isEmpty)
+    }
+
+    "引数が空の場合はwhenArgInsufficientを元のコンテキストで実行する" in {
+      val branch = new RecordingExecutor
+      val insufficientHandler = new RecordingExecutor
+      val executor =
+        BranchedExecutor(Map("give" -> branch), whenArgInsufficient = Some(insufficientHandler))
+
+      val context = contextWith(List())
+      executor.executionWith(context).unsafeRunSync()
+
+      assert(branch.recordedExecutionContext.isEmpty)
+      assert(insufficientHandler.recordedExecutionContext.contains(context))
+    }
+
+    "分岐が見つからない場合はwhenBranchNotFoundを元のコンテキストで実行する" in {
+      val branch = new RecordingExecutor
+      val notFoundHandler = new RecordingExecutor
+      val executor =
+        BranchedExecutor(Map("give" -> branch), whenBranchNotFound = Some(notFoundHandler))
+
+      val context = contextWith(List("unknown", "arg"))
+      executor.executionWith(context).unsafeRunSync()
+
+      assert(branch.recordedExecutionContext.isEmpty)
+      assert(notFoundHandler.recordedExecutionContext.contains(context))
+    }
+
+    "ハンドラがNoneの場合は何も実行しない" in {
+      val branch = new RecordingExecutor
+      val executor = BranchedExecutor(
+        Map("give" -> branch),
+        whenArgInsufficient = None,
+        whenBranchNotFound = None
+      )
+
+      executor.executionWith(contextWith(List())).unsafeRunSync()
+      executor.executionWith(contextWith(List("unknown"))).unsafeRunSync()
+
+      assert(branch.recordedExecutionContext.isEmpty)
+    }
+  }
+
+  "tabCandidatesFor" should {
+    "引数が空の場合、分岐名のソート済みリストを返す" in {
+      val executor = BranchedExecutor(
+        Map(
+          "list" -> new RecordingExecutor,
+          "give" -> new RecordingExecutor,
+          "get" -> new RecordingExecutor
+        )
+      )
+
+      assert(executor.tabCandidatesFor(contextWith(List())) == List("get", "give", "list"))
+    }
+
+    "第一引数に対応する分岐がある場合、その分岐へ残りの引数で委譲する" in {
+      val giveBranch = new RecordingExecutor(tabCandidates = List("player1", "player2"))
+      val executor = BranchedExecutor(Map("give" -> giveBranch))
+
+      val candidates = executor.tabCandidatesFor(contextWith(List("give", "pl")))
+
+      assert(candidates == List("player1", "player2"))
+      assert(giveBranch.recordedTabContext.exists(_.args == List("pl")))
+    }
+
+    "対応する分岐がない場合は空リストを返す" in {
+      val executor = BranchedExecutor(Map("give" -> new RecordingExecutor))
+
+      assert(executor.tabCandidatesFor(contextWith(List("unknown", "x"))) == Nil)
+    }
+  }
+}

--- a/src/test/scala/com/github/unchama/itemmigration/domain/ItemMigrationVersionNumberSpec.scala
+++ b/src/test/scala/com/github/unchama/itemmigration/domain/ItemMigrationVersionNumberSpec.scala
@@ -1,0 +1,62 @@
+package com.github.unchama.itemmigration.domain
+
+import eu.timepit.refined.auto._
+import org.scalatest.wordspec.AnyWordSpec
+
+/**
+ * [[ItemMigrationVersionNumber]] と [[ItemMigrations]] のバージョン順序の回帰テスト。
+ *
+ * `ItemMigrationVersionNumber(1, 0, 0)` のようなリテラル構築は refined.auto._ の
+ * コンパイル時検証に依存しており、Scala 3移行でinlineファクトリへ置き換える方針の
+ * ため、文字列変換・パース・ソート順の現行挙動をここで固定する。
+ */
+class ItemMigrationVersionNumberSpec extends AnyWordSpec {
+
+  "ItemMigrationVersionNumber" should {
+    "versionStringでドット区切りの文字列になる" in {
+      assert(ItemMigrationVersionNumber(1, 0, 0).versionString == "1.0.0")
+      assert(ItemMigrationVersionNumber(0).versionString == "0")
+      assert(ItemMigrationVersionNumber(1, 10, 3).versionString == "1.10.3")
+    }
+
+    "fromStringで非負整数のドット区切りをパースできる" in {
+      assert(
+        ItemMigrationVersionNumber
+          .fromString("1.0.0")
+          .contains(ItemMigrationVersionNumber(1, 0, 0))
+      )
+      assert(ItemMigrationVersionNumber.fromString("0").contains(ItemMigrationVersionNumber(0)))
+    }
+
+    "fromStringとversionStringは往復可能である" in {
+      assert(
+        ItemMigrationVersionNumber.fromString("1.4.0").map(_.versionString).contains("1.4.0")
+      )
+    }
+
+    "fromStringは不正な入力に対してNoneを返す" in {
+      assert(ItemMigrationVersionNumber.fromString("1.-1.0").isEmpty)
+      assert(ItemMigrationVersionNumber.fromString("a.b.c").isEmpty)
+      assert(ItemMigrationVersionNumber.fromString("").isEmpty)
+      assert(ItemMigrationVersionNumber.fromString("1..0").isEmpty)
+    }
+  }
+
+  "ItemMigrations.sorted" should {
+    "バージョン番号を数値として辞書式にソートする" in {
+      def migrationOf(version: ItemMigrationVersionNumber): ItemMigration =
+        ItemMigration(version, identity)
+
+      val v1_0_0 = ItemMigrationVersionNumber(1, 0, 0)
+      val v1_2_0 = ItemMigrationVersionNumber(1, 2, 0)
+      val v1_10_0 = ItemMigrationVersionNumber(1, 10, 0)
+      val v2_0_0 = ItemMigrationVersionNumber(2, 0, 0)
+
+      val sorted =
+        ItemMigrations(IndexedSeq(v2_0_0, v1_10_0, v1_0_0, v1_2_0).map(migrationOf)).sorted
+
+      // 文字列ソートでは "1.10.0" < "1.2.0" になるが、数値ソートでは 1.2.0 < 1.10.0 である
+      assert(sorted.versions == List(v1_0_0, v1_2_0, v1_10_0, v2_0_0))
+    }
+  }
+}

--- a/src/test/scala/com/github/unchama/menuinventory/ChestSlotRefSpec.scala
+++ b/src/test/scala/com/github/unchama/menuinventory/ChestSlotRefSpec.scala
@@ -1,0 +1,33 @@
+package com.github.unchama.menuinventory
+
+import eu.timepit.refined.auto._
+import org.scalatest.wordspec.AnyWordSpec
+
+/**
+ * [[ChestSlotRef]] の回帰テスト。
+ *
+ * `ChestSlotRef(行, 列)` のリテラル呼び出しはリポジトリ内に約300箇所存在し、
+ * refined.auto._ のマクロによるコンパイル時リテラル検証に依存している。
+ * Scala 3移行ではこの検証をinlineファクトリへ置き換える方針のため、
+ * スロットID計算の現行挙動をここで固定する。
+ */
+class ChestSlotRefSpec extends AnyWordSpec {
+
+  "ChestSlotRef.apply" should {
+    "行インデックス×9 + 列インデックスのスロットIDを計算する" in {
+      assert(ChestSlotRef(0, 0) == 0)
+      assert(ChestSlotRef(0, 4) == 4)
+      assert(ChestSlotRef(0, 8) == 8)
+      assert(ChestSlotRef(1, 0) == 9)
+      assert(ChestSlotRef(1, 8) == 17)
+      assert(ChestSlotRef(3, 4) == 31)
+      assert(ChestSlotRef(5, 0) == 45)
+      assert(ChestSlotRef(5, 8) == 53)
+    }
+
+    "6行を超える行インデックスも計算できる（行数の上限は型では制約されない）" in {
+      assert(ChestSlotRef(6, 0) == 54)
+      assert(ChestSlotRef(10, 8) == 98)
+    }
+  }
+}

--- a/src/test/scala/com/github/unchama/seichiassist/menus/paging/PageCounterSpec.scala
+++ b/src/test/scala/com/github/unchama/seichiassist/menus/paging/PageCounterSpec.scala
@@ -1,0 +1,39 @@
+package com.github.unchama.seichiassist.menus.paging
+
+import eu.timepit.refined.auto._
+import eu.timepit.refined.types.numeric.PosInt
+import org.scalatest.wordspec.AnyWordSpec
+
+/**
+ * [[PageCounter]] の回帰テスト。
+ *
+ * `PosInt(...)` リテラルは `RefinedTypeOps.apply` マクロによるコンパイル時検証に
+ * 依存しており、Scala 3移行ではinlineファクトリへ置き換える方針のため、
+ * ページ数計算の現行挙動をここで固定する。
+ */
+class PageCounterSpec extends AnyWordSpec {
+
+  "PageCounter.totalPage" should {
+    "アイテム数0でも1ページを返す" in {
+      assert(PageCounter.totalPage(0, PosInt(26)) == PosInt(1))
+    }
+
+    "1ページに収まる場合は1ページを返す" in {
+      assert(PageCounter.totalPage(1, PosInt(26)) == PosInt(1))
+      assert(PageCounter.totalPage(26, PosInt(26)) == PosInt(1))
+    }
+
+    "1ページから溢れた分は切り上げる" in {
+      // NicknameShopMenu は26件/ページ、NicknameCombinationMenu は27件/ページで利用している
+      assert(PageCounter.totalPage(27, PosInt(26)) == PosInt(2))
+      assert(PageCounter.totalPage(52, PosInt(26)) == PosInt(2))
+      assert(PageCounter.totalPage(53, PosInt(26)) == PosInt(3))
+      assert(PageCounter.totalPage(27, PosInt(27)) == PosInt(1))
+      assert(PageCounter.totalPage(28, PosInt(27)) == PosInt(2))
+    }
+
+    "1件/ページではアイテム数がそのままページ数になる" in {
+      assert(PageCounter.totalPage(5, PosInt(1)) == PosInt(5))
+    }
+  }
+}


### PR DESCRIPTION
### このPRの変更点と理由:

Scala 3.3 LTS への移行準備（Phase 1）のPRです。テスト追加のみで、本体コードの変更はありません。

**コマンド引数DSLの回帰テスト（32件）**

Scala 3 移行では Shapeless HList による引数型の蓄積を Scala 3 の Tuple へ置き換える設計変更が必要になるため、その前にコマンドDSLの外部から観測できる挙動を固定します。

- **ContextualExecutorBuilderSpec**: 引数パースの宣言順序、余剰引数の `yetToBeParsed` への残留、パース失敗時のエラー通知と実行スキップ、引数不足時の挙動（既定 / `ifArgumentsMissing`）、`refineSenderWithError` による送信者型の絞り込み
- **ParsersSpec**: 全パーサの受理・拒否・境界値挙動。本体コードで実際に使われている3種の refined 型（`Positive`、`NonNegative`、`Interval.Closed[1,64]`）で検証
- **BranchedExecutorSpec**: サブコマンドの分岐解決、引数不足・分岐不明時のハンドラ、タブ補完候補の列挙と委譲

**refinedリテラル構築3定義の回帰テスト（11件）**

Scala 3 版 refined 0.11.4 では `auto._` のコンパイル時リテラル検証が失われます。調査の結果、リテラル refine の95%が3定義（`ChestSlotRef` 306箇所、`ItemMigrationVersionNumber`、`PageCounter` の `PosInt` マクロ）に集中していることが分かったため、移行時にこれらへ inline ファクトリを実装する方針とし、その受け入れ基準となる現行挙動をテストで固定します。

- **ChestSlotRefSpec**: スロットID計算（行×9+列）
- **PageCounterSpec**: ページ数計算（0件時1ページ、端数切り上げ）
- **ItemMigrationVersionNumberSpec**: `versionString`/`fromString` の往復、不正入力の拒否、`ItemMigrations.sorted` の数値ソート順（`1.2.0 < 1.10.0`）

### 補足情報:

テスト作成の過程で判明した現行仕様: `Parsers.closedRangeInt` は refined の述語検証に失敗した場合、引数で指定した失敗エフェクトではなく **refineV の英語エラーメッセージ**（例: `Predicate (-1 < 0) did not fail.`）をそのままプレイヤーへ送ります。回帰テストとしては現行挙動をそのまま固定し、メッセージの改善は移行完了後に別途検討するのが良いと考えています。

ローカル（Temurin JDK 17）で全177テスト、`scalafmtCheckAll`・`scalafix --check` を確認済みです。

🤖 Generated with [Claude Code](https://claude.com/claude-code)