### PR TITLE
ci: CIビルドのdebugログレベル設定を削除

### DIFF
--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -25,8 +25,6 @@ on:
 
 jobs:
   build_check:
-    env:
-      BUILD_ENVIRONMENT_IS_CI_OR_LOCAL: "CI"
     runs-on: ubuntu-24.04
     container: ghcr.io/giganticminecraft/seichiassist-builder-v2:776da10
     steps:

--- a/build.sbt
+++ b/build.sbt
@@ -23,15 +23,6 @@ ThisBuild / semanticdbVersion := scalafixSemanticdb.revision
 // kind-projector 構文を使いたいため
 addCompilerPlugin("org.typelevel" %% "kind-projector" % "0.13.4" cross CrossVersion.full)
 
-// CIビルドで詳細なログを確認するため
-ThisBuild / logLevel := {
-  if (scala.sys.env.get("BUILD_ENVIRONMENT_IS_CI_OR_LOCAL").contains("CI")) {
-    Level.Debug
-  } else {
-    Level.Info
-  }
-}
-
 // テストが落ちた時にスタックトレースを表示するため。
 // ScalaTest のオプションは https://www.scalatest.org/user_guide/using_the_runner を参照のこと。
 Compile / testOptions += Tests.Argument("-oS")


### PR DESCRIPTION
### このPRの変更点と理由:

CI では `BUILD_ENVIRONMENT_IS_CI_OR_LOCAL=CI` により `ThisBuild / logLevel` が `Level.Debug` になっていましたが、debug ログが大量に出力されて build_check ジョブのログが実質読めない状態になっていました（例: [このジョブ](https://github.com/GiganticMinecraft/SeichiAssist/actions/runs/29726922859/job/88302068263)）。

- `build.sbt` の logLevel 分岐を削除し、CI もローカルと同じ既定の Info レベルにします
- この環境変数を読む箇所は他にないため、`build-check.yml` の env 設定もあわせて削除します

### 補足情報:

ローカルでビルド定義のロードを確認済みです。デバッグログが必要になった場合は、一時的に `sbt -debug` を使うか、該当ジョブだけ `--debug` 相当の指定を足すのが良いと思います。

🤖 Generated with [Claude Code](https://claude.com/claude-code)