### PR TITLE
test: ContextCoercionのimplicit解決の回帰テストを追加

### DIFF
--- a/src/test/scala/com/github/unchama/generic/ContextCoercionResolutionSpec.scala
+++ b/src/test/scala/com/github/unchama/generic/ContextCoercionResolutionSpec.scala
@@ -1,0 +1,59 @@
+package com.github.unchama.generic
+
+import cats.effect.{IO, SyncIO}
+import org.scalatest.wordspec.AnyWordSpec
+
+/**
+ * [[ContextCoercion]] の implicit 解決の回帰テスト。
+ *
+ * `ContextCoercion[SyncIO, IO]` には、専用インスタンス
+ * [[ContextCoercion.catsEffectSyncIOToIOCoercion]] と汎用インスタンス
+ * [[ContextCoercion.syncEffectToSync]] の両方が適用可能である。
+ * Scala 2 では特殊化された val が優先されるが、Scala 3 では implicit の
+ * 優先順位規則が変わるため、移行後も同じインスタンスが選択されることを
+ * このテストで検証する（SeichiAssist の DI 配線は G=SyncIO, F=IO で
+ * この解決に依存している）。
+ */
+class ContextCoercionResolutionSpec extends AnyWordSpec {
+
+  "ContextCoercion[SyncIO, IO]の暗黙解決" should {
+    "汎用のsyncEffectToSyncではなく専用のcatsEffectSyncIOToIOCoercionを選択する" in {
+      val resolved = implicitly[ContextCoercion[SyncIO, IO]]
+
+      assert(resolved eq ContextCoercion.catsEffectSyncIOToIOCoercion)
+    }
+
+    "SyncIOの計算を実行せずにIOへ持ち上げ、IOの実行時に副作用が起こる" in {
+      var executed = false
+      val syncIO = SyncIO { executed = true }
+
+      val io = ContextCoercion[SyncIO, IO, Unit](syncIO)
+
+      assert(!executed)
+      io.unsafeRunSync()
+      assert(executed)
+    }
+
+    "値を保ったままIOへ変換する" in {
+      assert(ContextCoercion[SyncIO, IO, Int](SyncIO.pure(42)).unsafeRunSync() == 42)
+    }
+  }
+
+  "ContextCoercion[F, F]の暗黙解決" should {
+    "identityCoercionが解決され、計算を変更しない" in {
+      val io = IO.pure(42)
+
+      assert(implicitly[ContextCoercion[IO, IO]].apply(io).unsafeRunSync() == 42)
+    }
+  }
+
+  "CoercibleComputationのcoerceTo構文" should {
+    "SyncIOの計算をIOへ変換できる" in {
+      import ContextCoercion._
+
+      val syncIO = SyncIO.pure("value")
+
+      assert(syncIO.coerceTo[IO].unsafeRunSync() == "value")
+    }
+  }
+}


### PR DESCRIPTION
### このPRの変更点と理由:

Scala 3.3 LTS への移行準備（Phase 1）のPRです。#2932 の続きで、テスト追加のみです。

`ContextCoercion[SyncIO, IO]` には専用インスタンス `catsEffectSyncIOToIOCoercion`（val）と汎用インスタンス `syncEffectToSync`（`SyncEffect`/`Sync` 制約つき def）の両方が適用可能で、Scala 2 では特殊化された val が優先して選択されます。Scala 3 では implicit の優先順位規則が変わるため、SeichiAssist の DI 配線（G=SyncIO, F=IO）が依存するこの解決結果が移行後も変わらないことを検証できるよう、`eq` によるインスタンス同一性テストで固定します。

あわせて次も検証します：

- SyncIO → IO 変換の遅延実行セマンティクス（IO 実行まで副作用が起こらない）
- `ContextCoercion[F, F]`（identityCoercion）の解決と恒等性
- `coerceTo` 拡張構文

### 補足情報:

`SeichiAssist.scala` の DI 配線全体（implicit 106箇所）は Bukkit サーバーなしでは実行できないため、ユニットテストで固定できるのは implicit 解決の核心部分のみです。配線全体の等価性は Phase 3 の実機QAで確認します（QA項目リストは作成済み）。

ローカル（Temurin JDK 17）で全182テスト、`scalafmtCheckAll`・`scalafix --check` を確認済みです。

🤖 Generated with [Claude Code](https://claude.com/claude-code)