### PR TITLE
build!: Scala 3.3.8へ移行する

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,6 +1,6 @@
 version = 3.11.2
 preset=IntelliJ
-runner.dialect = scala213
+runner.dialect = scala3
 
 maxColumn = 96
 

--- a/build.sbt
+++ b/build.sbt
@@ -209,7 +209,10 @@ lazy val root = (project in file(".")).settings(
   ),
   // sbt-assembly 1.0.0からはTestを明示的にタスクツリーに入れる必要がある
   // cf. https://github.com/sbt/sbt-assembly/pull/432/commits/361224a6202856bc2e572df811d0e6a1f1efda98
-  Compile / assembly / test := (Test / test).value
+  // NOTE: assemblyタスクが参照するのは `assembly / test` スコープである。
+  // 以前は `Compile / assembly / test` に配線されており、assemblyの実行時に
+  // テストが走っていなかった（CIのassemblyだけではテストが実行されない状態だった）。
+  assembly / test := (Test / test).value
 )
 
 // endregion

--- a/build.sbt
+++ b/build.sbt
@@ -93,7 +93,7 @@ val dependenciesToEmbed = Seq(
   "org.slf4j" % "slf4j-jdk14" % "1.7.36",
 
   // type-safety utils
-  "eu.timepit" %% "refined" % "0.11.4",
+  "io.github.iltotore" %% "iron" % "3.3.2",
   "com.beachape" %% "enumeratum" % "1.9.8",
 
   // protobuf

--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,4 @@
 import ResourceFilter.filterResources
-import sbt.Keys.baseDirectory
 
 import java.io._
 
@@ -29,6 +28,7 @@ Compile / testOptions += Tests.Argument("-oS")
 // region 依存関係
 
 resolvers ++= Seq(
+  // ajd4jpのミラーのため
   "jitpack.io" at "https://jitpack.io",
   "maven.sk89q.com" at "https://maven.enginehub.org/repo/",
   "maven.playpro.com" at "https://maven.playpro.com",
@@ -37,9 +37,7 @@ resolvers ++= Seq(
   "repo.maven.apache.org" at "https://repo.maven.apache.org/maven2",
   "hub.spigotmc.org" at "https://hub.spigotmc.org/nexus/content/repositories/snapshots",
   "oss.sonatype.org" at "https://oss.sonatype.org/content/repositories/snapshots",
-  "repo.phoenix616.dev" at "https://repo.phoenix616.dev", // authlibのための
-  // ajd4jpのミラーのため
-  "jitpack.io" at "https://jitpack.io"
+  "repo.phoenix616.dev" at "https://repo.phoenix616.dev" // authlibのため
 )
 
 val providedDependencies = Seq(
@@ -52,11 +50,6 @@ val providedDependencies = Seq(
   "net.coreprotect" % "coreprotect" % "21.3",
   "com.mojang" % "authlib" % "6.0.59"
 ).map(_ % "provided")
-
-// NOTE(scala3): src/scalafix配下のカスタムルール2つ（.scalafix.confにもCIにも未参照）は、
-// scalafix-coreがScala 2.13向けにのみ公開されておりScala 3コンパイラでは
-// コンパイルできないため、Scala 3移行に伴い配線を外している。
-// 再度有効化する場合は、ルールを別プロジェクトに切り出して2.13でクロスビルドする必要がある。
 
 val testDependencies = Seq(
   "org.scalamock" %% "scalamock" % "6.2.0",
@@ -186,7 +179,10 @@ lazy val root = (project in file(".")).settings(
   name := "SeichiAssist",
   assembly / assemblyOutputPath := baseDirectory.value / "target" / "build" / "SeichiAssist.jar",
   libraryDependencies := providedDependencies ++ testDependencies ++ dependenciesToEmbed,
-  // src/scalafix配下のカスタムルールのコンパイルを無効化する（依存関係セクションのNOTE参照）
+  // src/scalafix配下のカスタムルール2つ（.scalafix.confにもCIにも未参照）のコンパイルを
+  // 無効化する。scalafix-coreはScala 2.13向けにのみ公開されており、Scala 3コンパイラでは
+  // コンパイルできない。再度有効化する場合は、ルールを別プロジェクトへ切り出して
+  // 2.13でクロスビルドする必要がある。
   ScalafixConfig / sources := Nil,
   excludeDependencies := Seq(ExclusionRule(organization = "org.bukkit", name = "bukkit")),
   unmanagedBase := baseDirectory.value / "localDependencies",
@@ -212,11 +208,9 @@ lazy val root = (project in file(".")).settings(
       )
       .inAll
   ),
-  // sbt-assembly 1.0.0からはTestを明示的にタスクツリーに入れる必要がある
-  // cf. https://github.com/sbt/sbt-assembly/pull/432/commits/361224a6202856bc2e572df811d0e6a1f1efda98
-  // NOTE: assemblyタスクが参照するのは `assembly / test` スコープである。
-  // 以前は `Compile / assembly / test` に配線されており、assemblyの実行時に
-  // テストが走っていなかった（CIのassemblyだけではテストが実行されない状態だった）。
+  // assemblyの実行時にテストを走らせる（sbt-assembly 1.0.0からはデフォルトで実行されない）。
+  // assemblyタスクが参照するのは `assembly / test` スコープであることに注意。
+  // 誤って `Compile / assembly / test` へ配線するとテストが実行されないままassemblyが成功する。
   assembly / test := (Test / test).value
 )
 

--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ import java.io._
 
 // region 全プロジェクト共通のメタデータ
 
-ThisBuild / scalaVersion := "2.13.18"
+ThisBuild / scalaVersion := "3.3.8"
 // ThisBuild / version はGitHub Actionsによって取得/自動更新される。
 // 次の行は ThisBuild / version := "(\d*)" の形式でなければならない。
 ThisBuild / version := "106"
@@ -13,15 +13,12 @@ ThisBuild / organization := "click.seichi"
 ThisBuild / description := "ギガンティック☆整地鯖の独自要素を司るプラグイン"
 
 // Scalafixが要求するため、semanticdbは有効化する
+// Scala 3ではコンパイラ内蔵の-Xsemanticdbが使われるため、semanticdbVersionの指定は不要
 ThisBuild / semanticdbEnabled := true
-ThisBuild / semanticdbVersion := scalafixSemanticdb.revision
 
 // endregion
 
 // region 雑多な設定
-
-// kind-projector 構文を使いたいため
-addCompilerPlugin("org.typelevel" %% "kind-projector" % "0.13.4" cross CrossVersion.full)
 
 // テストが落ちた時にスタックトレースを表示するため。
 // ScalaTest のオプションは https://www.scalatest.org/user_guide/using_the_runner を参照のこと。
@@ -56,12 +53,10 @@ val providedDependencies = Seq(
   "com.mojang" % "authlib" % "6.0.59"
 ).map(_ % "provided")
 
-val scalafixCoreDep =
-  "ch.epfl.scala" %% "scalafix-core" % _root_
-    .scalafix
-    .sbt
-    .BuildInfo
-    .scalafixVersion % ScalafixConfig
+// NOTE(scala3): src/scalafix配下のカスタムルール2つ（.scalafix.confにもCIにも未参照）は、
+// scalafix-coreがScala 2.13向けにのみ公開されておりScala 3コンパイラでは
+// コンパイルできないため、Scala 3移行に伴い配線を外している。
+// 再度有効化する場合は、ルールを別プロジェクトに切り出して2.13でクロスビルドする必要がある。
 
 val testDependencies = Seq(
   "org.scalamock" %% "scalamock" % "6.2.0",
@@ -180,7 +175,8 @@ unmanagedResources / excludeFilter :=
 // region ScalaPBの設定
 
 Compile / PB.protoSources := Seq(baseDirectory.value / "protocol")
-Compile / PB.targets := Seq(scalapb.gen() -> (Compile / sourceManaged).value / "scalapb")
+Compile / PB.targets :=
+  Seq(scalapb.gen(scala3Sources = true) -> (Compile / sourceManaged).value / "scalapb")
 
 // endregion
 
@@ -189,22 +185,19 @@ Compile / PB.targets := Seq(scalapb.gen() -> (Compile / sourceManaged).value / "
 lazy val root = (project in file(".")).settings(
   name := "SeichiAssist",
   assembly / assemblyOutputPath := baseDirectory.value / "target" / "build" / "SeichiAssist.jar",
-  libraryDependencies := (providedDependencies :+ scalafixCoreDep) ++ testDependencies ++ dependenciesToEmbed,
+  libraryDependencies := providedDependencies ++ testDependencies ++ dependenciesToEmbed,
+  // src/scalafix配下のカスタムルールのコンパイルを無効化する（依存関係セクションのNOTE参照）
+  ScalafixConfig / sources := Nil,
   excludeDependencies := Seq(ExclusionRule(organization = "org.bukkit", name = "bukkit")),
   unmanagedBase := baseDirectory.value / "localDependencies",
   scalacOptions ++= Seq(
-    "-Yprofile-trace",
-    "profile.trace",
     "-encoding",
     "utf8",
     "-unchecked",
-    "-language:higherKinds",
     "-deprecation",
-    "-Xsource:3",
-    "-Xsource-features:case-apply-copy-access",
-    "-Ypatmat-exhaust-depth",
-    "320",
-    "-Ywarn-unused"
+    // enumeratumのfindValuesがマクロでコンパニオンのツリーを参照するため
+    "-Yretain-trees",
+    "-Wunused:all"
   ),
   javacOptions ++= Seq("-encoding", "utf8"),
   assembly / assemblyShadeRules ++= Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -197,7 +197,12 @@ lazy val root = (project in file(".")).settings(
     "-deprecation",
     // enumeratumのfindValuesがマクロでコンパニオンのツリーを参照するため
     "-Yretain-trees",
-    "-Wunused:all"
+    "-Wunused:all",
+    // implicit valの初期化が自分自身を暗黙引数として解決すると、フィールドに
+    // 未初期化のnullが格納される実行時バグになる（例: 匿名クラス内の
+    // `override protected implicit val F: Monad[F] = implicitly`）。
+    // この種の警告は見逃すと危険なため、コンパイルエラーへ昇格させる。
+    "-Wconf:msg=Infinite loop in function body:e"
   ),
   javacOptions ++= Seq("-encoding", "utf8"),
   assembly / assemblyShadeRules ++= Seq(

--- a/src/main/scala/com/github/unchama/buildassist/listener/BlockLineUpTriggerListener.scala
+++ b/src/main/scala/com/github/unchama/buildassist/listener/BlockLineUpTriggerListener.scala
@@ -20,7 +20,7 @@ import scala.util.chaining.scalaUtilChainingOps
 import scala.util.control.Breaks
 
 class BlockLineUpTriggerListener[
-  F[_]: IncrementBuildExpWhenBuiltWithSkill[*[_], Player]: SyncEffect
+  F[_]: [f[_]] =>> IncrementBuildExpWhenBuiltWithSkill[f, Player]: SyncEffect
 ](
   implicit manaApi: ManaApi[IO, SyncIO, Player],
   mineStackAPI: MineStackAPI[IO, Player, ItemStack]

--- a/src/main/scala/com/github/unchama/buildassist/listener/TilingSkillTriggerListener.scala
+++ b/src/main/scala/com/github/unchama/buildassist/listener/TilingSkillTriggerListener.scala
@@ -19,9 +19,9 @@ import org.bukkit.{Location, Material}
 import scala.util.chaining._
 import scala.util.control.Breaks
 
-class TilingSkillTriggerListener[G[_]: ConcurrentEffect, F[
+class TilingSkillTriggerListener[G[_]: ConcurrentEffect, F[_]: [f[
   _
-]: IncrementBuildExpWhenBuiltWithSkill[*[_], Player]: SyncEffect](
+]] =>> IncrementBuildExpWhenBuiltWithSkill[f, Player]: SyncEffect](
   implicit mineStackAPI: MineStackAPI[G, Player, ItemStack]
 ) extends Listener {
 

--- a/src/main/scala/com/github/unchama/buildassist/menu/BlockPlacementSkillMenu.scala
+++ b/src/main/scala/com/github/unchama/buildassist/menu/BlockPlacementSkillMenu.scala
@@ -34,7 +34,7 @@ object BlockPlacementSkillMenu extends Menu {
 
   class Environment(
     implicit val canOpenMainMenu: CanOpen[IO, BuildMainMenu.type],
-    implicit val playerHeadSkinAPI: PlayerHeadSkinAPI[IO, Player]
+    val playerHeadSkinAPI: PlayerHeadSkinAPI[IO, Player]
   )
 
   override val frame: MenuFrame =
@@ -108,7 +108,9 @@ object BlockPlacementSkillMenu extends Menu {
           .lore(
             s"$RESET$AQUA${UNDERLINE}スキルの使用設定: ${if (isSkillEnabled) "ON" else "OFF"}",
             s"$RESET$AQUA${UNDERLINE}スキルの範囲設定: $skillRange×$skillRange",
-            s"$RESET$AQUA${UNDERLINE}MineStack優先設定: ${if (isConsumingMineStack) "ON" else "OFF"}"
+            s"$RESET$AQUA${UNDERLINE}MineStack優先設定: ${
+                if (isConsumingMineStack) "ON" else "OFF"
+              }"
           )
           .build()
 

--- a/src/main/scala/com/github/unchama/buildassist/menu/BuildAssistMenuRouter.scala
+++ b/src/main/scala/com/github/unchama/buildassist/menu/BuildAssistMenuRouter.scala
@@ -12,7 +12,7 @@ import org.bukkit.entity.Player
 import org.bukkit.inventory.ItemStack
 
 trait BuildAssistMenuRouter[F[_]] {
-  implicit val canOpenBuildMainMenu: F CanOpen BuildMainMenu.type
+  implicit def canOpenBuildMainMenu: F CanOpen BuildMainMenu.type
 }
 
 object BuildAssistMenuRouter {

--- a/src/main/scala/com/github/unchama/buildassist/menu/MineStackMassCraftMenu.scala
+++ b/src/main/scala/com/github/unchama/buildassist/menu/MineStackMassCraftMenu.scala
@@ -1,5 +1,7 @@
 package com.github.unchama.buildassist.menu
 
+import io.github.iltotore.iron.autoRefine
+
 import cats.data.{Kleisli, NonEmptyList}
 import cats.effect.IO
 import com.github.unchama.buildassist.BuildAssist

--- a/src/main/scala/com/github/unchama/buildassist/menu/MineStackMassCraftMenu.scala
+++ b/src/main/scala/com/github/unchama/buildassist/menu/MineStackMassCraftMenu.scala
@@ -42,7 +42,7 @@ object MineStackMassCraftMenu {
     implicit val canOpenBuildMainMenu: CanOpen[IO, BuildMainMenu.type],
     val canOpenItself: CanOpen[IO, MineStackMassCraftMenu],
     val mineStackAPI: MineStackAPI[IO, Player, ItemStack],
-    implicit val playerHeadSkinAPI: PlayerHeadSkinAPI[IO, Player]
+    val playerHeadSkinAPI: PlayerHeadSkinAPI[IO, Player]
   )
 
   case class MassCraftRecipe(
@@ -236,7 +236,6 @@ object MineStackMassCraftMenu {
    * `Seq`の`i`番目の`List`には、 メニュー`(i+1)`番目のインベントリ内のスロットへの参照とレシピブロックの組が格納されている。
    */
   val recipeBlocks: Seq[List[(Int, MassCraftRecipeBlock)]] = {
-    import eu.timepit.refined.auto._
 
     val oneToHundred: List[Int] = List(1, 10, 100)
     val oneToThousand: List[Int] = List(1, 10, 100, 1000)
@@ -1310,8 +1309,6 @@ case class MineStackMassCraftMenu(pageNumber: Int = 1) extends Menu {
     import com.github.unchama.menuinventory.syntax._
     MenuFrame(6.chestRows, ColorScheme.purpleBold(s"MineStackブロック一括クラフト$pageNumber"))
   }
-
-  import eu.timepit.refined.auto._
 
   override def computeMenuLayout(
     player: Player

--- a/src/main/scala/com/github/unchama/bungeesemaphoreresponder/bukkit/listeners/BungeeSemaphoreCooperator.scala
+++ b/src/main/scala/com/github/unchama/bungeesemaphoreresponder/bukkit/listeners/BungeeSemaphoreCooperator.scala
@@ -52,7 +52,7 @@ class BungeeSemaphoreCooperator[F[_]: ConcurrentEffect: Timer](
             case Validated.Valid(_) =>
               synchronization.confirmSaveCompletionOf(name)
             case Validated.Invalid(errors) =>
-              synchronization.notifySaveFailureOf(name) >> errors.traverse(error =>
+              synchronization.notifySaveFailureOf(name) >> errors.traverse_(error =>
                 Sync[F].delay {
                   error.printStackTrace()
                 }

--- a/src/main/scala/com/github/unchama/bungeesemaphoreresponder/domain/PlayerDataFinalizer.scala
+++ b/src/main/scala/com/github/unchama/bungeesemaphoreresponder/domain/PlayerDataFinalizer.scala
@@ -27,7 +27,7 @@ trait PlayerDataFinalizer[F[_], Player] {
     PlayerDataFinalizer(player => trans.apply(onQuitOf(player)))
   }
 
-  def coerceContextTo[G[_]: ContextCoercion[F, *[_]]]: PlayerDataFinalizer[G, Player] =
+  def coerceContextTo[G[_]: [g[_]] =>> ContextCoercion[F, g]]: PlayerDataFinalizer[G, Player] =
     transformContext[G](implicitly)
 
 }

--- a/src/main/scala/com/github/unchama/concurrent/RepeatingRoutine.scala
+++ b/src/main/scala/com/github/unchama/concurrent/RepeatingRoutine.scala
@@ -26,7 +26,7 @@ object RepeatingRoutine {
     }
   }
 
-  def foreverMRecovering[F[_]: Timer: MonadError[*[_], Throwable]: ErrorLogger, U, R](
+  def foreverMRecovering[F[_]: Timer: [f[_]] =>> MonadError[f, Throwable]: ErrorLogger, U, R](
     action: F[U]
   )(getIntervalToNextExecution: F[FiniteDuration]): F[R] = {
     val recoveringAction: F[Unit] =
@@ -62,9 +62,10 @@ object RepeatingRoutine {
    *   ループにて保持される状態の型
    * @return
    */
-  def whileDefinedMRecovering[F[_]: MonadError[*[_], Throwable]: Timer: ErrorLogger, State](
-    init: State
-  )(
+  def whileDefinedMRecovering[F[_]: [f[_]] =>> MonadError[
+    f,
+    Throwable
+  ]: Timer: ErrorLogger, State](init: State)(
     action: State => F[Option[State]]
   )(getIntervalToNextExecution: F[FiniteDuration]): F[Unit] = {
     val recoveringAction: State => F[Option[State]] = s =>

--- a/src/main/scala/com/github/unchama/contextualexecutor/Contexts.scala
+++ b/src/main/scala/com/github/unchama/contextualexecutor/Contexts.scala
@@ -1,7 +1,6 @@
 package com.github.unchama.contextualexecutor
 
 import org.bukkit.command.{Command, CommandSender}
-import shapeless.HList
 
 /**
  * コマンドの実行時に使用された[Command]とエイリアスの情報
@@ -27,7 +26,7 @@ case class RawCommandContext(
  *   特殊な処理を行う際にのみ利用されるべきものであり、ほとんどのユースケースでは型安全性が保証されないこのフィールドよりも
  *   [[parsed]]を参照してすでにパースされた値を取り扱うことが好ましい。
  */
-case class PartiallyParsedArgs[+Args <: HList](parsed: Args, yetToBeParsed: List[String])
+case class PartiallyParsedArgs[+Args <: Tuple](parsed: Args, yetToBeParsed: List[String])
 
 /**
  * コマンドの実行時のコマンド引数や実行者などの情報を変換, 加工したデータ.
@@ -39,7 +38,7 @@ case class PartiallyParsedArgs[+Args <: HList](parsed: Args, yetToBeParsed: List
  * @param args
  *   引数情報
  */
-case class ParsedArgCommandContext[+CS <: CommandSender, +Args <: HList](
+case class ParsedArgCommandContext[+CS <: CommandSender, +Args <: Tuple](
   sender: CS,
   command: ExecutedCommand,
   args: PartiallyParsedArgs[Args]

--- a/src/main/scala/com/github/unchama/contextualexecutor/builder/ContextualExecutorBuilder.scala
+++ b/src/main/scala/com/github/unchama/contextualexecutor/builder/ContextualExecutorBuilder.scala
@@ -11,8 +11,6 @@ import com.github.unchama.contextualexecutor.{
 import com.github.unchama.targetedeffect.TargetedEffect
 import com.github.unchama.targetedeffect.commandsender.MessageEffect
 import org.bukkit.command.CommandSender
-import shapeless.ops.hlist.Prepend
-import shapeless.{HList, HNil, :: => HCons}
 
 import scala.reflect.ClassTag
 
@@ -29,8 +27,7 @@ import scala.reflect.ClassTag
  * @param argumentsParser
  *   [RawCommandContext]から[PartiallyParsedArgs]の作成を試みる関数
  */
-// TODO(scala3): HListをTupleに置き換える。Shapelessで実装された同等の操作がネイティブに (`Tuple.Map` などを通じて) サポートされている。
-case class ContextualExecutorBuilder[CS <: CommandSender, HArgs <: HList](
+case class ContextualExecutorBuilder[CS <: CommandSender, HArgs <: Tuple](
   senderTypeValidation: SenderTypeValidation[CS],
   argumentsParser: CommandArgumentsParser[CS, HArgs],
   onMissingArguments: Option[ContextualExecutor] = None
@@ -40,9 +37,9 @@ case class ContextualExecutorBuilder[CS <: CommandSender, HArgs <: HList](
   /**
    * 引数を追加で受け取る。追加された引数は[[HArgs]]の末尾に追加され、新しいContextualExecutionBuilderが返される。
    */
-  def thenParse[LastArg](parserToBeAdded: SingleArgumentParser[LastArg])(
-    implicit prepend: Prepend[HArgs, HCons[LastArg, HNil]]
-  ): ContextualExecutorBuilder[CS, prepend.Out] = {
+  def thenParse[LastArg](
+    parserToBeAdded: SingleArgumentParser[LastArg]
+  ): ContextualExecutorBuilder[CS, Tuple.Append[HArgs, LastArg]] = {
     this.copy(argumentsParser = (sender, rawContext) => {
       val program = for {
         head <- OptionT(this.argumentsParser(sender, rawContext))
@@ -60,7 +57,7 @@ case class ContextualExecutorBuilder[CS <: CommandSender, HArgs <: HList](
           case Right(lastArg) => OptionT.pure[IO](lastArg)
         }
       } yield {
-        val parsedArguments = (head.parsed :+ parsedLastArg)(prepend)
+        val parsedArguments = head.parsed :* parsedLastArg
         PartiallyParsedArgs(parsedArguments, head.yetToBeParsed.tail)
       }
 
@@ -187,14 +184,14 @@ case class ContextualExecutorBuilder[CS <: CommandSender, HArgs <: HList](
 }
 
 object ContextualExecutorBuilder {
-  private def defaultArgumentParser: CommandArgumentsParser[CommandSender, HNil] = {
-    case (_, context) => IO.pure(Some(PartiallyParsedArgs(HNil, context.args)))
+  private def defaultArgumentParser: CommandArgumentsParser[CommandSender, EmptyTuple] = {
+    case (_, context) => IO.pure(Some(PartiallyParsedArgs(EmptyTuple, context.args)))
   }
 
   private val defaultSenderValidation: SenderTypeValidation[CommandSender] = {
     (sender: CommandSender) => IO.pure(Some(sender))
   }
 
-  def beginConfiguration: ContextualExecutorBuilder[CommandSender, HNil] =
+  def beginConfiguration: ContextualExecutorBuilder[CommandSender, EmptyTuple] =
     ContextualExecutorBuilder(defaultSenderValidation, defaultArgumentParser)
 }

--- a/src/main/scala/com/github/unchama/contextualexecutor/builder/Parsers.scala
+++ b/src/main/scala/com/github/unchama/contextualexecutor/builder/Parsers.scala
@@ -4,8 +4,8 @@ import cats.effect.IO
 import com.github.unchama.generic.{CoerceTo, TryInto}
 import com.github.unchama.targetedeffect.TargetedEffect
 import com.github.unchama.targetedeffect.TargetedEffect.emptyEffect
-import eu.timepit.refined.api.Refined
-import eu.timepit.refined.numeric.NonNegative
+import io.github.iltotore.iron.:|
+import io.github.iltotore.iron.constraint.numeric.GreaterEqual
 import org.bukkit.command.CommandSender
 
 import java.time.LocalDate
@@ -20,11 +20,11 @@ object Parsers {
 
   def nonNegativeInteger(
     failureMessage: TargetedEffect[CommandSender] = emptyEffect
-  ): SingleArgumentParser[Int Refined NonNegative] =
-    closedRangeInt[Int Refined NonNegative](0, Int.MaxValue, failureMessage)
+  ): SingleArgumentParser[Int :| GreaterEqual[0]] =
+    closedRangeInt[Int :| GreaterEqual[0]](0, Int.MaxValue, failureMessage)
 
   /**
-   * @tparam X refineされているかもしれない整数型。例: `Int`、[[Refined]][Int, [[eu.timepit.refined.numeric.Positive]]]
+   * @tparam X 制約付きかもしれない整数型。例: `Int`、`Int :| Positive`
    * @return
    *   [smallEnd]より大きいか等しく[largeEnd]より小さいか等しい整数のパーサ
    */

--- a/src/main/scala/com/github/unchama/contextualexecutor/builder/package.scala
+++ b/src/main/scala/com/github/unchama/contextualexecutor/builder/package.scala
@@ -4,7 +4,6 @@ import cats.data.Kleisli
 import cats.effect.IO
 import com.github.unchama.targetedeffect.TargetedEffect
 import org.bukkit.command.CommandSender
-import shapeless.HList
 
 package object builder {
   type Result[+Error, +Success] = Either[Error, Success]
@@ -20,16 +19,16 @@ package object builder {
 
   type SenderTypeValidation[+CS] = CommandSender => IO[Option[CS]]
 
-  type CommandArgumentsParser[-CS, Args <: HList] =
+  type CommandArgumentsParser[-CS, Args <: Tuple] =
     (CS, RawCommandContext) => IO[Option[PartiallyParsedArgs[Args]]]
 
-  type ScopedContextualExecution[CS <: CommandSender, Args <: HList] =
+  type ScopedContextualExecution[CS <: CommandSender, Args <: Tuple] =
     ParsedArgCommandContext[CS, Args] => IO[TargetedEffect[CS]]
 
-  type ExecutionF[F[_], CS <: CommandSender, U, Args <: HList] =
+  type ExecutionF[F[_], CS <: CommandSender, U, Args <: Tuple] =
     ParsedArgCommandContext[CS, Args] => F[U]
 
   // コンテキストから、 CS に対して実行できる作用への関数
-  type ExecutionCSEffect[F[_], CS <: CommandSender, U, Args <: HList] =
+  type ExecutionCSEffect[F[_], CS <: CommandSender, U, Args <: Tuple] =
     ParsedArgCommandContext[CS, Args] => Kleisli[F, CS, U]
 }

--- a/src/main/scala/com/github/unchama/datarepository/KeyedDataRepository.scala
+++ b/src/main/scala/com/github/unchama/datarepository/KeyedDataRepository.scala
@@ -18,8 +18,8 @@ object KeyedDataRepository {
       override def isDefinedAt(x: K): Boolean = f(x).isDefined
     }
 
-  implicit def functor[K]: Functor[KeyedDataRepository[K, *]] =
-    new Functor[KeyedDataRepository[K, *]] {
+  implicit def functor[K]: Functor[[a] =>> KeyedDataRepository[K, a]] =
+    new Functor[[a] =>> KeyedDataRepository[K, a]] {
       override def map[A, B](
         fa: KeyedDataRepository[K, A]
       )(f: A => B): KeyedDataRepository[K, B] = {

--- a/src/main/scala/com/github/unchama/datarepository/bukkit/player/BukkitRepositoryControls.scala
+++ b/src/main/scala/com/github/unchama/datarepository/bukkit/player/BukkitRepositoryControls.scala
@@ -38,7 +38,7 @@ case class BukkitRepositoryControls[F[_], R](
   def map[S](f: R => S): BukkitRepositoryControls[F, S] =
     BukkitRepositoryControls(repository.map(f), initializer, backupProcess, finalizer)
 
-  def coerceFinalizationContextTo[G[_]: ContextCoercion[F, *[_]]]
+  def coerceFinalizationContextTo[G[_]: [g[_]] =>> ContextCoercion[F, g]]
     : BukkitRepositoryControls[G, R] =
     transformFinalizationContext(ContextCoercion.asFunctionK)
 }

--- a/src/main/scala/com/github/unchama/datarepository/definitions/MutexRepositoryDefinition.scala
+++ b/src/main/scala/com/github/unchama/datarepository/definitions/MutexRepositoryDefinition.scala
@@ -7,7 +7,7 @@ import com.github.unchama.generic.effect.concurrent.Mutex
 
 object MutexRepositoryDefinition {
 
-  def over[F[_]: Concurrent, G[_]: Sync: ContextCoercion[*[_], F], Player, R](
+  def over[F[_]: Concurrent, G[_]: Sync: [f[_]] =>> ContextCoercion[f, F], Player, R](
     underlying: RepositoryDefinition.Phased[G, Player, R]
   ): underlying.Self[Mutex[F, G, R]] =
     underlying.flatXmap(r => Mutex.of[F, G, R](r))(_.readLatest)

--- a/src/main/scala/com/github/unchama/datarepository/definitions/SessionMutexRepositoryDefinition.scala
+++ b/src/main/scala/com/github/unchama/datarepository/definitions/SessionMutexRepositoryDefinition.scala
@@ -14,8 +14,8 @@ object SessionMutexRepositoryDefinition {
 
   import cats.implicits._
 
-  def withRepositoryContext[F[_]: ConcurrentEffect, G[_]: Sync: ContextCoercion[
-    *[_],
+  def withRepositoryContext[F[_]: ConcurrentEffect, G[_]: Sync: [f[_]] =>> ContextCoercion[
+    f,
     F
   ], Player]: RepositoryDefinition[G, Player, SessionMutex[F, G]] = {
     RepositoryDefinition

--- a/src/main/scala/com/github/unchama/datarepository/definitions/SignallingRepositoryDefinition.scala
+++ b/src/main/scala/com/github/unchama/datarepository/definitions/SignallingRepositoryDefinition.scala
@@ -17,9 +17,9 @@ object SignallingRepositoryDefinition {
   import FiberAdjoinedRepositoryDefinition.FiberAdjoined
   import cats.implicits._
 
-  def withPublishSink[G[_]: Sync, F[_]: ConcurrentEffect: ContextCoercion[
+  def withPublishSink[G[_]: Sync, F[_]: ConcurrentEffect: [g[_]] =>> ContextCoercion[
     G,
-    *[_]
+    g
   ]: ErrorLogger, Player: HasUuid, T](publishSink: Pipe[F, (Player, T), Unit])(
     definition: RepositoryDefinition.Phased[G, Player, T]
   ): Phased.TwoPhased[G, Player, Ref[G, T] FiberAdjoined F] = {
@@ -48,9 +48,9 @@ object SignallingRepositoryDefinition {
       } { case (ref, fiberPromise) => ref.get.map(_ -> fiberPromise) }
   }
 
-  def withPublishSinkHidden[G[_]: Sync, F[_]: ConcurrentEffect: ContextCoercion[
+  def withPublishSinkHidden[G[_]: Sync, F[_]: ConcurrentEffect: [g[_]] =>> ContextCoercion[
     G,
-    *[_]
+    g
   ]: ErrorLogger, Player: HasUuid, T](publishSink: Pipe[F, (Player, T), Unit])(
     definition: RepositoryDefinition.Phased[G, Player, T]
   ): RepositoryDefinition[G, Player, Ref[G, T]] =

--- a/src/main/scala/com/github/unchama/datarepository/template/initialization/SinglePhasedRepositoryInitialization.scala
+++ b/src/main/scala/com/github/unchama/datarepository/template/initialization/SinglePhasedRepositoryInitialization.scala
@@ -39,8 +39,8 @@ object SinglePhasedRepositoryInitialization {
   import cats.implicits._
 
   implicit def functorInstance[F[_]: Functor]
-    : Functor[SinglePhasedRepositoryInitialization[F, *]] =
-    new Functor[SinglePhasedRepositoryInitialization[F, *]] {
+    : Functor[[a] =>> SinglePhasedRepositoryInitialization[F, a]] =
+    new Functor[[a] =>> SinglePhasedRepositoryInitialization[F, a]] {
       override def map[A, B](fa: SinglePhasedRepositoryInitialization[F, A])(
         f: A => B
       ): SinglePhasedRepositoryInitialization[F, B] =

--- a/src/main/scala/com/github/unchama/datarepository/template/initialization/TwoPhasedRepositoryInitialization.scala
+++ b/src/main/scala/com/github/unchama/datarepository/template/initialization/TwoPhasedRepositoryInitialization.scala
@@ -49,8 +49,8 @@ object TwoPhasedRepositoryInitialization {
   import cats.implicits._
 
   implicit def functorInstance[F[_]: Functor, Player]
-    : Functor[TwoPhasedRepositoryInitialization[F, Player, *]] =
-    new Functor[TwoPhasedRepositoryInitialization[F, Player, *]] {
+    : Functor[[a] =>> TwoPhasedRepositoryInitialization[F, Player, a]] =
+    new Functor[[a] =>> TwoPhasedRepositoryInitialization[F, Player, a]] {
       override def map[A, B](
         fa: TwoPhasedRepositoryInitialization[F, Player, A]
       )(f: A => B): TwoPhasedRepositoryInitialization[F, Player, B] =

--- a/src/main/scala/com/github/unchama/fs2/workaround/fs3/Fs3Channel.scala
+++ b/src/main/scala/com/github/unchama/fs2/workaround/fs3/Fs3Channel.scala
@@ -189,7 +189,7 @@ object Fs3Channel {
             Deferred[F, Unit].flatMap { waiting =>
               state
                 .modify {
-                  case State(values, size, ignorePreviousWaiting @ _, producers, closed) =>
+                  case State(values, size, _ @_, producers, closed) =>
                     if (values.nonEmpty || producers.nonEmpty) {
                       var unblock_ = F.unit
                       var allValues_ = values

--- a/src/main/scala/com/github/unchama/generic/ApplicativeErrorThrowableExtra.scala
+++ b/src/main/scala/com/github/unchama/generic/ApplicativeErrorThrowableExtra.scala
@@ -7,7 +7,7 @@ object ApplicativeErrorThrowableExtra {
 
   import cats.implicits._
 
-  def recoverWithStackTrace[F[_]: ApplicativeError[*[_], Throwable]: ErrorLogger, A](
+  def recoverWithStackTrace[F[_]: [f[_]] =>> ApplicativeError[f, Throwable]: ErrorLogger, A](
     action: F[A]
   )(message: String, recover: => A): F[A] =
     action.handleErrorWith { error => ErrorLogger[F].error(error)(message).as(recover) }

--- a/src/main/scala/com/github/unchama/generic/CoerceTo.scala
+++ b/src/main/scala/com/github/unchama/generic/CoerceTo.scala
@@ -1,6 +1,6 @@
 package com.github.unchama.generic
 
-import eu.timepit.refined.api.Refined
+import io.github.iltotore.iron.:|
 
 /**
  * `From`型の値を`To`型の値に「強制」する方法を提供する。
@@ -26,14 +26,12 @@ object CoerceTo {
     override def coerceTo(from: T): T = from
   }
 
-  implicit def forgetRefinedPredicate[T, Predicate]: CoerceTo[T Refined Predicate, T] =
-    new CoerceTo[T Refined Predicate, T] {
+  implicit def forgetRefinedPredicate[T, Predicate]: CoerceTo[T :| Predicate, T] =
+    new CoerceTo[T :| Predicate, T] {
 
       /**
        * @inheritdoc
        */
-      override def coerceTo(from: Refined[T, Predicate]): T = from match {
-        case Refined(t) => t
-      }
+      override def coerceTo(from: T :| Predicate): T = from
     }
 }

--- a/src/main/scala/com/github/unchama/generic/ContextCoercion.scala
+++ b/src/main/scala/com/github/unchama/generic/ContextCoercion.scala
@@ -43,15 +43,17 @@ object ContextCoercion extends ContextCoercionOps {
   implicit def syncEffectToSync[F[_]: SyncEffect, G[_]: Sync]: ContextCoercion[F, G] = {
     import cats.effect.implicits._
 
-    fromFunctionK(λ[F ~> G] { fa =>
-      Sync[G].delay {
+    fromFunctionK(new FunctionK[F, G] {
+      def apply[A](fa: F[A]): G[A] = Sync[G].delay {
         fa.runSync[SyncIO].unsafeRunSync()
       }
     })
   }
 
   implicit val catsEffectSyncIOToIOCoercion: ContextCoercion[SyncIO, IO] = fromFunctionK {
-    λ[SyncIO ~> IO](_.toIO)
+    new FunctionK[SyncIO, IO] {
+      def apply[A](fa: SyncIO[A]): IO[A] = fa.toIO
+    }
   }
 
 }

--- a/src/main/scala/com/github/unchama/generic/RefDict.scala
+++ b/src/main/scala/com/github/unchama/generic/RefDict.scala
@@ -27,8 +27,8 @@ trait RefDict[F[_], Key, Value] {
 
 object RefDict {
 
-  implicit def contravariantFunctor[F[_], Value]: Contravariant[RefDict[F, *, Value]] =
-    new Contravariant[RefDict[F, *, Value]] {
+  implicit def contravariantFunctor[F[_], Value]: Contravariant[[a] =>> RefDict[F, a, Value]] =
+    new Contravariant[[a] =>> RefDict[F, a, Value]] {
       override def contramap[A, B](fa: RefDict[F, A, Value])(f: B => A): RefDict[F, B, Value] =
         new RefDict[F, B, Value] {
           override def read(key: B): F[Option[Value]] = fa.read(f(key))

--- a/src/main/scala/com/github/unchama/generic/TryInto.scala
+++ b/src/main/scala/com/github/unchama/generic/TryInto.scala
@@ -12,7 +12,8 @@ object TryInto {
   private def fromFunction[F, T, E](fn: F => Either[E, T]): TryInto[F, T, E] =
     (f: F) => fn(f)
 
-  implicit def refineByPredicate[A, P: Validate[A, *]]: TryInto[A, A Refined P, String] =
+  implicit def refineByPredicate[A, P: [a] =>> Validate[A, a]]
+    : TryInto[A, A Refined P, String] =
     fromFunction(refineV(_))
 
   implicit def refl[From, To >: From]: TryInto[From, To, Nothing] =

--- a/src/main/scala/com/github/unchama/generic/TryInto.scala
+++ b/src/main/scala/com/github/unchama/generic/TryInto.scala
@@ -1,7 +1,6 @@
 package com.github.unchama.generic
 
-import eu.timepit.refined.api.{Refined, Validate}
-import eu.timepit.refined.refineV
+import io.github.iltotore.iron.{:|, RuntimeConstraint, refineEither}
 
 // https://www.scala-lang.org/files/archive/spec/2.13/06-expressions.html#sam-conversion
 trait TryInto[From, To, ConversionErr] {
@@ -12,9 +11,10 @@ object TryInto {
   private def fromFunction[F, T, E](fn: F => Either[E, T]): TryInto[F, T, E] =
     (f: F) => fn(f)
 
-  implicit def refineByPredicate[A, P: [a] =>> Validate[A, a]]
-    : TryInto[A, A Refined P, String] =
-    fromFunction(refineV(_))
+  implicit def refineByConstraint[A, P](
+    implicit constraint: RuntimeConstraint[A, P]
+  ): TryInto[A, A :| P, String] =
+    fromFunction(_.refineEither[P])
 
   implicit def refl[From, To >: From]: TryInto[From, To, Nothing] =
     fromFunction(from => Right(from))

--- a/src/main/scala/com/github/unchama/generic/effect/ResourceScope.scala
+++ b/src/main/scala/com/github/unchama/generic/effect/ResourceScope.scala
@@ -94,7 +94,7 @@ object ResourceScope {
    * @tparam R
    *   リソースハンドラの型
    */
-  def unsafeCreate[F[_]: Concurrent, G[_]: Sync: ContextCoercion[*[_], F], R]
+  def unsafeCreate[F[_]: Concurrent, G[_]: Sync: [f[_]] =>> ContextCoercion[f, F], R]
     : ResourceScope[F, G, R] = {
     new MultiDictResourceScope()
   }
@@ -102,7 +102,7 @@ object ResourceScope {
   /**
    * 新たな資源スコープを作成する計算。
    */
-  def create[F[_]: Concurrent, G[_]: Sync: ContextCoercion[*[_], F], R]
+  def create[F[_]: Concurrent, G[_]: Sync: [f[_]] =>> ContextCoercion[f, F], R]
     : F[ResourceScope[F, G, R]] = {
     Concurrent[F].delay(unsafeCreate[F, G, R])
   }
@@ -117,8 +117,10 @@ object ResourceScope {
    * @tparam R
    *   リソースハンドラの型
    */
-  def unsafeCreateSingletonScope[F[_]: Concurrent, G[_]: Sync: ContextCoercion[*[_], F], R]
-    : SingleResourceScope[F, G, R] = new SingleResourceScope()
+  def unsafeCreateSingletonScope[F[_]: Concurrent, G[_]: Sync: [f[_]] =>> ContextCoercion[
+    f,
+    F
+  ], R]: SingleResourceScope[F, G, R] = new SingleResourceScope()
 
   /**
    * `ResourceScope` の標準的な実装。
@@ -184,7 +186,7 @@ object ResourceScope {
   class SingleResourceScope[F[_]: Concurrent, G[_], ResourceHandler] private[ResourceScope] (
     implicit override val DataAccessContext: Sync[G],
     contextCoercion: ContextCoercion[G, F]
-  ) extends ResourceScope[OptionT[F, *], G, ResourceHandler] {
+  ) extends ResourceScope[[a] =>> OptionT[F, a], G, ResourceHandler] {
 
     type OptionF[a] = OptionT[F, a]
 

--- a/src/main/scala/com/github/unchama/generic/effect/concurrent/AsymmetricSignallingRef.scala
+++ b/src/main/scala/com/github/unchama/generic/effect/concurrent/AsymmetricSignallingRef.scala
@@ -58,7 +58,7 @@ object AsymmetricSignallingRef {
   /**
    * 指定された値で初期化された[[AsymmetricSignallingRef]]を作成する作用。
    */
-  def apply[G[_]: Sync, F[_]: ConcurrentEffect: ContextCoercion[G, *[_]], A](
+  def apply[G[_]: Sync, F[_]: ConcurrentEffect: [g[_]] =>> ContextCoercion[G, g], A](
     initial: A
   ): G[AsymmetricSignallingRef[G, F, A]] = in[G, G, F, A](initial)
 
@@ -67,7 +67,7 @@ object AsymmetricSignallingRef {
    *
    * [[apply]] とほぼ等価であるが、状態の作成を別の作用型の中で行う。
    */
-  def in[H[_]: Sync, G[_]: Sync, F[_]: ConcurrentEffect: ContextCoercion[G, *[_]], A](
+  def in[H[_]: Sync, G[_]: Sync, F[_]: ConcurrentEffect: [g[_]] =>> ContextCoercion[G, g], A](
     initial: A
   ): H[AsymmetricSignallingRef[G, F, A]] = {
     val initialState = TimeStamped(new Token, new Token, initial)

--- a/src/main/scala/com/github/unchama/generic/effect/concurrent/Mutex.scala
+++ b/src/main/scala/com/github/unchama/generic/effect/concurrent/Mutex.scala
@@ -4,11 +4,10 @@ import cats.effect.concurrent.{MVar, MVar2, Ref}
 import cats.effect.{Bracket, Concurrent, ExitCase, Sync}
 import com.github.unchama.generic.ContextCoercion
 
-final class Mutex[
-  MutexContext[_],
-  ReadContext[_]: ContextCoercion[*[_], MutexContext],
-  A
-] private (mVar: MVar2[MutexContext, A], previous: Ref[ReadContext, A])(
+final class Mutex[MutexContext[_], ReadContext[_]: [f[_]] =>> ContextCoercion[
+  f,
+  MutexContext
+], A] private (mVar: MVar2[MutexContext, A], previous: Ref[ReadContext, A])(
   implicit fBracket: Bracket[MutexContext, Throwable]
 ) {
 
@@ -62,7 +61,7 @@ object Mutex {
 
   import cats.implicits._
 
-  def of[F[_]: Concurrent, G[_]: Sync: ContextCoercion[*[_], F], A](
+  def of[F[_]: Concurrent, G[_]: Sync: [f[_]] =>> ContextCoercion[f, F], A](
     initial: A
   ): G[Mutex[F, G, A]] = {
     for {

--- a/src/main/scala/com/github/unchama/generic/effect/concurrent/SessionMutex.scala
+++ b/src/main/scala/com/github/unchama/generic/effect/concurrent/SessionMutex.scala
@@ -37,7 +37,8 @@ object SessionMutex {
 
   import cats.implicits._
 
-  def newIn[F[_]: Concurrent, G[_]: Sync: ContextCoercion[*[_], F]]: G[SessionMutex[F, G]] =
+  def newIn[F[_]: Concurrent, G[_]: Sync: [f[_]] =>> ContextCoercion[f, F]]
+    : G[SessionMutex[F, G]] =
     for {
       mutex <- Mutex.of[F, G, TryableFiber[F, Unit]](TryableFiber.unit[F])
     } yield new SessionMutex(mutex)

--- a/src/main/scala/com/github/unchama/generic/tag/tag.scala
+++ b/src/main/scala/com/github/unchama/generic/tag/tag.scala
@@ -19,7 +19,7 @@ package com.github.unchama.generic.tag
  */
 
 object tag {
-  type @@[+T, U] = T with Tagged[U]
+  type @@[+T, U] = T & Tagged[U]
 
   def apply[U] = new Tagger[U]
 

--- a/src/main/scala/com/github/unchama/generic/tag/tag.scala
+++ b/src/main/scala/com/github/unchama/generic/tag/tag.scala
@@ -19,14 +19,23 @@ package com.github.unchama.generic.tag
  */
 
 object tag {
-  type @@[+T, U] = T & Tagged[U]
+
+  /**
+   * `T` に幽霊型 `U` を付与したタグ付き型。`T @@ U <: T` であり、実行時表現は `T` そのもの。
+   *
+   * NOTE(scala3): Scala 2時代はShapeless由来の交差型 `T with Tagged[U]` と
+   * `asInstanceOf` によるエンコーディングだったが、Scala 3では交差型の消去規則が
+   * 異なり、フィールドのJVM型が `Tagged` 側へ消去されて格納時に
+   * ClassCastException を起こす（実際に PluginExecutionContexts の初期化が
+   * ExceptionInInitializerError でプラグインのロードを失敗させた）。
+   * このため、消去が `T` になる上限境界付き opaque type へ変更した。
+   */
+  opaque type @@[+T, U] <: T = T
 
   def apply[U] = new Tagger[U]
 
-  trait Tagged[U]
-
   class Tagger[U] {
-    def apply[T](t: T): T @@ U = t.asInstanceOf[T @@ U]
+    def apply[T](t: T): T @@ U = t
   }
 
 }

--- a/src/main/scala/com/github/unchama/itemmigration/domain/ItemMigrationVersionNumber.scala
+++ b/src/main/scala/com/github/unchama/itemmigration/domain/ItemMigrationVersionNumber.scala
@@ -15,6 +15,8 @@ object ItemMigrationVersionNumber {
   import eu.timepit.refined.api.Refined
   import eu.timepit.refined.numeric.NonNegative
 
+  import scala.quoted.{Expr, Quotes, Varargs}
+
   def apply(
     versionHead: ItemMigrationVersionComponent,
     versionRest: ItemMigrationVersionComponent*
@@ -22,24 +24,44 @@ object ItemMigrationVersionNumber {
     ItemMigrationVersionNumber(NonEmptyList.of(versionHead, versionRest: _*))
   }
 
-  // 以下のinlineオーバーロードは、Scala 2でrefined.auto._のマクロが担っていた
-  // バージョン成分リテラルのコンパイル時検証を置き換えるもの。
-  // 成分が非負リテラルでなければコンパイルエラーになる。
+  /**
+   * バージョン成分の整数リテラル列から [[ItemMigrationVersionNumber]] を構築する。
+   *
+   * 成分数は任意（1つ以上）で、Scala 2時代にrefined.auto._のマクロと可変長引数の
+   * 組み合わせで可能だった構築（`ItemMigrationVersionNumber(1, 0)` 等）と同じ形を
+   * 受け入れる。各成分が非負の整数リテラルであることはコンパイル時に検証される。
+   */
+  inline def apply(inline components: Int*): ItemMigrationVersionNumber =
+    ${ literalApplyImpl('components) }
 
-  inline def apply(inline v1: Int): ItemMigrationVersionNumber =
-    inline if (v1 >= 0)
-      ItemMigrationVersionNumber(NonEmptyList.of(Refined.unsafeApply(v1)))
-    else
-      scala.compiletime.error("バージョン成分は非負のリテラルでなければならない")
+  private def literalApplyImpl(
+    components: Expr[Seq[Int]]
+  )(using quotes: Quotes): Expr[ItemMigrationVersionNumber] = {
+    import quotes.reflect.report
 
-  inline def apply(inline v1: Int, inline v2: Int, inline v3: Int): ItemMigrationVersionNumber =
-    inline if (v1 >= 0 && v2 >= 0 && v3 >= 0)
-      ItemMigrationVersionNumber(
-        NonEmptyList
-          .of(Refined.unsafeApply(v1), Refined.unsafeApply(v2), Refined.unsafeApply(v3))
-      )
-    else
-      scala.compiletime.error("バージョン成分は非負のリテラルでなければならない")
+    components match {
+      case Varargs(componentExprs) =>
+        val componentValues = componentExprs.map { componentExpr =>
+          componentExpr
+            .value
+            .getOrElse(report.errorAndAbort("バージョン成分は整数リテラルでなければならない", componentExpr))
+        }
+
+        if (componentValues.isEmpty)
+          report.errorAndAbort("バージョン成分は1つ以上指定しなければならない")
+
+        if (componentValues.exists(_ < 0))
+          report.errorAndAbort("バージョン成分は非負のリテラルでなければならない")
+
+        val componentList = Expr.ofList(componentValues.toList.map { value =>
+          '{ Refined.unsafeApply[Int, NonNegative](${ Expr(value) }) }
+        })
+
+        '{ ItemMigrationVersionNumber(NonEmptyList.fromListUnsafe($componentList)) }
+      case _ =>
+        report.errorAndAbort("バージョン成分はリテラルの列でなければならない")
+    }
+  }
 
   def fromString(string: String): Option[ItemMigrationVersionNumber] =
     string

--- a/src/main/scala/com/github/unchama/itemmigration/domain/ItemMigrationVersionNumber.scala
+++ b/src/main/scala/com/github/unchama/itemmigration/domain/ItemMigrationVersionNumber.scala
@@ -12,6 +12,7 @@ object ItemMigrationVersionNumber {
 
   import cats.implicits._
   import eu.timepit.refined._
+  import eu.timepit.refined.api.Refined
   import eu.timepit.refined.numeric.NonNegative
 
   def apply(
@@ -20,6 +21,25 @@ object ItemMigrationVersionNumber {
   ): ItemMigrationVersionNumber = {
     ItemMigrationVersionNumber(NonEmptyList.of(versionHead, versionRest: _*))
   }
+
+  // 以下のinlineオーバーロードは、Scala 2でrefined.auto._のマクロが担っていた
+  // バージョン成分リテラルのコンパイル時検証を置き換えるもの。
+  // 成分が非負リテラルでなければコンパイルエラーになる。
+
+  inline def apply(inline v1: Int): ItemMigrationVersionNumber =
+    inline if (v1 >= 0)
+      ItemMigrationVersionNumber(NonEmptyList.of(Refined.unsafeApply(v1)))
+    else
+      scala.compiletime.error("バージョン成分は非負のリテラルでなければならない")
+
+  inline def apply(inline v1: Int, inline v2: Int, inline v3: Int): ItemMigrationVersionNumber =
+    inline if (v1 >= 0 && v2 >= 0 && v3 >= 0)
+      ItemMigrationVersionNumber(
+        NonEmptyList
+          .of(Refined.unsafeApply(v1), Refined.unsafeApply(v2), Refined.unsafeApply(v3))
+      )
+    else
+      scala.compiletime.error("バージョン成分は非負のリテラルでなければならない")
 
   def fromString(string: String): Option[ItemMigrationVersionNumber] =
     string

--- a/src/main/scala/com/github/unchama/itemmigration/domain/ItemMigrationVersionNumber.scala
+++ b/src/main/scala/com/github/unchama/itemmigration/domain/ItemMigrationVersionNumber.scala
@@ -4,17 +4,22 @@ import cats.data.NonEmptyList
 
 case class ItemMigrationVersionNumber(components: NonEmptyList[ItemMigrationVersionComponent]) {
 
-  def versionString: String = components.map(_.value.toString).toList.mkString(".")
+  def versionString: String = components.map(_.toString).toList.mkString(".")
 
 }
 
 object ItemMigrationVersionNumber {
 
   import cats.implicits._
-  import eu.timepit.refined._
-  import eu.timepit.refined.api.Refined
-  import eu.timepit.refined.numeric.NonNegative
+  import io.github.iltotore.iron.constraint.numeric.GreaterEqual
+  import io.github.iltotore.iron.refineEither
 
+  /**
+   * バージョン成分から [[ItemMigrationVersionNumber]] を構築する。
+   *
+   * 成分数は任意（1つ以上）。リテラルを渡した場合、非負であることはIronにより
+   * コンパイル時に検証される（Scala 2時代のrefined.auto._と同じ受け入れ範囲）。
+   */
   def apply(
     versionHead: ItemMigrationVersionComponent,
     versionRest: ItemMigrationVersionComponent*
@@ -22,45 +27,13 @@ object ItemMigrationVersionNumber {
     ItemMigrationVersionNumber(NonEmptyList.of(versionHead, versionRest: _*))
   }
 
-  /**
-   * バージョン成分の整数リテラル列から [[ItemMigrationVersionNumber]] を構築する。
-   *
-   * Scala 2時代はrefined.auto._のマクロと可変長引数の組み合わせにより任意の成分数を
-   * 受け入れていたが、Scala 3移行に際して、リテラル構築で受け入れる成分数は3つまでと
-   * することで合意した（既存のバージョン定義はすべて3成分以下）。
-   * 各成分が非負の整数リテラルであることはコンパイル時に検証される。
-   * 4成分以上が必要になった場合はオーバーロードを追加すること。
-   */
-  inline def apply(inline v1: Int): ItemMigrationVersionNumber =
-    inline if (v1 >= 0)
-      ItemMigrationVersionNumber(NonEmptyList.of(Refined.unsafeApply(v1)))
-    else
-      scala.compiletime.error("バージョン成分は非負のリテラルでなければならない")
-
-  inline def apply(inline v1: Int, inline v2: Int): ItemMigrationVersionNumber =
-    inline if (v1 >= 0 && v2 >= 0)
-      ItemMigrationVersionNumber(
-        NonEmptyList.of(Refined.unsafeApply(v1), Refined.unsafeApply(v2))
-      )
-    else
-      scala.compiletime.error("バージョン成分は非負のリテラルでなければならない")
-
-  inline def apply(inline v1: Int, inline v2: Int, inline v3: Int): ItemMigrationVersionNumber =
-    inline if (v1 >= 0 && v2 >= 0 && v3 >= 0)
-      ItemMigrationVersionNumber(
-        NonEmptyList
-          .of(Refined.unsafeApply(v1), Refined.unsafeApply(v2), Refined.unsafeApply(v3))
-      )
-    else
-      scala.compiletime.error("バージョン成分は非負のリテラルでなければならない")
-
   def fromString(string: String): Option[ItemMigrationVersionNumber] =
     string
       .split('.')
       .toList
       .traverse(_.toIntOption)
       .flatMap { components =>
-        components.traverse(component => refineV[NonNegative](component)).toOption
+        components.traverse(component => component.refineEither[GreaterEqual[0]]).toOption
       }
       .flatMap { componentList =>
         NonEmptyList.fromList(componentList).map(ItemMigrationVersionNumber(_))

--- a/src/main/scala/com/github/unchama/itemmigration/domain/ItemMigrationVersionNumber.scala
+++ b/src/main/scala/com/github/unchama/itemmigration/domain/ItemMigrationVersionNumber.scala
@@ -15,8 +15,6 @@ object ItemMigrationVersionNumber {
   import eu.timepit.refined.api.Refined
   import eu.timepit.refined.numeric.NonNegative
 
-  import scala.quoted.{Expr, Quotes, Varargs}
-
   def apply(
     versionHead: ItemMigrationVersionComponent,
     versionRest: ItemMigrationVersionComponent*
@@ -27,41 +25,34 @@ object ItemMigrationVersionNumber {
   /**
    * バージョン成分の整数リテラル列から [[ItemMigrationVersionNumber]] を構築する。
    *
-   * 成分数は任意（1つ以上）で、Scala 2時代にrefined.auto._のマクロと可変長引数の
-   * 組み合わせで可能だった構築（`ItemMigrationVersionNumber(1, 0)` 等）と同じ形を
-   * 受け入れる。各成分が非負の整数リテラルであることはコンパイル時に検証される。
+   * Scala 2時代はrefined.auto._のマクロと可変長引数の組み合わせにより任意の成分数を
+   * 受け入れていたが、Scala 3移行に際して、リテラル構築で受け入れる成分数は3つまでと
+   * することで合意した（既存のバージョン定義はすべて3成分以下）。
+   * 各成分が非負の整数リテラルであることはコンパイル時に検証される。
+   * 4成分以上が必要になった場合はオーバーロードを追加すること。
    */
-  inline def apply(inline components: Int*): ItemMigrationVersionNumber =
-    ${ literalApplyImpl('components) }
+  inline def apply(inline v1: Int): ItemMigrationVersionNumber =
+    inline if (v1 >= 0)
+      ItemMigrationVersionNumber(NonEmptyList.of(Refined.unsafeApply(v1)))
+    else
+      scala.compiletime.error("バージョン成分は非負のリテラルでなければならない")
 
-  private def literalApplyImpl(
-    components: Expr[Seq[Int]]
-  )(using quotes: Quotes): Expr[ItemMigrationVersionNumber] = {
-    import quotes.reflect.report
+  inline def apply(inline v1: Int, inline v2: Int): ItemMigrationVersionNumber =
+    inline if (v1 >= 0 && v2 >= 0)
+      ItemMigrationVersionNumber(
+        NonEmptyList.of(Refined.unsafeApply(v1), Refined.unsafeApply(v2))
+      )
+    else
+      scala.compiletime.error("バージョン成分は非負のリテラルでなければならない")
 
-    components match {
-      case Varargs(componentExprs) =>
-        val componentValues = componentExprs.map { componentExpr =>
-          componentExpr
-            .value
-            .getOrElse(report.errorAndAbort("バージョン成分は整数リテラルでなければならない", componentExpr))
-        }
-
-        if (componentValues.isEmpty)
-          report.errorAndAbort("バージョン成分は1つ以上指定しなければならない")
-
-        if (componentValues.exists(_ < 0))
-          report.errorAndAbort("バージョン成分は非負のリテラルでなければならない")
-
-        val componentList = Expr.ofList(componentValues.toList.map { value =>
-          '{ Refined.unsafeApply[Int, NonNegative](${ Expr(value) }) }
-        })
-
-        '{ ItemMigrationVersionNumber(NonEmptyList.fromListUnsafe($componentList)) }
-      case _ =>
-        report.errorAndAbort("バージョン成分はリテラルの列でなければならない")
-    }
-  }
+  inline def apply(inline v1: Int, inline v2: Int, inline v3: Int): ItemMigrationVersionNumber =
+    inline if (v1 >= 0 && v2 >= 0 && v3 >= 0)
+      ItemMigrationVersionNumber(
+        NonEmptyList
+          .of(Refined.unsafeApply(v1), Refined.unsafeApply(v2), Refined.unsafeApply(v3))
+      )
+    else
+      scala.compiletime.error("バージョン成分は非負のリテラルでなければならない")
 
   def fromString(string: String): Option[ItemMigrationVersionNumber] =
     string

--- a/src/main/scala/com/github/unchama/itemmigration/domain/ItemMigrations.scala
+++ b/src/main/scala/com/github/unchama/itemmigration/domain/ItemMigrations.scala
@@ -8,7 +8,7 @@ import org.bukkit.inventory.ItemStack
 case class ItemMigrations(migrations: IndexedSeq[ItemMigration]) {
 
   private implicit val versionComponentOrdering: Ordering[ItemMigrationVersionComponent] = {
-    Ordering.by(_.value)
+    Ordering.by[ItemMigrationVersionComponent, Int](component => component)
   }
 
   /**

--- a/src/main/scala/com/github/unchama/itemmigration/domain/package.scala
+++ b/src/main/scala/com/github/unchama/itemmigration/domain/package.scala
@@ -1,11 +1,11 @@
 package com.github.unchama.itemmigration
 
-import eu.timepit.refined.api.Refined
-import eu.timepit.refined.numeric.NonNegative
+import io.github.iltotore.iron.:|
+import io.github.iltotore.iron.constraint.numeric.GreaterEqual
 import org.bukkit.inventory.ItemStack
 
 package object domain {
-  type ItemMigrationVersionComponent = Int Refined NonNegative
+  type ItemMigrationVersionComponent = Int :| GreaterEqual[0]
 
   type ItemStackConversion = ItemStack => ItemStack
 }

--- a/src/main/scala/com/github/unchama/menuinventory/ChestSlotRef.scala
+++ b/src/main/scala/com/github/unchama/menuinventory/ChestSlotRef.scala
@@ -8,7 +8,12 @@ object ChestSlotRef {
   type ChestColumnIndexRef = Int Refined Interval.ClosedOpen[0, 9]
 
   /**
-   * チェストインベントリでのスロットへの参照を計算する
+   * チェストインベントリでのスロットへの参照を計算する。
+   *
+   * 引数はリテラルでなければならず、制約（rowIndexは0以上、columnIndexは0以上9未満）の違反は
+   * コンパイル時に検出される。Scala 2ではrefined.auto._のマクロが担っていたコンパイル時検証を
+   * inline化により置き換えたもの。実行時に検証済みの値から計算する場合は[[fromRefined]]を使う。
+   *
    * @param rowIndex
    *   一番上の行から参照したいスロットを含む行まで移動する行数
    * @param columnIndex
@@ -16,6 +21,15 @@ object ChestSlotRef {
    * @return
    *   `rowIndex`と`columnIndex`により指定されたスロットのスロットid
    */
-  def apply(rowIndex: ChestRowIndexRef, columnIndex: ChestColumnIndexRef): Int =
+  inline def apply(inline rowIndex: Int, inline columnIndex: Int): Int =
+    inline if (rowIndex >= 0 && columnIndex >= 0 && columnIndex < 9)
+      rowIndex * 9 + columnIndex
+    else
+      scala.compiletime.error("ChestSlotRef: rowIndexは0以上、columnIndexは0以上9未満のリテラルでなければならない")
+
+  /**
+   * 実行時に検証済みのrefined値からスロットidを計算する。
+   */
+  def fromRefined(rowIndex: ChestRowIndexRef, columnIndex: ChestColumnIndexRef): Int =
     rowIndex.value * 9 + columnIndex.value
 }

--- a/src/main/scala/com/github/unchama/menuinventory/ChestSlotRef.scala
+++ b/src/main/scala/com/github/unchama/menuinventory/ChestSlotRef.scala
@@ -1,18 +1,17 @@
 package com.github.unchama.menuinventory
 
-import eu.timepit.refined.api.Refined
-import eu.timepit.refined.numeric.{Interval, NonNegative}
+import io.github.iltotore.iron.:|
+import io.github.iltotore.iron.constraint.numeric.{GreaterEqual, Interval}
 
 object ChestSlotRef {
-  type ChestRowIndexRef = Int Refined NonNegative
-  type ChestColumnIndexRef = Int Refined Interval.ClosedOpen[0, 9]
+  type ChestRowIndexRef = Int :| GreaterEqual[0]
+  type ChestColumnIndexRef = Int :| Interval.ClosedOpen[0, 9]
 
   /**
-   * チェストインベントリでのスロットへの参照を計算する。
+   * チェストインベントリでのスロットへの参照を計算する
    *
-   * 引数はリテラルでなければならず、制約（rowIndexは0以上、columnIndexは0以上9未満）の違反は
-   * コンパイル時に検出される。Scala 2ではrefined.auto._のマクロが担っていたコンパイル時検証を
-   * inline化により置き換えたもの。実行時に検証済みの値から計算する場合は[[fromRefined]]を使う。
+   * リテラルを渡した場合、制約（rowIndexは0以上、columnIndexは0以上9未満）の違反は
+   * Ironによりコンパイル時に検出される。実行時に検証済みの値もそのまま渡せる。
    *
    * @param rowIndex
    *   一番上の行から参照したいスロットを含む行まで移動する行数
@@ -21,15 +20,6 @@ object ChestSlotRef {
    * @return
    *   `rowIndex`と`columnIndex`により指定されたスロットのスロットid
    */
-  inline def apply(inline rowIndex: Int, inline columnIndex: Int): Int =
-    inline if (rowIndex >= 0 && columnIndex >= 0 && columnIndex < 9)
-      rowIndex * 9 + columnIndex
-    else
-      scala.compiletime.error("ChestSlotRef: rowIndexは0以上、columnIndexは0以上9未満のリテラルでなければならない")
-
-  /**
-   * 実行時に検証済みのrefined値からスロットidを計算する。
-   */
-  def fromRefined(rowIndex: ChestRowIndexRef, columnIndex: ChestColumnIndexRef): Int =
-    rowIndex.value * 9 + columnIndex.value
+  def apply(rowIndex: ChestRowIndexRef, columnIndex: ChestColumnIndexRef): Int =
+    rowIndex * 9 + columnIndex
 }

--- a/src/main/scala/com/github/unchama/seichiassist/achievement/Nicknames.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/achievement/Nicknames.scala
@@ -285,13 +285,13 @@ object Nicknames {
   val getNicknameFor: AchievementId => Option[NicknamesToBeUnlocked] = Nicknames.map.get
 
   def getHeadPartFor(achievementId: AchievementId): Option[PartialNickname] =
-    getNicknameFor(achievementId).flatMap(_.head())
+    getNicknameFor(achievementId).flatMap(_.head)
 
   def getMiddlePartFor(achievementId: AchievementId): Option[PartialNickname] =
-    getNicknameFor(achievementId).flatMap(_.middle())
+    getNicknameFor(achievementId).flatMap(_.middle)
 
   def getTailPartFor(achievementId: AchievementId): Option[PartialNickname] =
-    getNicknameFor(achievementId).flatMap(_.tail())
+    getNicknameFor(achievementId).flatMap(_.tail)
 
   /**
    * @deprecated
@@ -326,11 +326,11 @@ object Nicknames {
  * この構造で持たれる二つ名は、対応する実績を解除、または対応する二つ名を購入していれば、 二つ名組み合わせ設定で使用できるようになる。
  */
 sealed trait NicknamesToBeUnlocked {
-  def head(): Option[String]
+  def head: Option[String]
 
-  def middle(): Option[String]
+  def middle: Option[String]
 
-  def tail(): Option[String]
+  def tail: Option[String]
 }
 
 case class HeadTail(private val _head: String, private val _tail: String)

--- a/src/main/scala/com/github/unchama/seichiassist/commands/RegionOwnerTransferCommand.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/commands/RegionOwnerTransferCommand.scala
@@ -12,7 +12,6 @@ import com.sk89q.worldguard.protection.regions.ProtectedRegion
 import org.bukkit.Bukkit
 import org.bukkit.command.TabExecutor
 import org.bukkit.entity.Player
-import shapeless.{::, HNil}
 
 object RegionOwnerTransferCommand {
   import com.github.unchama.contextualexecutor.builder.ParserResponse._
@@ -26,7 +25,7 @@ object RegionOwnerTransferCommand {
       }
     }
     .buildWithExecutionCSEffect { context =>
-      val regionName :: newOwner :: HNil = context.args.parsed
+      val (regionName, newOwner) = context.args.parsed
       val sender = context.sender
 
       val region =

--- a/src/main/scala/com/github/unchama/seichiassist/commands/RmpCommand.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/commands/RmpCommand.scala
@@ -49,14 +49,14 @@ object RmpCommand {
 
   private val removeExecutor = argsAndSenderConfiguredBuilder.buildWith { context =>
     val (world, days) = context.args.parsed
-    removeRegions(world, days.value)
+    removeRegions(world, days)
   }
 
   private val listExecutor = argsAndSenderConfiguredBuilder.buildWith { context =>
     val (world, days) = context.args.parsed
 
     IO {
-      getOldRegionsIn(world, days.value).map { removalTargets =>
+      getOldRegionsIn(world, days).map { removalTargets =>
         if (removalTargets.isEmpty) {
           MessageEffect(s"${GREEN}該当Regionは存在しません")
         } else {

--- a/src/main/scala/com/github/unchama/seichiassist/commands/RmpCommand.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/commands/RmpCommand.scala
@@ -17,7 +17,6 @@ import com.sk89q.worldguard.protection.regions.ProtectedRegion
 import org.bukkit.ChatColor._
 import org.bukkit.command.{CommandSender, ConsoleCommandSender, TabExecutor}
 import org.bukkit.{Bukkit, World}
-import shapeless.{::, HNil}
 
 import scala.jdk.CollectionConverters._
 
@@ -49,12 +48,12 @@ object RmpCommand {
     .ifArgumentsMissing(printDescriptionExecutor)
 
   private val removeExecutor = argsAndSenderConfiguredBuilder.buildWith { context =>
-    val (world :: days :: HNil) = context.args.parsed
+    val (world, days) = context.args.parsed
     removeRegions(world, days.value)
   }
 
   private val listExecutor = argsAndSenderConfiguredBuilder.buildWith { context =>
-    val (world :: days :: HNil) = context.args.parsed
+    val (world, days) = context.args.parsed
 
     IO {
       getOldRegionsIn(world, days.value).map { removalTargets =>

--- a/src/main/scala/com/github/unchama/seichiassist/commands/contextual/builder/BuilderTemplates.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/commands/contextual/builder/BuilderTemplates.scala
@@ -3,11 +3,10 @@ package com.github.unchama.seichiassist.commands.contextual.builder
 import com.github.unchama.contextualexecutor.builder.ContextualExecutorBuilder
 import org.bukkit.ChatColor._
 import org.bukkit.entity.Player
-import shapeless.HNil
 
 object BuilderTemplates {
 
-  def playerCommandBuilder: ContextualExecutorBuilder[Player, HNil] =
+  def playerCommandBuilder: ContextualExecutorBuilder[Player, EmptyTuple] =
     ContextualExecutorBuilder
       .beginConfiguration
       .refineSenderWithError[Player](s"${GREEN}このコマンドはゲーム内から実行してください。")

--- a/src/main/scala/com/github/unchama/seichiassist/effects/unfocused/BroadcastEffect.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/effects/unfocused/BroadcastEffect.scala
@@ -15,10 +15,11 @@ object BroadcastEffect {
         players <- IO {
           val players = Bukkit.getOnlinePlayers
 
-          players.synchronized {
+          val snapshot: List[Player] = players.synchronized {
             import scala.jdk.CollectionConverters._
             players.asScala.toList
           }
+          snapshot
         }
         _ <- players.traverse(effect.run)
       } yield ()

--- a/src/main/scala/com/github/unchama/seichiassist/menus/BuildMainMenu.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/menus/BuildMainMenu.scala
@@ -48,7 +48,6 @@ private case class ButtonComputations(player: Player)(
   playerHeadSkinAPI: PlayerHeadSkinAPI[IO, Player]
 ) {
 
-  import BuildMainMenu._
   import com.github.unchama.seichiassist.concurrent.PluginExecutionContexts.layoutPreparationContext
   import player._
 
@@ -408,7 +407,7 @@ object BuildMainMenu extends Menu {
     val ioOnMainThread: OnMinecraftServerThread[IO],
     val canOpenBlockPlacementSkillMenu: CanOpen[IO, BlockPlacementSkillMenu.type],
     val canOpenMassCraftMenu: CanOpen[IO, MineStackMassCraftMenu],
-    implicit val playerHeadSkinAPI: PlayerHeadSkinAPI[IO, Player]
+    val playerHeadSkinAPI: PlayerHeadSkinAPI[IO, Player]
   )
 
   val EMPHASIZE = s"$UNDERLINE$BOLD"

--- a/src/main/scala/com/github/unchama/seichiassist/menus/RegionMenu.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/menus/RegionMenu.scala
@@ -93,8 +93,8 @@ object RegionMenu extends Menu {
               s"${GRAY}と出れば保護設定完了です",
               s"${RED}赤色で別の英文が出た場合",
               s"${GRAY}保護の設定に失敗しています",
-              s"$GRAY・別の保護と被っていないか",
-              s"$GRAY・保護数上限に達していないか",
+              s"${GRAY}・別の保護と被っていないか",
+              s"${GRAY}・保護数上限に達していないか",
               s"${GRAY}確認してください"
             )
           else Seq()

--- a/src/main/scala/com/github/unchama/seichiassist/menus/RegionMenu.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/menus/RegionMenu.scala
@@ -29,7 +29,7 @@ object RegionMenu extends Menu {
 
   class Environment(
     implicit val ioCanOpenGridRegionMenu: IO CanOpen GridRegionMenu.type,
-    implicit val gridRegionAPI: GridRegionAPI[IO, Player, Location, World]
+    val gridRegionAPI: GridRegionAPI[IO, Player, Location, World]
   )
 
   override val frame: MenuFrame = MenuFrame(Right(InventoryType.HOPPER), s"${BLACK}保護メニュー")

--- a/src/main/scala/com/github/unchama/seichiassist/menus/ServerSwitchMenu.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/menus/ServerSwitchMenu.scala
@@ -22,7 +22,6 @@ import org.bukkit.entity.Player
 object ServerSwitchMenu extends Menu {
 
   import enumeratum._
-  import eu.timepit.refined.auto._
 
   /**
    * UI上のサーバを表すオブジェクト.
@@ -74,7 +73,7 @@ object ServerSwitchMenu extends Menu {
 
   class Environment(
     implicit val ioCanOpenStickMenu: IO CanOpen FirstPage.type,
-    implicit val playerHeadSkinAPI: PlayerHeadSkinAPI[IO, Player]
+    val playerHeadSkinAPI: PlayerHeadSkinAPI[IO, Player]
   )
 
   /**

--- a/src/main/scala/com/github/unchama/seichiassist/menus/ServerSwitchMenu.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/menus/ServerSwitchMenu.scala
@@ -1,5 +1,7 @@
 package com.github.unchama.seichiassist.menus
 
+import io.github.iltotore.iron.autoRefine
+
 import cats.effect.IO
 import com.github.unchama.itemstackbuilder.IconItemStackBuilder
 import com.github.unchama.menuinventory.router.CanOpen

--- a/src/main/scala/com/github/unchama/seichiassist/menus/TopLevelRouter.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/menus/TopLevelRouter.scala
@@ -68,13 +68,13 @@ import com.github.unchama.seichiassist.menus.trade.TradeSelector
 
 trait TopLevelRouter[F[_]] {
 
-  implicit val canOpenStickMenu: F CanOpen FirstPage.type
+  implicit def canOpenStickMenu: F CanOpen FirstPage.type
 
-  implicit val canOpenAchievementMenu: F CanOpen AchievementMenu.type
+  implicit def canOpenAchievementMenu: F CanOpen AchievementMenu.type
 
-  implicit val ioCanOpenMineStackMenu: F CanOpen MineStackMainMenu.type
+  implicit def ioCanOpenMineStackMenu: F CanOpen MineStackMainMenu.type
 
-  implicit val ioCanOpenCategorizedMineStackMenu: F CanOpen CategorizedMineStackMenu
+  implicit def ioCanOpenCategorizedMineStackMenu: F CanOpen CategorizedMineStackMenu
 
 }
 

--- a/src/main/scala/com/github/unchama/seichiassist/menus/VoteMenu.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/menus/VoteMenu.scala
@@ -48,7 +48,7 @@ object VoteMenu extends Menu {
     val fairyAPI: FairyAPI[IO, SyncIO, Player],
     val ioCanOpenFirstPage: IO CanOpen FirstPage.type,
     val fairySpeechAPI: FairySpeechAPI[IO, Player],
-    implicit val playerHeadSkinAPI: PlayerHeadSkinAPI[IO, Player]
+    val playerHeadSkinAPI: PlayerHeadSkinAPI[IO, Player]
   )
 
   /**
@@ -64,7 +64,6 @@ object VoteMenu extends Menu {
     player: Player
   )(implicit environment: Environment): IO[MenuSlotLayout] = {
     import environment._
-    import eu.timepit.refined.auto._
     val constantButtons = ConstantButtons(player)
     import constantButtons._
 

--- a/src/main/scala/com/github/unchama/seichiassist/menus/VoteMenu.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/menus/VoteMenu.scala
@@ -1,5 +1,7 @@
 package com.github.unchama.seichiassist.menus
 
+import io.github.iltotore.iron.autoRefine
+
 import cats.data.{Kleisli, NonEmptyList}
 import cats.effect.{ConcurrentEffect, IO, SyncIO}
 import cats.implicits._

--- a/src/main/scala/com/github/unchama/seichiassist/menus/achievement/AchievementCategoryMenu.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/menus/achievement/AchievementCategoryMenu.scala
@@ -27,8 +27,6 @@ import org.bukkit.entity.Player
 
 object AchievementCategoryMenu {
 
-  import eu.timepit.refined.auto._
-
   type AchievementGroupRepr = (AchievementGroup, Material)
 
   val groupsLayoutFor: AchievementCategory => Map[Int, AchievementGroupRepr] = {
@@ -82,7 +80,7 @@ object AchievementCategoryMenu {
   class Environment(
     implicit val ioCanOpenAchievementMainMenu: IO CanOpen AchievementMenu.type,
     val ioCanOpenAchievementGroupMenu: IO CanOpen AchievementGroupMenu,
-    implicit val playerHeadSkinAPI: PlayerHeadSkinAPI[IO, Player]
+    val playerHeadSkinAPI: PlayerHeadSkinAPI[IO, Player]
   )
 
 }
@@ -99,7 +97,6 @@ case class AchievementCategoryMenu(category: AchievementCategory) extends Menu {
     player: Player
   )(implicit environment: Environment): IO[MenuSlotLayout] = {
     import environment._
-    import eu.timepit.refined.auto._
 
     val groupButtons =
       groupsLayoutFor(category).view.mapValues(repr => buttonFor(repr)).toMap

--- a/src/main/scala/com/github/unchama/seichiassist/menus/achievement/AchievementCategoryMenu.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/menus/achievement/AchievementCategoryMenu.scala
@@ -1,5 +1,7 @@
 package com.github.unchama.seichiassist.menus.achievement
 
+import io.github.iltotore.iron.autoRefine
+
 import cats.effect.IO
 import com.github.unchama.itemstackbuilder.{IconItemStackBuilder, SkullItemStackBuilder}
 import com.github.unchama.menuinventory.router.CanOpen

--- a/src/main/scala/com/github/unchama/seichiassist/menus/achievement/AchievementMenu.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/menus/achievement/AchievementMenu.scala
@@ -1,5 +1,7 @@
 package com.github.unchama.seichiassist.menus.achievement
 
+import io.github.iltotore.iron.autoRefine
+
 import cats.effect.IO
 import com.github.unchama.itemstackbuilder.IconItemStackBuilder
 import com.github.unchama.menuinventory.router.CanOpen

--- a/src/main/scala/com/github/unchama/seichiassist/menus/achievement/AchievementMenu.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/menus/achievement/AchievementMenu.scala
@@ -25,7 +25,6 @@ import org.bukkit.{Material, Sound}
 object AchievementMenu extends Menu {
 
   import com.github.unchama.menuinventory.syntax._
-  import eu.timepit.refined.auto._
 
   class Environment(
     implicit val ioCanOpenStickMenu: IO CanOpen FirstPage.type,
@@ -33,7 +32,7 @@ object AchievementMenu extends Menu {
     val ioOnMainThread: OnMinecraftServerThread[IO],
     val voteAPI: VoteAPI[IO, Player],
     val ioCanOpenNickNameMenu: IO CanOpen NickNameMenu.type,
-    implicit val playerHeadSkinAPI: PlayerHeadSkinAPI[IO, Player]
+    val playerHeadSkinAPI: PlayerHeadSkinAPI[IO, Player]
   )
 
   override val frame: MenuFrame = MenuFrame(4.chestRows, s"$DARK_PURPLE${BOLD}実績・二つ名システム")

--- a/src/main/scala/com/github/unchama/seichiassist/menus/achievement/group/AchievementGroupMenu.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/menus/achievement/group/AchievementGroupMenu.scala
@@ -22,7 +22,7 @@ object AchievementGroupMenu {
   class Environment(
     implicit val ioCanOpenGroupMenu: IO CanOpen AchievementGroupMenu,
     val ioCanOpenCategoryMenu: IO CanOpen AchievementCategoryMenu,
-    implicit val playerHeadSkinAPI: PlayerHeadSkinAPI[IO, Player]
+    val playerHeadSkinAPI: PlayerHeadSkinAPI[IO, Player]
   )
 
   val sequentialEntriesIn: AchievementGroup => List[GroupMenuEntry] = CachedFunction {
@@ -109,7 +109,6 @@ case class AchievementGroupMenu(group: AchievementGroup, pageNumber: Int = 1) ex
   )(implicit environment: AchievementGroupMenu.Environment): IO[MenuSlotLayout] = {
     import cats.implicits._
     import environment._
-    import eu.timepit.refined.auto._
 
     def buttonToTransferTo(
       newPageNumber: Int,

--- a/src/main/scala/com/github/unchama/seichiassist/menus/achievement/group/AchievementGroupMenu.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/menus/achievement/group/AchievementGroupMenu.scala
@@ -1,5 +1,7 @@
 package com.github.unchama.seichiassist.menus.achievement.group
 
+import io.github.iltotore.iron.autoRefine
+
 import cats.effect.IO
 import com.github.unchama.generic.CachedFunction
 import com.github.unchama.itemstackbuilder.{SkullItemStackBuilder, SkullOwnerReference}

--- a/src/main/scala/com/github/unchama/seichiassist/menus/gridregion/GridRegionMenu.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/menus/gridregion/GridRegionMenu.scala
@@ -278,8 +278,8 @@ object GridRegionMenu extends Menu {
                 .lore(
                   List(
                     s"$RED${UNDERLINE}以下の原因により保護を作成できません。",
-                    s"$RED・保護の範囲が他の保護と重複している",
-                    s"$RED・保護の作成上限に達している"
+                    s"${RED}・保護の範囲が他の保護と重複している",
+                    s"${RED}・保護の作成上限に達している"
                   )
                 )
                 .build()

--- a/src/main/scala/com/github/unchama/seichiassist/menus/gridregion/GridRegionMenu.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/menus/gridregion/GridRegionMenu.scala
@@ -30,7 +30,7 @@ object GridRegionMenu extends Menu {
 
   class Environment(
     implicit val onMainThread: OnMinecraftServerThread[IO],
-    implicit val layoutPreparationContext: LayoutPreparationContext,
+    val layoutPreparationContext: LayoutPreparationContext,
     val gridRegionAPI: GridRegionAPI[IO, Player, Location, World],
     val ioCanOpenGridTemplateMenu: IO CanOpen GridTemplateMenu.type
   )

--- a/src/main/scala/com/github/unchama/seichiassist/menus/gridregion/GridTemplateMenu.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/menus/gridregion/GridTemplateMenu.scala
@@ -37,9 +37,9 @@ object GridTemplateMenu extends Menu {
 
   class Environment(
     implicit val canOpenGridRegionMenu: IO CanOpen GridRegionMenu.type,
-    implicit val gridRegionAPI: GridRegionAPI[IO, Player, Location, World],
-    implicit val layoutPreparationContext: LayoutPreparationContext,
-    implicit val onMinecraftServerThread: OnMinecraftServerThread[IO]
+    val gridRegionAPI: GridRegionAPI[IO, Player, Location, World],
+    val layoutPreparationContext: LayoutPreparationContext,
+    val onMinecraftServerThread: OnMinecraftServerThread[IO]
   )
 
   override val frame: MenuFrame =

--- a/src/main/scala/com/github/unchama/seichiassist/menus/home/HomeMenu.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/menus/home/HomeMenu.scala
@@ -9,6 +9,7 @@ import com.github.unchama.menuinventory.slot.button.Button
 import com.github.unchama.menuinventory.slot.button.action.LeftClickButtonEffect
 import com.github.unchama.menuinventory.syntax.IntInventorySizeOps
 import com.github.unchama.menuinventory.{ChestSlotRef, Menu, MenuFrame, MenuSlotLayout}
+import io.github.iltotore.iron.autoRefine
 import com.github.unchama.seichiassist.concurrent.PluginExecutionContexts.onMainThread
 import com.github.unchama.seichiassist.menus.CommonButtons
 import com.github.unchama.seichiassist.menus.stickmenu.FirstPage
@@ -47,9 +48,8 @@ case class HomeMenu(pageIndex: Int = 0) extends Menu {
   override def computeMenuLayout(
     player: Player
   )(implicit environment: Environment): IO[MenuSlotLayout] = {
-    import eu.timepit.refined._
-    import eu.timepit.refined.api.Refined
-    import eu.timepit.refined.numeric._
+    import io.github.iltotore.iron.constraint.numeric.Interval
+    import io.github.iltotore.iron.refineEither
 
     val buttonComputations = HomeMenuButtonComputations(player)
     import buttonComputations._
@@ -63,12 +63,13 @@ case class HomeMenu(pageIndex: Int = 0) extends Menu {
     val homePointPart = for {
       homeNumber <- homeNumberRange
     } yield {
-      val columnEither = refineV[Interval.ClosedOpen[0, 9]](homeNumber - 9 * pageIndex - 1)
+      val columnEither =
+        (homeNumber - 9 * pageIndex - 1).refineEither[Interval.ClosedOpen[0, 9]]
       columnEither.fold(
         _ => throw new RuntimeException("This branch should not be reached."),
         column =>
           Map(
-            ChestSlotRef.fromRefined(Refined.unsafeApply(0), column) ->
+            ChestSlotRef(0, column) ->
               ConstantButtons.warpToHomePointButton(homeNumber)
           )
       )
@@ -76,16 +77,17 @@ case class HomeMenu(pageIndex: Int = 0) extends Menu {
 
     // ボタンの構築に副作用がある箇所のメニュー定義
     val dynamicPartComputation = homeNumberRange.toList.flatTraverse { homeNumber =>
-      val columnEither = refineV[Interval.ClosedOpen[0, 9]](homeNumber - 9 * pageIndex - 1)
+      val columnEither =
+        (homeNumber - 9 * pageIndex - 1).refineEither[Interval.ClosedOpen[0, 9]]
       columnEither.fold(
         _ => throw new RuntimeException("This branch should not be reached."),
         column => {
           List(
-            ChestSlotRef.fromRefined(Refined.unsafeApply(1), column) ->
+            ChestSlotRef(1, column) ->
               setHomeNameButton(homeNumber),
-            ChestSlotRef.fromRefined(Refined.unsafeApply(2), column) ->
+            ChestSlotRef(2, column) ->
               buttonComputations.setHomeButton(homeNumber),
-            ChestSlotRef.fromRefined(Refined.unsafeApply(3), column) ->
+            ChestSlotRef(3, column) ->
               buttonComputations.removeHomeButton(homeNumber)
           ).traverse(_.sequence)
         }

--- a/src/main/scala/com/github/unchama/seichiassist/menus/home/HomeMenu.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/menus/home/HomeMenu.scala
@@ -19,7 +19,6 @@ import com.github.unchama.seichiassist.{ManagedWorld, SkullOwners}
 import com.github.unchama.targetedeffect._
 import com.github.unchama.targetedeffect.player.PlayerEffects._
 import com.github.unchama.targetedeffect.player.{CommandEffect, FocusedSoundEffect}
-import eu.timepit.refined.auto._
 import org.bukkit.ChatColor._
 import org.bukkit.entity.Player
 import org.bukkit.{Material, Sound}
@@ -28,12 +27,12 @@ object HomeMenu {
 
   class Environment(
     implicit val ioCanOpenConfirmationMenu: IO CanOpen HomeChangeConfirmationMenu,
-    implicit val ioCanOpenFirstPage: IO CanOpen FirstPage.type,
-    implicit val ioCanOpenHome: IO CanOpen HomeMenu,
+    val ioCanOpenFirstPage: IO CanOpen FirstPage.type,
+    val ioCanOpenHome: IO CanOpen HomeMenu,
     val ioCanOpenHomeRemoveConfirmationMenu: IO CanOpen HomeRemoveConfirmationMenu,
-    implicit val homeReadAPI: HomeReadAPI[IO],
-    implicit val asyncShift: NonServerThreadContextShift[IO],
-    implicit val playerHeadSkinAPI: PlayerHeadSkinAPI[IO, Player]
+    val homeReadAPI: HomeReadAPI[IO],
+    val asyncShift: NonServerThreadContextShift[IO],
+    val playerHeadSkinAPI: PlayerHeadSkinAPI[IO, Player]
   )
 
 }
@@ -49,7 +48,7 @@ case class HomeMenu(pageIndex: Int = 0) extends Menu {
     player: Player
   )(implicit environment: Environment): IO[MenuSlotLayout] = {
     import eu.timepit.refined._
-    import eu.timepit.refined.auto._
+    import eu.timepit.refined.api.Refined
     import eu.timepit.refined.numeric._
 
     val buttonComputations = HomeMenuButtonComputations(player)
@@ -68,7 +67,10 @@ case class HomeMenu(pageIndex: Int = 0) extends Menu {
       columnEither.fold(
         _ => throw new RuntimeException("This branch should not be reached."),
         column =>
-          Map(ChestSlotRef(0, column) -> ConstantButtons.warpToHomePointButton(homeNumber))
+          Map(
+            ChestSlotRef.fromRefined(Refined.unsafeApply(0), column) ->
+              ConstantButtons.warpToHomePointButton(homeNumber)
+          )
       )
     }
 
@@ -79,9 +81,12 @@ case class HomeMenu(pageIndex: Int = 0) extends Menu {
         _ => throw new RuntimeException("This branch should not be reached."),
         column => {
           List(
-            ChestSlotRef(1, column) -> setHomeNameButton(homeNumber),
-            ChestSlotRef(2, column) -> buttonComputations.setHomeButton(homeNumber),
-            ChestSlotRef(3, column) -> buttonComputations.removeHomeButton(homeNumber)
+            ChestSlotRef.fromRefined(Refined.unsafeApply(1), column) ->
+              setHomeNameButton(homeNumber),
+            ChestSlotRef.fromRefined(Refined.unsafeApply(2), column) ->
+              buttonComputations.setHomeButton(homeNumber),
+            ChestSlotRef.fromRefined(Refined.unsafeApply(3), column) ->
+              buttonComputations.removeHomeButton(homeNumber)
           ).traverse(_.sequence)
         }
       )

--- a/src/main/scala/com/github/unchama/seichiassist/menus/minestack/CategorizedMineStackMenu.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/menus/minestack/CategorizedMineStackMenu.scala
@@ -26,8 +26,8 @@ object CategorizedMineStackMenu {
     val ioCanOpenSelectItemColorMenu: IO CanOpen MineStackSelectItemKindMenu,
     val onMainThread: OnMinecraftServerThread[IO],
     val mineStackAPI: MineStackAPI[IO, Player, ItemStack],
-    implicit val gachaPrizeAPI: GachaPrizeAPI[IO, ItemStack, Player],
-    implicit val playerHeadSkinAPI: PlayerHeadSkinAPI[IO, Player]
+    val gachaPrizeAPI: GachaPrizeAPI[IO, ItemStack, Player],
+    val playerHeadSkinAPI: PlayerHeadSkinAPI[IO, Player]
   )
 
 }
@@ -39,7 +39,6 @@ case class CategorizedMineStackMenu(category: MineStackObjectCategory, pageIndex
     extends Menu {
 
   import com.github.unchama.menuinventory.syntax._
-  import eu.timepit.refined.auto._
 
   /**
    * マインスタックオブジェクトボタンを置くセクションの行数

--- a/src/main/scala/com/github/unchama/seichiassist/menus/minestack/CategorizedMineStackMenu.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/menus/minestack/CategorizedMineStackMenu.scala
@@ -1,5 +1,7 @@
 package com.github.unchama.seichiassist.menus.minestack
 
+import io.github.iltotore.iron.autoRefine
+
 import cats.effect.IO
 import com.github.unchama.generic.MapExtra
 import com.github.unchama.itemstackbuilder.{SkullItemStackBuilder, SkullOwnerReference}

--- a/src/main/scala/com/github/unchama/seichiassist/menus/minestack/MineStackMainMenu.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/menus/minestack/MineStackMainMenu.scala
@@ -22,15 +22,14 @@ import org.bukkit.inventory.ItemStack
 object MineStackMainMenu extends Menu {
 
   import com.github.unchama.menuinventory.syntax._
-  import eu.timepit.refined.auto._
 
   class Environment(
     implicit val ioOnMainThread: OnMinecraftServerThread[IO],
-    implicit val ioCanOpenFirstPage: IO CanOpen FirstPage.type,
-    implicit val ioCanOpenCategorizedMineStackMenu: IO CanOpen CategorizedMineStackMenu,
-    implicit val gachaPrizeAPI: GachaPrizeAPI[IO, ItemStack, Player],
-    implicit val mineStackAPI: MineStackAPI[IO, Player, ItemStack],
-    implicit val playerHeadSkinAPI: PlayerHeadSkinAPI[IO, Player]
+    val ioCanOpenFirstPage: IO CanOpen FirstPage.type,
+    val ioCanOpenCategorizedMineStackMenu: IO CanOpen CategorizedMineStackMenu,
+    val gachaPrizeAPI: GachaPrizeAPI[IO, ItemStack, Player],
+    val mineStackAPI: MineStackAPI[IO, Player, ItemStack],
+    val playerHeadSkinAPI: PlayerHeadSkinAPI[IO, Player]
   )
 
   override val frame: MenuFrame = MenuFrame(6.chestRows, s"$DARK_PURPLE${BOLD}MineStackメインメニュー")

--- a/src/main/scala/com/github/unchama/seichiassist/menus/minestack/MineStackMainMenu.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/menus/minestack/MineStackMainMenu.scala
@@ -1,5 +1,7 @@
 package com.github.unchama.seichiassist.menus.minestack
 
+import io.github.iltotore.iron.autoRefine
+
 import cats.effect.IO
 import com.github.unchama.itemstackbuilder.IconItemStackBuilder
 import com.github.unchama.menuinventory._

--- a/src/main/scala/com/github/unchama/seichiassist/menus/minestack/MineStackSelectItemKindMenu.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/menus/minestack/MineStackSelectItemKindMenu.scala
@@ -1,5 +1,7 @@
 package com.github.unchama.seichiassist.menus.minestack
 
+import io.github.iltotore.iron.autoRefine
+
 import cats.effect.IO
 import cats.implicits.toTraverseOps
 import com.github.unchama.itemstackbuilder.{SkullItemStackBuilder, SkullOwnerReference}

--- a/src/main/scala/com/github/unchama/seichiassist/menus/minestack/MineStackSelectItemKindMenu.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/menus/minestack/MineStackSelectItemKindMenu.scala
@@ -11,7 +11,6 @@ import com.github.unchama.seichiassist.menus.CommonButtons
 import com.github.unchama.seichiassist.subsystems.gachaprize.GachaPrizeAPI
 import com.github.unchama.seichiassist.subsystems.minestack.MineStackAPI
 import com.github.unchama.seichiassist.subsystems.minestack.domain.minestackobject.MineStackObjectWithKindVariants
-import eu.timepit.refined.auto._
 import org.bukkit.ChatColor.{BOLD, DARK_BLUE}
 import org.bukkit.entity.Player
 import org.bukkit.inventory.ItemStack
@@ -23,10 +22,10 @@ object MineStackSelectItemKindMenu {
 
   class Environment(
     implicit val canOpenCategorizedMineStackMenu: CanOpen[IO, CategorizedMineStackMenu],
-    implicit val canOpenSelectItemKindMenu: CanOpen[IO, MineStackSelectItemKindMenu],
-    implicit val mineStackAPI: MineStackAPI[IO, Player, ItemStack],
-    implicit val gachaPrizeAPI: GachaPrizeAPI[IO, ItemStack, Player],
-    implicit val playerHeadSkinAPI: PlayerHeadSkinAPI[IO, Player]
+    val canOpenSelectItemKindMenu: CanOpen[IO, MineStackSelectItemKindMenu],
+    val mineStackAPI: MineStackAPI[IO, Player, ItemStack],
+    val gachaPrizeAPI: GachaPrizeAPI[IO, ItemStack, Player],
+    val playerHeadSkinAPI: PlayerHeadSkinAPI[IO, Player]
   )
 
 }

--- a/src/main/scala/com/github/unchama/seichiassist/menus/nicknames/NickNameMenu.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/menus/nicknames/NickNameMenu.scala
@@ -1,5 +1,7 @@
 package com.github.unchama.seichiassist.menus.nicknames
 
+import io.github.iltotore.iron.autoRefine
+
 import cats.data.Kleisli
 import cats.effect.IO
 import com.github.unchama.itemstackbuilder.{IconItemStackBuilder, SkullItemStackBuilder}

--- a/src/main/scala/com/github/unchama/seichiassist/menus/nicknames/NickNameMenu.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/menus/nicknames/NickNameMenu.scala
@@ -33,17 +33,15 @@ object NickNameMenu extends Menu {
 
   class Environment(
     implicit val ioCanOpenAchievementMenu: IO CanOpen AchievementMenu.type,
-    implicit val layoutPreparationContext: LayoutPreparationContext,
-    implicit val onMinecraftServerThread: OnMinecraftServerThread[IO],
-    implicit val voteAPI: VoteAPI[IO, Player],
-    implicit val playerHeadSkinAPI: PlayerHeadSkinAPI[IO, Player],
-    implicit val ioCanOpenNicknameCombinationMenu: IO CanOpen NicknameCombinationMenu,
-    implicit val ioCanOpenNicknameShopMenu: IO CanOpen NicknameShopMenu
+    val layoutPreparationContext: LayoutPreparationContext,
+    val onMinecraftServerThread: OnMinecraftServerThread[IO],
+    val voteAPI: VoteAPI[IO, Player],
+    val playerHeadSkinAPI: PlayerHeadSkinAPI[IO, Player],
+    val ioCanOpenNicknameCombinationMenu: IO CanOpen NicknameCombinationMenu,
+    val ioCanOpenNicknameShopMenu: IO CanOpen NicknameShopMenu
   )
 
   override val frame: MenuFrame = MenuFrame(4.chestRows, s"$DARK_PURPLE${BOLD}二つ名組み合わせシステム")
-
-  import eu.timepit.refined.auto._
 
   override def computeMenuLayout(
     player: Player

--- a/src/main/scala/com/github/unchama/seichiassist/menus/nicknames/NicknameCombinationMenu.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/menus/nicknames/NicknameCombinationMenu.scala
@@ -122,13 +122,12 @@ case class NicknameCombinationMenu(pageIndex: Int = 0, nicknamePart: NicknamePar
           }
       }
 
-    import eu.timepit.refined.auto._
-    import eu.timepit.refined.numeric.GreaterEqual
-    import eu.timepit.refined._
+    import io.github.iltotore.iron.constraint.numeric.GreaterEqual
+    import io.github.iltotore.iron.{autoRefine, refineUnsafe}
 
     // NOTE: `length` 呼び出して 0 を下回ることはない
     val totalItems =
-      refineV[GreaterEqual[0]].unsafeFrom(liftedArchivementId.length)
+      (liftedArchivementId.length).refineUnsafe[GreaterEqual[0]]
 
     val totalNumberOfPages = PageCounter.totalPage(totalItems, 27)
 

--- a/src/main/scala/com/github/unchama/seichiassist/menus/nicknames/NicknameCombinationMenu.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/menus/nicknames/NicknameCombinationMenu.scala
@@ -35,8 +35,8 @@ object NicknameCombinationMenu {
 
   class Environment(
     implicit val playerHeadSkinAPI: PlayerHeadSkinAPI[IO, Player],
-    implicit val ioCanOpenNicknameCombinationMenu: IO CanOpen NicknameCombinationMenu,
-    implicit val ioCanOpenNicknameMenu: IO CanOpen NickNameMenu.type
+    val ioCanOpenNicknameCombinationMenu: IO CanOpen NicknameCombinationMenu,
+    val ioCanOpenNicknameMenu: IO CanOpen NickNameMenu.type
   )
 
   sealed trait NicknamePart {

--- a/src/main/scala/com/github/unchama/seichiassist/menus/nicknames/NicknameShopMenu.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/menus/nicknames/NicknameShopMenu.scala
@@ -59,9 +59,8 @@ case class NicknameShopMenu(val pageIndex: Int = 0) extends Menu {
     val nicknameShopMenuButtons = NicknameShopMenuButtons(player)
 
     import nicknameShopMenuButtons._
-    import eu.timepit.refined.auto._
-    import eu.timepit.refined.numeric.GreaterEqual
-    import eu.timepit.refined._
+    import io.github.iltotore.iron.constraint.numeric.GreaterEqual
+    import io.github.iltotore.iron.{autoRefine, refineUnsafe}
 
     val achievementRanges = Seq(9801 until 9834, 9911 until 9939)
     val achievementIdWithNicknamesToBeUnlocked =
@@ -74,7 +73,7 @@ case class NicknameShopMenu(val pageIndex: Int = 0) extends Menu {
 
     // NOTE: `length` 呼び出して 0 を下回ることはない
     val totalItems =
-      refineV[GreaterEqual[0]].unsafeFrom(achievementIdWithNicknamesToBeUnlocked.length)
+      (achievementIdWithNicknamesToBeUnlocked.length).refineUnsafe[GreaterEqual[0]]
 
     val totalNumberOfPages =
       PageCounter.totalPage(totalItems, 26)

--- a/src/main/scala/com/github/unchama/seichiassist/menus/nicknames/NicknameShopMenu.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/menus/nicknames/NicknameShopMenu.scala
@@ -36,8 +36,8 @@ object NicknameShopMenu {
 
   class Environment(
     implicit val playerHeadSkinAPI: PlayerHeadSkinAPI[IO, Player],
-    implicit val ioCanOpenNicknameShopMenu: IO CanOpen NicknameShopMenu,
-    implicit val ioCanOpenNicknameMenu: IO CanOpen NickNameMenu.type
+    val ioCanOpenNicknameShopMenu: IO CanOpen NicknameShopMenu,
+    val ioCanOpenNicknameMenu: IO CanOpen NickNameMenu.type
   )
 
 }

--- a/src/main/scala/com/github/unchama/seichiassist/menus/paging/PageCounter.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/menus/paging/PageCounter.scala
@@ -6,8 +6,11 @@ import eu.timepit.refined.numeric.GreaterEqual
 import eu.timepit.refined.api.Refined
 
 object PageCounter {
-  def totalPage(totalItems: Int Refined GreaterEqual[0], itemsPerPage: PosInt): PosInt = {
-    if (totalItems.value == 0) return PosInt(1)
+  private def computeTotalPage(
+    totalItems: Int Refined GreaterEqual[0],
+    itemsPerPage: PosInt
+  ): PosInt = {
+    if (totalItems.value == 0) return PosInt.unsafeFrom(1)
 
     val (basePage, rem) = totalItems.value /% itemsPerPage.value
 
@@ -15,4 +18,18 @@ object PageCounter {
 
     PosInt.unsafeFrom(result)
   }
+
+  /**
+   * ページ数を計算する。`itemsPerPage` はリテラルでなければならず、
+   * 正であることはコンパイル時に検証される。
+   * Scala 2ではrefined.auto._のマクロが担っていたコンパイル時検証をinline化により置き換えたもの。
+   */
+  inline def totalPage(
+    totalItems: Int Refined GreaterEqual[0],
+    inline itemsPerPage: Int
+  ): PosInt =
+    inline if (itemsPerPage > 0)
+      computeTotalPage(totalItems, PosInt.unsafeFrom(itemsPerPage))
+    else
+      scala.compiletime.error("PageCounter: itemsPerPageは正のリテラルでなければならない")
 }

--- a/src/main/scala/com/github/unchama/seichiassist/menus/paging/PageCounter.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/menus/paging/PageCounter.scala
@@ -1,35 +1,24 @@
 package com.github.unchama.seichiassist.menus.paging
 
+import io.github.iltotore.iron.constraint.numeric.{GreaterEqual, Positive}
+import io.github.iltotore.iron.{:|, refineUnsafe}
+
 import scala.math.Integral.Implicits._
-import eu.timepit.refined.types.numeric.PosInt
-import eu.timepit.refined.numeric.GreaterEqual
-import eu.timepit.refined.api.Refined
 
 object PageCounter {
-  private def computeTotalPage(
-    totalItems: Int Refined GreaterEqual[0],
-    itemsPerPage: PosInt
-  ): PosInt = {
-    if (totalItems.value == 0) return PosInt.unsafeFrom(1)
 
-    val (basePage, rem) = totalItems.value /% itemsPerPage.value
+  /**
+   * ページ数を計算する。`itemsPerPage` にリテラルを渡した場合、正であることは
+   * Ironによりコンパイル時に検証される。
+   */
+  def totalPage(totalItems: Int :| GreaterEqual[0], itemsPerPage: Int :| Positive): Int :|
+    Positive = {
+    if (totalItems == 0) return 1.refineUnsafe
+
+    val (basePage, rem) = (totalItems: Int) /% itemsPerPage
 
     val result = if (rem == 0) basePage else basePage + 1
 
-    PosInt.unsafeFrom(result)
+    result.refineUnsafe
   }
-
-  /**
-   * ページ数を計算する。`itemsPerPage` はリテラルでなければならず、
-   * 正であることはコンパイル時に検証される。
-   * Scala 2ではrefined.auto._のマクロが担っていたコンパイル時検証をinline化により置き換えたもの。
-   */
-  inline def totalPage(
-    totalItems: Int Refined GreaterEqual[0],
-    inline itemsPerPage: Int
-  ): PosInt =
-    inline if (itemsPerPage > 0)
-      computeTotalPage(totalItems, PosInt.unsafeFrom(itemsPerPage))
-    else
-      scala.compiletime.error("PageCounter: itemsPerPageは正のリテラルでなければならない")
 }

--- a/src/main/scala/com/github/unchama/seichiassist/menus/ranking/RankingMenu.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/menus/ranking/RankingMenu.scala
@@ -120,7 +120,6 @@ object RankingMenuTemplates {
 // TODO: Rは生のデータ型を想定しているが、何らかのenumを想定することはできるか？
 //       ここにSeichiAmountData等を書きたくない気持ちがある。
 case class RankingMenu[R](template: RankingMenuTemplate[R], pageIndex: Int = 0) extends Menu {
-  import eu.timepit.refined.auto._
   import cats.implicits._
 
   final private val perPage = 45

--- a/src/main/scala/com/github/unchama/seichiassist/menus/ranking/RankingMenu.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/menus/ranking/RankingMenu.scala
@@ -1,5 +1,7 @@
 package com.github.unchama.seichiassist.menus.ranking
 
+import io.github.iltotore.iron.autoRefine
+
 import cats.effect.IO
 import com.github.unchama.concurrent.NonServerThreadContextShift
 import com.github.unchama.itemstackbuilder.{

--- a/src/main/scala/com/github/unchama/seichiassist/menus/ranking/RankingRootMenu.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/menus/ranking/RankingRootMenu.scala
@@ -14,7 +14,6 @@ import com.github.unchama.seichiassist.subsystems.breakcount.domain.SeichiAmount
 import com.github.unchama.seichiassist.subsystems.buildcount.domain.playerdata.BuildAmountData
 import com.github.unchama.seichiassist.subsystems.playerheadskin.PlayerHeadSkinAPI
 import com.github.unchama.seichiassist.subsystems.ranking.domain.values.{LoginTime, VoteCount}
-import eu.timepit.refined.auto._
 import org.bukkit.ChatColor._
 import org.bukkit.Material
 import org.bukkit.entity.Player
@@ -27,7 +26,7 @@ object RankingRootMenu extends Menu {
     val ioCanOpenBuildRankingMenu: IO CanOpen RankingMenu[BuildAmountData],
     val ioCanOpenLoginTimeRankingMenu: IO CanOpen RankingMenu[LoginTime],
     val ioCanOpenVoteCountRankingMenu: IO CanOpen RankingMenu[VoteCount],
-    implicit val playerHeadSkinAPI: PlayerHeadSkinAPI[IO, Player]
+    val playerHeadSkinAPI: PlayerHeadSkinAPI[IO, Player]
   )
 
   override val frame: MenuFrame = MenuFrame(4.chestRows, s"$DARK_PURPLE${BOLD}ランキング")

--- a/src/main/scala/com/github/unchama/seichiassist/menus/ranking/RankingRootMenu.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/menus/ranking/RankingRootMenu.scala
@@ -1,5 +1,7 @@
 package com.github.unchama.seichiassist.menus.ranking
 
+import io.github.iltotore.iron.autoRefine
+
 import cats.effect.IO
 import com.github.unchama.itemstackbuilder.IconItemStackBuilder
 import com.github.unchama.menuinventory.router.CanOpen

--- a/src/main/scala/com/github/unchama/seichiassist/menus/skill/ActiveSkillEffectMenu.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/menus/skill/ActiveSkillEffectMenu.scala
@@ -42,7 +42,7 @@ object ActiveSkillEffectMenu extends Menu {
     val ioOnMainThread: OnMinecraftServerThread[IO],
     val voteAPI: VoteAPI[IO, Player],
     val donateAPI: DonatePremiumPointAPI[IO],
-    implicit val playerHeadSkinAPI: PlayerHeadSkinAPI[IO, Player]
+    val playerHeadSkinAPI: PlayerHeadSkinAPI[IO, Player]
   )
 
   override val frame: MenuFrame = MenuFrame(6.chestRows, s"$DARK_PURPLE${BOLD}整地スキルエフェクト選択")
@@ -263,7 +263,6 @@ object ActiveSkillEffectMenu extends Menu {
     import c._
     import cats.implicits._
     import environment._
-    import eu.timepit.refined.auto._
 
     val computeDynamicPart = {
       List(ChestSlotRef(0, 0) -> effectDataButton) ++ ActiveSkillNormalEffect

--- a/src/main/scala/com/github/unchama/seichiassist/menus/skill/ActiveSkillEffectMenu.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/menus/skill/ActiveSkillEffectMenu.scala
@@ -1,5 +1,7 @@
 package com.github.unchama.seichiassist.menus.skill
 
+import io.github.iltotore.iron.autoRefine
+
 import cats.data.Kleisli
 import cats.effect.IO
 import com.github.unchama.itemstackbuilder.{IconItemStackBuilder, SkullItemStackBuilder}

--- a/src/main/scala/com/github/unchama/seichiassist/menus/skill/ActiveSkillMenu.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/menus/skill/ActiveSkillMenu.scala
@@ -63,7 +63,7 @@ object ActiveSkillMenu extends Menu {
     val ioCanOpenFirstPage: IO CanOpen FirstPage.type,
     val ioOnMainThread: OnMinecraftServerThread[IO],
     val globalNotification: DiscordNotificationAPI[IO],
-    implicit val playerHeadSkinAPI: PlayerHeadSkinAPI[IO, Player]
+    val playerHeadSkinAPI: PlayerHeadSkinAPI[IO, Player]
   )
 
   override val frame: MenuFrame = MenuFrame(5.chestRows, s"$DARK_PURPLE${BOLD}整地スキル選択")
@@ -509,7 +509,6 @@ object ActiveSkillMenu extends Menu {
   )(implicit environment: Environment): IO[MenuSlotLayout] = {
     import cats.implicits._
     import environment._
-    import eu.timepit.refined.auto._
 
     val buttonComputations = new ButtonComputations(player)
     import ConstantButtons._

--- a/src/main/scala/com/github/unchama/seichiassist/menus/skill/ActiveSkillMenu.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/menus/skill/ActiveSkillMenu.scala
@@ -1,5 +1,7 @@
 package com.github.unchama.seichiassist.menus.skill
 
+import io.github.iltotore.iron.autoRefine
+
 import cats.data.Kleisli
 import cats.effect.concurrent.Ref
 import cats.effect.{ConcurrentEffect, IO, SyncIO}

--- a/src/main/scala/com/github/unchama/seichiassist/menus/skill/PassiveSkillMenu.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/menus/skill/PassiveSkillMenu.scala
@@ -1,5 +1,7 @@
 package com.github.unchama.seichiassist.menus.skill
 
+import io.github.iltotore.iron.autoRefine
+
 import cats.effect.{IO, SyncIO}
 import com.github.unchama.itemstackbuilder.IconItemStackBuilder
 import com.github.unchama.menuinventory.router.CanOpen

--- a/src/main/scala/com/github/unchama/seichiassist/menus/skill/PassiveSkillMenu.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/menus/skill/PassiveSkillMenu.scala
@@ -34,10 +34,10 @@ object PassiveSkillMenu extends Menu {
 
   class Environment(
     implicit val breakCountApi: BreakCountAPI[IO, SyncIO, Player],
-    implicit val breakSkillTargetConfigAPI: BreakSkillTargetConfigAPI[IO, Player],
-    implicit val breakSuppressionPreferenceAPI: BreakSuppressionPreferenceAPI[IO, Player],
+    val breakSkillTargetConfigAPI: BreakSkillTargetConfigAPI[IO, Player],
+    val breakSuppressionPreferenceAPI: BreakSuppressionPreferenceAPI[IO, Player],
     val ioCanOpenFirstPage: IO CanOpen FirstPage.type,
-    implicit val playerHeadSkinAPI: PlayerHeadSkinAPI[IO, Player]
+    val playerHeadSkinAPI: PlayerHeadSkinAPI[IO, Player]
   )
 
   /**
@@ -54,7 +54,6 @@ object PassiveSkillMenu extends Menu {
   )(implicit environment: Environment): IO[MenuSlotLayout] = {
     import cats.implicits._
     import environment._
-    import eu.timepit.refined.auto._
 
     val buttonComputations = new ButtonComputations(player)
     import buttonComputations._

--- a/src/main/scala/com/github/unchama/seichiassist/menus/skill/PremiumPointTransactionHistoryMenu.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/menus/skill/PremiumPointTransactionHistoryMenu.scala
@@ -25,7 +25,7 @@ object PremiumPointTransactionHistoryMenu {
     implicit val ioCanOpenActiveSkillEffectMenu: IO CanOpen ActiveSkillEffectMenu.type,
     val ioCanOpenTransactionHistoryMenu: IO CanOpen PremiumPointTransactionHistoryMenu,
     val donateAPI: DonatePremiumPointAPI[IO],
-    implicit val playerHeadSkinAPI: PlayerHeadSkinAPI[IO, Player]
+    val playerHeadSkinAPI: PlayerHeadSkinAPI[IO, Player]
   )
 
 }
@@ -33,7 +33,6 @@ object PremiumPointTransactionHistoryMenu {
 case class PremiumPointTransactionHistoryMenu(pageNumber: Int) extends Menu {
 
   import com.github.unchama.menuinventory.syntax._
-  import eu.timepit.refined.auto._
 
   override type Environment = PremiumPointTransactionHistoryMenu.Environment
   override val frame: MenuFrame = MenuFrame(4.chestRows, s"$BLUE${BOLD}プレミアムエフェクト購入履歴")

--- a/src/main/scala/com/github/unchama/seichiassist/menus/skill/PremiumPointTransactionHistoryMenu.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/menus/skill/PremiumPointTransactionHistoryMenu.scala
@@ -1,5 +1,7 @@
 package com.github.unchama.seichiassist.menus.skill
 
+import io.github.iltotore.iron.autoRefine
+
 import cats.effect.IO
 import com.github.unchama.itemstackbuilder.{
   IconItemStackBuilder,

--- a/src/main/scala/com/github/unchama/seichiassist/menus/stickmenu/FirstPage.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/menus/stickmenu/FirstPage.scala
@@ -79,7 +79,6 @@ object FirstPage extends Menu {
     onMainThread
   }
   import com.github.unchama.targetedeffect.player.PlayerEffects._
-  import eu.timepit.refined.auto._
 
   class Environment(
     implicit val breakCountAPI: BreakCountReadAPI[IO, SyncIO, Player],
@@ -105,7 +104,7 @@ object FirstPage extends Menu {
     val gachaTicketAPI: GachaTicketAPI[IO],
     val voteAPI: VoteAPI[IO, Player],
     val nonServerThreadContextShift: NonServerThreadContextShift[IO],
-    implicit val playerHeadSkinAPI: PlayerHeadSkinAPI[IO, Player]
+    val playerHeadSkinAPI: PlayerHeadSkinAPI[IO, Player]
   )
 
   override val frame: MenuFrame =

--- a/src/main/scala/com/github/unchama/seichiassist/menus/stickmenu/FirstPage.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/menus/stickmenu/FirstPage.scala
@@ -1,5 +1,7 @@
 package com.github.unchama.seichiassist.menus.stickmenu
 
+import io.github.iltotore.iron.autoRefine
+
 import cats.data.Kleisli
 import cats.effect.{IO, SyncIO}
 import com.github.unchama.concurrent.NonServerThreadContextShift

--- a/src/main/scala/com/github/unchama/seichiassist/menus/stickmenu/FirstPage.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/menus/stickmenu/FirstPage.scala
@@ -571,8 +571,8 @@ object FirstPage extends Menu {
       implicit ioCanOpenServerSwitchMenu: IO CanOpen ServerSwitchMenu.type
     ): Button = {
       val buttonLore = List(
-        s"$GRAY・各サバイバルサーバー",
-        s"$GRAY・公共施設サーバー",
+        s"${GRAY}・各サバイバルサーバー",
+        s"${GRAY}・公共施設サーバー",
         s"${GRAY}間を移動する時に使います",
         s"$DARK_RED${UNDERLINE}クリックして開く"
       )
@@ -591,8 +591,8 @@ object FirstPage extends Menu {
 
     val spawnCommandButton: Button = {
       val buttonLore = List(
-        s"$GRAY・整地ワールド間を移動するとき",
-        s"$GRAY・拠点を建築するとき",
+        s"${GRAY}・整地ワールド間を移動するとき",
+        s"${GRAY}・拠点を建築するとき",
         s"$GRAY に使います",
         s"$DARK_RED${UNDERLINE}クリックするとワープします",
         s"${DARK_GRAY}command=>[/spawn]"

--- a/src/main/scala/com/github/unchama/seichiassist/menus/stickmenu/SecondPage.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/menus/stickmenu/SecondPage.scala
@@ -59,7 +59,6 @@ object SecondPage extends Menu {
   import com.github.unchama.targetedeffect._
   import com.github.unchama.targetedeffect.player.PlayerEffects._
   import com.github.unchama.util.InventoryUtil._
-  import eu.timepit.refined.auto._
   import menuinventory.syntax._
 
   class Environment(
@@ -68,7 +67,7 @@ object SecondPage extends Menu {
     val gachaDrawAPI: GachaDrawAPI[IO, Player],
     val gachaPointAPI: GachaPointApi[IO, SyncIO, Player],
     val consumeGachaTicketAPI: ConsumeGachaTicketAPI[IO, Player],
-    implicit val playerHeadSkinAPI: PlayerHeadSkinAPI[IO, Player]
+    val playerHeadSkinAPI: PlayerHeadSkinAPI[IO, Player]
   )
 
   override val frame: MenuFrame =

--- a/src/main/scala/com/github/unchama/seichiassist/menus/stickmenu/SecondPage.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/menus/stickmenu/SecondPage.scala
@@ -1,5 +1,7 @@
 package com.github.unchama.seichiassist.menus.stickmenu
 
+import io.github.iltotore.iron.autoRefine
+
 import cats.effect.{IO, SyncIO}
 import com.github.unchama.itemstackbuilder.{
   IconItemStackBuilder,

--- a/src/main/scala/com/github/unchama/seichiassist/menus/trade/GachaTradeFromMineStack.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/menus/trade/GachaTradeFromMineStack.scala
@@ -1,5 +1,7 @@
 package com.github.unchama.seichiassist.menus.trade
 
+import io.github.iltotore.iron.autoRefine
+
 import com.github.unchama.menuinventory.Menu
 import com.github.unchama.menuinventory.MenuFrame
 import cats.effect.IO

--- a/src/main/scala/com/github/unchama/seichiassist/menus/trade/GachaTradeFromMineStack.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/menus/trade/GachaTradeFromMineStack.scala
@@ -37,12 +37,12 @@ import com.github.unchama.seichiassist.subsystems.tradesystems.subsystems.gachat
 object GachaTradeFromMineStackMenu {
   class Environment(
     implicit val mineStackAPI: MineStackAPI[IO, Player, ItemStack],
-    implicit val gachaTradeAPI: GachaTradeAPI[IO, Player, ItemStack],
-    implicit val gachaPrizeAPI: GachaPrizeAPI[IO, ItemStack, Player],
-    implicit val onMainThread: OnMinecraftServerThread[IO],
-    implicit val ioCanOpenTradeSelector: IO CanOpen TradeSelector.type,
-    implicit val ioCanOpenGachaTradeMenu: IO CanOpen GachaTradeFromMineStackMenu,
-    implicit val playerHeadSkinAPI: PlayerHeadSkinAPI[IO, Player]
+    val gachaTradeAPI: GachaTradeAPI[IO, Player, ItemStack],
+    val gachaPrizeAPI: GachaPrizeAPI[IO, ItemStack, Player],
+    val onMainThread: OnMinecraftServerThread[IO],
+    val ioCanOpenTradeSelector: IO CanOpen TradeSelector.type,
+    val ioCanOpenGachaTradeMenu: IO CanOpen GachaTradeFromMineStackMenu,
+    val playerHeadSkinAPI: PlayerHeadSkinAPI[IO, Player]
   )
 
   sealed trait ExchangeAmount {
@@ -79,7 +79,6 @@ case class GachaTradeFromMineStackMenu(
 
   import com.github.unchama.menuinventory.syntax._
   import cats.implicits._
-  import eu.timepit.refined.auto._
 
   override val frame: MenuFrame = MenuFrame(6.chestRows, s"$LIGHT_PURPLE${BOLD}交換したい景品を選んでください")
 

--- a/src/main/scala/com/github/unchama/seichiassist/menus/trade/TradeSelector.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/menus/trade/TradeSelector.scala
@@ -1,5 +1,7 @@
 package com.github.unchama.seichiassist.menus.trade
 
+import io.github.iltotore.iron.autoRefine
+
 import com.github.unchama.menuinventory.Menu
 import com.github.unchama.menuinventory.MenuFrame
 import cats.effect.IO

--- a/src/main/scala/com/github/unchama/seichiassist/menus/trade/TradeSelector.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/menus/trade/TradeSelector.scala
@@ -23,15 +23,14 @@ import com.github.unchama.minecraft.actions.OnMinecraftServerThread
 object TradeSelector extends Menu {
 
   import com.github.unchama.menuinventory.syntax._
-  import eu.timepit.refined.auto._
 
   override val frame: MenuFrame = MenuFrame(4.chestRows, s"$LIGHT_PURPLE${BOLD}交換元を選んでください")
 
   class Environment(
     implicit val ioCanOpenFirstPage: IO CanOpen FirstPage.type,
-    implicit val ioCanOpenGachaTradeMenu: IO CanOpen GachaTradeFromMineStackMenu,
-    implicit val playerHeadSkinAPI: PlayerHeadSkinAPI[IO, Player],
-    implicit val onMainThread: OnMinecraftServerThread[IO]
+    val ioCanOpenGachaTradeMenu: IO CanOpen GachaTradeFromMineStackMenu,
+    val playerHeadSkinAPI: PlayerHeadSkinAPI[IO, Player],
+    val onMainThread: OnMinecraftServerThread[IO]
   )
 
   override def computeMenuLayout(

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/anywhereender/System.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/anywhereender/System.scala
@@ -24,7 +24,10 @@ object System {
   import ContextCoercion._
   import cats.implicits._
 
-  def wired[F[_]: BreakCountReadAPI[IO, *[_], Player]: ContextCoercion[*[_], G], G[_]: Effect](
+  def wired[F[_]: [g[_]] =>> BreakCountReadAPI[IO, g, Player]: [f[_]] =>> ContextCoercion[
+    f,
+    G
+  ], G[_]: Effect](
     configuration: SystemConfiguration
   )(implicit onMainThread: OnMinecraftServerThread[IO]): System[G] = new System[G] {
 

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/bookedachivement/bukkit/command/AchievementCommand.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/bookedachivement/bukkit/command/AchievementCommand.scala
@@ -9,9 +9,9 @@ import com.github.unchama.seichiassist.subsystems.bookedachivement.domain.Achiev
 import com.github.unchama.seichiassist.subsystems.bookedachivement.service.AchievementBookingService
 import com.github.unchama.targetedeffect.commandsender.MessageEffect
 import com.github.unchama.targetedeffect.{SequentialEffect, TargetedEffect}
-import eu.timepit.refined.api.Refined
-import eu.timepit.refined.numeric.Positive
-import eu.timepit.refined.auto._
+import io.github.iltotore.iron.:|
+import io.github.iltotore.iron.constraint.numeric.Positive
+
 import org.bukkit.Bukkit
 import org.bukkit.ChatColor.RED
 import org.bukkit.command.{CommandSender, TabExecutor}
@@ -35,7 +35,7 @@ object AchievementCommand {
    * には実績の存在確認のロジックが入っていたが、これは必要であったか？
    */
   private val achievementNumberParser =
-    Parsers.closedRangeInt[Int Refined Positive](
+    Parsers.closedRangeInt[Int :| Positive](
       1000,
       9999,
       MessageEffect(s"${RED}操作の対象として指定できるのはNo1000～9999の実績です。")

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/bookedachivement/bukkit/command/AchievementCommand.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/bookedachivement/bukkit/command/AchievementCommand.scala
@@ -16,7 +16,6 @@ import org.bukkit.Bukkit
 import org.bukkit.ChatColor.RED
 import org.bukkit.command.{CommandSender, TabExecutor}
 import org.bukkit.entity.Player
-import shapeless.HNil
 
 import scala.jdk.CollectionConverters._
 
@@ -85,11 +84,9 @@ object AchievementCommand {
     .thenParse(scopeParser)
     .ifArgumentsMissing(descriptionPrintExecutor)
     .buildWithExecutionF { context =>
-      import shapeless.::
-
       val sender = context.sender
 
-      val operation :: achievementNumber :: scopeSpec :: HNil = context.args.parsed
+      val (operation, achievementNumber, scopeSpec) = context.args.parsed
 
       def execution(): IO[TargetedEffect[CommandSender]] = {
         val targetPlayerNames: List[String] =

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/breakcount/System.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/breakcount/System.scala
@@ -48,7 +48,7 @@ object System {
     _
   ]: ConcurrentEffect: OnMinecraftServerThread: ErrorLogger: DiscordNotificationAPI, G[
     _
-  ]: SyncEffect: ContextCoercion[*[_], F]](
+  ]: SyncEffect: [f[_]] =>> ContextCoercion[f, F]](
   ): F[System[F, G]] = {
     implicit val persistence: SeichiAmountDataPersistence[G] =
       new JdbcSeichiAmountDataPersistence[G]

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/breakcount/application/actions/IncrementSeichiExp.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/breakcount/application/actions/IncrementSeichiExp.scala
@@ -26,7 +26,7 @@ object IncrementSeichiExp {
   /**
    * 与えられたデータレポジトリと更新を流すトピックを用いてプレーヤーの整地量を増加させるような 代数を作成する。
    */
-  def using[F[_]: Sync: ClassifyPlayerWorld[*[_], Player], G[_]: Effect, Player](
+  def using[F[_]: Sync: [f[_]] =>> ClassifyPlayerWorld[f, Player], G[_]: Effect, Player](
     dataRepository: KeyedDataRepository[Player, Ref[F, SeichiAmountData]],
     dataTopic: Fs3Topic[G, Option[(Player, SeichiAmountData)]]
   ): IncrementSeichiExp[F, Player] =

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/breakcountbar/System.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/breakcountbar/System.scala
@@ -34,9 +34,10 @@ object System {
 
   private final val topicSubscriptionSize = 10
 
-  def wired[G[_]: SyncEffect, F[_]: ConcurrentEffect: ContextCoercion[G, *[_]]: ErrorLogger](
-    breakCountReadAPI: BreakCountReadAPI[F, G, Player]
-  ): F[System[F, G, Player]] = {
+  def wired[
+    G[_]: SyncEffect,
+    F[_]: ConcurrentEffect: [g[_]] =>> ContextCoercion[G, g]: ErrorLogger
+  ](breakCountReadAPI: BreakCountReadAPI[F, G, Player]): F[System[F, G, Player]] = {
     import com.github.unchama.minecraft.bukkit.algebra.BukkitPlayerHasUuid.instance
 
     val persistence: BreakCountBarVisibilityPersistence[G] =

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/breakcountbar/application/BreakCountBarVisibilityRepositoryDefinition.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/breakcountbar/application/BreakCountBarVisibilityRepositoryDefinition.scala
@@ -18,9 +18,9 @@ import org.typelevel.log4cats.ErrorLogger
 
 object BreakCountBarVisibilityRepositoryDefinition {
 
-  def withContext[G[_]: Sync, F[_]: ConcurrentEffect: ContextCoercion[
+  def withContext[G[_]: Sync, F[_]: ConcurrentEffect: [g[_]] =>> ContextCoercion[
     G,
-    *[_]
+    g
   ]: ErrorLogger, Player: HasUuid](
     persistence: BreakCountBarVisibilityPersistence[G],
     publishChanges: Pipe[F, (Player, BreakCountBarVisibility), Unit]

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/breakcountbar/application/ExpBarSynchronizationRepositoryTemplate.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/breakcountbar/application/ExpBarSynchronizationRepositoryTemplate.scala
@@ -32,9 +32,9 @@ object ExpBarSynchronizationRepositoryTemplate {
   import cats.effect.implicits._
   import cats.implicits._
 
-  def initialization[G[_]: Sync, F[_]: ConcurrentEffect: ContextCoercion[
+  def initialization[G[_]: Sync, F[_]: ConcurrentEffect: [g[_]] =>> ContextCoercion[
     G,
-    *[_]
+    g
   ]: ErrorLogger, Player: HasUuid](
     breakCountReadAPI: BreakCountReadAPI[F, G, Player],
     visibilityValues: fs2.Stream[F, (Player, BreakCountBarVisibility)]

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/breakcountbar/domain/BreakCountBarVisibility.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/breakcountbar/domain/BreakCountBarVisibility.scala
@@ -1,7 +1,7 @@
 package com.github.unchama.seichiassist.subsystems.breakcountbar.domain
 
 sealed trait BreakCountBarVisibility {
-  val nextValue: BreakCountBarVisibility
+  def nextValue: BreakCountBarVisibility
 }
 
 object BreakCountBarVisibility {

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/breakskilltargetconfig/System.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/breakskilltargetconfig/System.scala
@@ -21,7 +21,7 @@ object System {
 
   import cats.implicits._
 
-  def wired[F[_], G[_]: SyncEffect: ContextCoercion[*[_], F]]: G[System[F, Player]] = {
+  def wired[F[_], G[_]: SyncEffect: [f[_]] =>> ContextCoercion[f, F]]: G[System[F, Player]] = {
     implicit val breakSkillTargetConfigPersistence: BreakSkillTargetConfigPersistence[G] =
       new JdbcBreakSkillTargetConfigPersistence[G]
 

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/breaksuppressionpreference/System.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/breaksuppressionpreference/System.scala
@@ -18,7 +18,7 @@ object System {
 
   import cats.implicits._
 
-  def wired[F[_], G[_]: SyncEffect: ContextCoercion[*[_], F]]: G[System[F, Player]] = {
+  def wired[F[_], G[_]: SyncEffect: [f[_]] =>> ContextCoercion[f, F]]: G[System[F, Player]] = {
     implicit val breakSuppressionPreferencePersistence
       : BreakSuppressionPreferencePersistence[G] =
       new JdbcBreakSuppressionPreferencePersistence[G]

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/buildcount/System.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/buildcount/System.scala
@@ -54,7 +54,7 @@ object System {
     _
   ]: OnMinecraftServerThread: ConcurrentEffect: ErrorLogger: DiscordNotificationAPI, G[
     _
-  ]: SyncEffect: ContextCoercion[*[_], F]: Clock](
+  ]: SyncEffect: [f[_]] =>> ContextCoercion[f, F]: Clock](
     implicit configuration: Configuration,
     getConnectedPlayers: GetConnectedPlayers[F, Player]
   ): F[System[F, G]] = {

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/buildcount/application/actions/IncrementBuildExpWhenBuiltByHand.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/buildcount/application/actions/IncrementBuildExpWhenBuiltByHand.scala
@@ -30,7 +30,7 @@ object IncrementBuildExpWhenBuiltByHand {
     implicit ev: IncrementBuildExpWhenBuiltByHand[F, Player]
   ): IncrementBuildExpWhenBuiltByHand[F, Player] = ev
 
-  def using[F[_]: ClassifyPlayerWorld[*[_], Player], G[_]: Effect, Player](
+  def using[F[_]: [f[_]] =>> ClassifyPlayerWorld[f, Player], G[_]: Effect, Player](
     rateLimiterRepository: KeyedDataRepository[Player, RateLimiter[F, BuildExpAmount]],
     dataRepository: KeyedDataRepository[Player, Ref[F, BuildAmountData]],
     dataTopic: Fs3Topic[G, (Player, BuildAmountData)]

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/buildcount/application/actions/IncrementBuildExpWhenBuiltWithSkill.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/buildcount/application/actions/IncrementBuildExpWhenBuiltWithSkill.scala
@@ -13,10 +13,10 @@ trait IncrementBuildExpWhenBuiltWithSkill[F[_], Player] {
 
 object IncrementBuildExpWhenBuiltWithSkill {
 
-  def apply[F[_]: IncrementBuildExpWhenBuiltWithSkill[*[_], Player], Player]
+  def apply[F[_]: [f[_]] =>> IncrementBuildExpWhenBuiltWithSkill[f, Player], Player]
     : IncrementBuildExpWhenBuiltWithSkill[F, Player] = implicitly
 
-  def withConfig[F[_]: IncrementBuildExpWhenBuiltByHand[*[_], Player], Player](
+  def withConfig[F[_]: [f[_]] =>> IncrementBuildExpWhenBuiltByHand[f, Player], Player](
     config: BuildExpMultiplier
   ): IncrementBuildExpWhenBuiltWithSkill[F, Player] =
     (player: Player, by: BuildExpAmount) =>

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/buildcount/bukkit/listeners/BuildExpIncrementer.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/buildcount/bukkit/listeners/BuildExpIncrementer.scala
@@ -10,8 +10,9 @@ import org.bukkit.event.{EventHandler, Listener}
 /**
  * Created by karayuu on 2020/10/07
  */
-class BuildExpIncrementer[F[_]: IncrementBuildExpWhenBuiltByHand[*[_], Player]: SyncEffect]
-    extends Listener {
+class BuildExpIncrementer[
+  F[_]: [f[_]] =>> IncrementBuildExpWhenBuiltByHand[f, Player]: SyncEffect
+] extends Listener {
 
   @EventHandler(ignoreCancelled = true)
   def onEvent(event: BlockPlaceEvent): Unit = {

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/buildcount/subsystems/notification/bukkit/actions/BukkitNotifyBuildAmountThreshold.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/buildcount/subsystems/notification/bukkit/actions/BukkitNotifyBuildAmountThreshold.scala
@@ -16,9 +16,9 @@ object BukkitNotifyBuildAmountThreshold {
   import cats.implicits._
 
   // TODO: BukkitNotifyLevelUpなのにdiffの展開やいつメッセージを出すかなどを扱うべきでない。
-  def apply[F[_]: Sync: DiscordNotificationAPI: OnMinecraftServerThread: GetConnectedPlayers[*[
+  def apply[F[_]: Sync: DiscordNotificationAPI: OnMinecraftServerThread: [f[
     _
-  ], Player]]: NotifyBuildAmountThreshold[F, Player] = {
+  ]] =>> GetConnectedPlayers[f, Player]]: NotifyBuildAmountThreshold[F, Player] = {
     new NotifyBuildAmountThreshold[F, Player] {
       override def ofBuildAmountTo(player: Player)(diff: Diff[BuildAmountData]): F[Unit] = {
         val Diff(oldBuildAmount, newBuildAmount) = diff

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/buildcount/subsystems/notification/bukkit/actions/BukkitNotifyLevelUp.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/buildcount/subsystems/notification/bukkit/actions/BukkitNotifyLevelUp.scala
@@ -21,9 +21,9 @@ object BukkitNotifyLevelUp {
   import cats.implicits._
 
   // TODO: BukkitNotifyLevelUpなのにdiffの展開やいつメッセージを出すかなどを扱うべきでない。
-  def apply[F[_]: Sync: OnMinecraftServerThread: DiscordNotificationAPI: GetConnectedPlayers[*[
+  def apply[F[_]: Sync: OnMinecraftServerThread: DiscordNotificationAPI: [f[
     _
-  ], Player]]: NotifyLevelUp[F, Player] = {
+  ]] =>> GetConnectedPlayers[f, Player]]: NotifyLevelUp[F, Player] = {
     new NotifyLevelUp[F, Player] {
       override def ofBuildLevelTo(player: Player)(diff: Diff[BuildLevel]): F[Unit] = {
         val Diff(oldLevel, newLevel) = diff

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/chatratelimiter/System.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/chatratelimiter/System.scala
@@ -13,7 +13,7 @@ import org.bukkit.entity.Player
 import org.bukkit.event.Listener
 
 object System {
-  def wired[F[_]: ConcurrentEffect, G[_]: SyncEffect: ContextCoercion[*[_], F]: Timer](
+  def wired[F[_]: ConcurrentEffect, G[_]: SyncEffect: [f[_]] =>> ContextCoercion[f, F]: Timer](
     implicit breakCountAPI: BreakCountReadAPI[F, G, Player]
   ): F[Subsystem[F]] = {
     val repository = ChatRateLimitRepositoryDefinition.inSyncContext[G, Player]

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/donate/bukkit/commands/DonationCommand.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/donate/bukkit/commands/DonationCommand.scala
@@ -15,7 +15,6 @@ import com.github.unchama.targetedeffect.UnfocusedEffect
 import com.github.unchama.targetedeffect.commandsender.{MessageEffect, MessageEffectF}
 import org.bukkit.ChatColor._
 import org.bukkit.command.TabExecutor
-import shapeless.HNil
 
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
@@ -32,9 +31,7 @@ class DonationCommand[F[_]: ConcurrentEffect](
       .thenParse(Parsers.identity)
       .thenParse(Parsers.integer(MessageEffect(s"${RED}付与するプレミアムエフェクトポイントは整数で指定してください。")))
       .buildWithExecutionCSEffect { context =>
-        import shapeless.::
-
-        val rawName :: rawDonatePoint :: HNil = context.args.parsed
+        val (rawName, rawDonatePoint) = context.args.parsed
         val playerName = PlayerName(rawName)
         val donatePoint = DonatePremiumEffectPoint(rawDonatePoint)
 

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/dragonnighttime/System.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/dragonnighttime/System.scala
@@ -22,9 +22,12 @@ trait System[F[_]] extends Subsystem[F] {
 }
 
 object System {
-  def backgroundProcess[F[_]: Concurrent: Timer: OnMinecraftServerThread: GetConnectedPlayers[*[
+  def backgroundProcess[F[_]: Concurrent: Timer: OnMinecraftServerThread: [f[
     _
-  ], org.bukkit.entity.Player], G[_]: ContextCoercion[*[_], F], Player](
+  ]] =>> GetConnectedPlayers[f, org.bukkit.entity.Player], G[_]: [f[_]] =>> ContextCoercion[
+    f,
+    F
+  ], Player](
     implicit fastDiggingEffectApi: FastDiggingEffectWriteApi[F, Player],
     manaApi: ManaApi[F, G, Player]
   ): F[Nothing] = {

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/dragonnighttime/application/DragonNightTimeRoutine.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/dragonnighttime/application/DragonNightTimeRoutine.scala
@@ -17,7 +17,10 @@ import java.time.{Instant, LocalDateTime, ZoneId}
 import java.util.concurrent.TimeUnit
 
 object DragonNightTimeRoutine {
-  def apply[F[_]: Concurrent: CanBroadcast: Timer, G[_]: ContextCoercion[*[_], F], Player](
+  def apply[F[_]: Concurrent: CanBroadcast: Timer, G[_]: [f[_]] =>> ContextCoercion[
+    f,
+    F
+  ], Player](
     implicit fastDiggingEffectApi: FastDiggingEffectWriteApi[F, Player],
     manaApi: ManaApi[F, G, Player]
   ): F[Nothing] = {

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/dragonnighttime/bukkit/instances/SyncCanBroadcastOnBukkit.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/dragonnighttime/bukkit/instances/SyncCanBroadcastOnBukkit.scala
@@ -10,7 +10,7 @@ import org.bukkit.entity.Player
 object SyncCanBroadcastOnBukkit {
   import cats.implicits._
 
-  def apply[F[_]: Sync: OnMinecraftServerThread: GetConnectedPlayers[*[_], Player]]
+  def apply[F[_]: Sync: OnMinecraftServerThread: [f[_]] =>> GetConnectedPlayers[f, Player]]
     : CanBroadcast[F] = (message: String) => {
     for {
       _ <- SendMessageEffect.sendMessageToEveryoneIgnoringPreferenceM[String, F](message)

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/expbottlestack/System.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/expbottlestack/System.scala
@@ -16,7 +16,7 @@ trait System[F[_], G[_], H[_]] extends Subsystem[H] {
 }
 
 object System {
-  def wired[F[_]: ConcurrentEffect, G[_]: SyncEffect: ContextCoercion[*[_], F], H[_]](
+  def wired[F[_]: ConcurrentEffect, G[_]: SyncEffect: [f[_]] =>> ContextCoercion[f, F], H[_]](
     implicit effectEnvironment: EffectEnvironment
   ): F[System[F, G, H]] = {
     import cats.implicits._

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/fastdiggingeffect/System.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/fastdiggingeffect/System.scala
@@ -72,10 +72,10 @@ object System {
 
   def wired[G[_]: SyncEffect, F[
     _
-  ]: OnMinecraftServerThread: Timer: ConcurrentEffect: ErrorLogger: ContextCoercion[
+  ]: OnMinecraftServerThread: Timer: ConcurrentEffect: ErrorLogger: [g[_]] =>> ContextCoercion[
     G,
-    *[_]
-  ]: GetConnectedPlayers[*[_], Player]: GetNetworkConnectionCount, H[_]](
+    g
+  ]: [f[_]] =>> GetConnectedPlayers[f, Player]: GetNetworkConnectionCount, H[_]](
     implicit breakCountReadAPI: BreakCountReadAPI[F, H, Player],
     config: Configuration
   ): F[System[F, F, Player]] = {

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/fastdiggingeffect/application/process/EffectStatsNotification.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/fastdiggingeffect/application/process/EffectStatsNotification.scala
@@ -10,7 +10,7 @@ import org.bukkit.ChatColor.{RED, RESET, WHITE, YELLOW}
 
 object EffectStatsNotification {
 
-  def using[F[_]: ConcurrentEffect: SendMinecraftMessage[*[_], Player], Player](
+  def using[F[_]: ConcurrentEffect: [f[_]] =>> SendMinecraftMessage[f, Player], Player](
     effectDiffWithSettings: fs2.Stream[
       F,
       (Player, (EffectListDiff, FastDiggingEffectStatsSettings))

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/fastdiggingeffect/application/process/PlayerCountEffectSynchronization.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/fastdiggingeffect/application/process/PlayerCountEffectSynchronization.scala
@@ -17,8 +17,8 @@ object PlayerCountEffectSynchronization {
 
   import scala.concurrent.duration._
 
-  def using[F[_]: ConcurrentEffect: Timer: GetConnectedPlayers[
-    *[_],
+  def using[F[_]: ConcurrentEffect: Timer: [f[_]] =>> GetConnectedPlayers[
+    f,
     Player
   ]: GetNetworkConnectionCount, Player](
     implicit configuration: Configuration,

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/fastdiggingeffect/application/process/SynchronizationProcess.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/fastdiggingeffect/application/process/SynchronizationProcess.scala
@@ -12,8 +12,8 @@ object SynchronizationProcess {
 
   import cats.implicits._
 
-  def using[F[_]: GrantFastDiggingEffect[*[_], Player]: MonadError[
-    *[_],
+  def using[F[_]: [f[_]] =>> GrantFastDiggingEffect[f, Player]: [f[_]] =>> MonadError[
+    f,
     Throwable
   ]: JavaTime, Player](
     suppressionState: KeyedDataRepository[

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/fastdiggingeffect/application/repository/EffectListRepositoryDefinitions.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/fastdiggingeffect/application/repository/EffectListRepositoryDefinitions.scala
@@ -28,7 +28,7 @@ object EffectListRepositoryDefinitions {
    */
   type RepositoryValue[F[_], G[_]] = Mutex[F, G, FastDiggingEffectList] FiberAdjoined F
 
-  def initialization[F[_]: Concurrent, G[_]: Sync: ContextCoercion[*[_], F]]
+  def initialization[F[_]: Concurrent, G[_]: Sync: [f[_]] =>> ContextCoercion[f, F]]
     : SinglePhasedRepositoryInitialization[G, RepositoryValue[F, G]] =
     (_, _) => {
       for {
@@ -37,9 +37,9 @@ object EffectListRepositoryDefinitions {
       } yield PrefetchResult.Success(ref, deferred)
     }
 
-  def tappingAction[F[_]: ConcurrentEffect: Timer: ErrorLogger, G[
+  def tappingAction[F[_]: ConcurrentEffect: Timer: ErrorLogger, G[_]: SyncEffect: [f[
     _
-  ]: SyncEffect: ContextCoercion[*[_], F], Player](
+  ]] =>> ContextCoercion[f, F], Player](
     effectTopic: Fs3Topic[F, Option[(Player, FastDiggingEffectList)]]
   ): (Player, RepositoryValue[F, G]) => G[Unit] = {
     case (player, (mutexRef, fiberPromise)) =>

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/fastdiggingeffect/application/repository/EffectStatsSettingsRepositoryDefinition.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/fastdiggingeffect/application/repository/EffectStatsSettingsRepositoryDefinition.scala
@@ -32,9 +32,9 @@ object EffectStatsSettingsRepositoryDefinition {
   import cats.effect.implicits._
   import cats.implicits._
 
-  def withContext[F[_]: ConcurrentEffect: JavaTime: ErrorLogger, G[_]: Sync: ContextCoercion[*[
+  def withContext[F[_]: ConcurrentEffect: JavaTime: ErrorLogger, G[_]: Sync: [f[
     _
-  ], F], Player: HasUuid](
+  ]] =>> ContextCoercion[f, F], Player: HasUuid](
     persistence: FastDiggingEffectStatsSettingsPersistence[G],
     publishEffectDiff: Pipe[
       F,

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/fourdimensionalpocket/System.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/fourdimensionalpocket/System.scala
@@ -48,9 +48,9 @@ object System {
   import cats.implicits._
   import com.github.unchama.minecraft.bukkit.algebra.BukkitPlayerHasUuid._
 
-  def wired[F[_]: ConcurrentEffect: OnMinecraftServerThread: ErrorLogger, G[
+  def wired[F[_]: ConcurrentEffect: OnMinecraftServerThread: ErrorLogger, G[_]: SyncEffect: [f[
     _
-  ]: SyncEffect: ContextCoercion[*[_], F]](breakCountReadAPI: BreakCountReadAPI[F, G, Player])(
+  ]] =>> ContextCoercion[f, F]](breakCountReadAPI: BreakCountReadAPI[F, G, Player])(
     implicit effectEnvironment: EffectEnvironment,
     syncIOUuidRepository: UuidRepository[SyncIO]
   ): F[System[F, Player]] = {
@@ -72,31 +72,32 @@ object System {
           )
         }
     } yield {
-      implicit val systemApi = new FourDimensionalPocketApi[F, Player] {
-        override val openPocketInventory: Kleisli[F, Player, Unit] = Kleisli { player =>
-          Sync[F].delay {
-            // 開く音を再生
-            player.playSound(player.getLocation, Sound.BLOCK_ENDER_CHEST_OPEN, 1f, 0.1f)
-          } >> ContextCoercion {
-            pocketInventoryRepositoryHandles.repository(player)._1.readLatest
-          }.flatMap(inventory => interactInventory.open(inventory)(player))
-        }
-        override val currentPocketSize
-          : KeyedDataRepository[Player, ReadOnlyRef[F, PocketSize]] = {
-          KeyedDataRepository.unlift { player =>
-            pocketInventoryRepositoryHandles.repository.lift(player).map {
-              case (mutex, _) =>
-                ReadOnlyRef.fromAnySource {
-                  ContextCoercion {
-                    mutex
-                      .readLatest
-                      .map(inventory => PocketSize.fromTotalStackCount(inventory.getSize))
+      implicit val systemApi: FourDimensionalPocketApi[F, Player] =
+        new FourDimensionalPocketApi[F, Player] {
+          override val openPocketInventory: Kleisli[F, Player, Unit] = Kleisli { player =>
+            Sync[F].delay {
+              // 開く音を再生
+              player.playSound(player.getLocation, Sound.BLOCK_ENDER_CHEST_OPEN, 1f, 0.1f)
+            } >> ContextCoercion {
+              pocketInventoryRepositoryHandles.repository(player)._1.readLatest
+            }.flatMap(inventory => interactInventory.open(inventory)(player))
+          }
+          override val currentPocketSize
+            : KeyedDataRepository[Player, ReadOnlyRef[F, PocketSize]] = {
+            KeyedDataRepository.unlift { player =>
+              pocketInventoryRepositoryHandles.repository.lift(player).map {
+                case (mutex, _) =>
+                  ReadOnlyRef.fromAnySource {
+                    ContextCoercion {
+                      mutex
+                        .readLatest
+                        .map(inventory => PocketSize.fromTotalStackCount(inventory.getSize))
+                    }
                   }
-                }
+              }
             }
           }
         }
-      }
 
       val openPocketListener =
         new OpenPocketInventoryOnPlacingEnderPortalFrame[F](systemApi, effectEnvironment)

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/fourdimensionalpocket/application/PocketInventoryRepositoryDefinition.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/fourdimensionalpocket/application/PocketInventoryRepositoryDefinition.scala
@@ -35,10 +35,12 @@ object PocketInventoryRepositoryDefinition {
   type RepositoryValue[F[_], G[_], Inventory] =
     (Mutex[F, G, Inventory], Deferred[F, Fiber[F, Nothing]])
 
-  def withContext[F[_]: ConcurrentEffect: ErrorLogger, G[_]: Sync: ContextCoercion[
-    *[_],
-    F
-  ], Player: HasUuid, Inventory: CreateInventory[G, *]: InteractInventory[F, Player, *]](
+  def withContext[
+    F[_]: ConcurrentEffect: ErrorLogger,
+    G[_]: Sync: [f[_]] =>> ContextCoercion[f, F],
+    Player: HasUuid,
+    Inventory: [a] =>> CreateInventory[G, a]: [a] =>> InteractInventory[F, Player, a]
+  ](
     persistence: PocketInventoryPersistence[G, Inventory],
     levelStream: fs2.Stream[F, (Player, Diff[SeichiLevel])]
   ): RepositoryDefinition[G, Player, RepositoryValue[F, G, Inventory]] =

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/fourdimensionalpocket/bukkit/commands/OpenPocketCommand.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/fourdimensionalpocket/bukkit/commands/OpenPocketCommand.scala
@@ -20,7 +20,7 @@ import org.bukkit.inventory.Inventory
 
 import java.util.UUID
 
-class OpenPocketCommand[F[_]: Effect: InteractInventory[*[_], Player, Inventory]](
+class OpenPocketCommand[F[_]: Effect: [f[_]] =>> InteractInventory[f, Player, Inventory]](
   repository: KeyedDataRepository[Player, ReadOnlyRef[F, Inventory]],
   persistence: RefDict[F, UUID, Inventory]
 )(implicit syncIOUuidRepository: UuidRepository[SyncIO]) {

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/gacha/System.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/gacha/System.scala
@@ -38,8 +38,8 @@ trait System[F[_], Player] extends Subsystem[F] {
 
 object System {
 
-  def wired[F[_]: ConcurrentEffect: OnMinecraftServerThread: GetConnectedPlayers[
-    *[_],
+  def wired[F[_]: ConcurrentEffect: OnMinecraftServerThread: [f[_]] =>> GetConnectedPlayers[
+    f,
     Player
   ]: GachaTicketAPI](
     implicit gachaPrizeAPI: GachaPrizeAPI[F, ItemStack, Player],

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/gacha/bukkit/GachaCommand.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/gacha/bukkit/GachaCommand.scala
@@ -34,7 +34,6 @@ import org.bukkit.ChatColor._
 import org.bukkit.command.{CommandSender, TabExecutor}
 import org.bukkit.entity.Player
 import org.bukkit.inventory.ItemStack
-import shapeless.HNil
 
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
@@ -154,8 +153,7 @@ class GachaCommand[F[_]: OnMinecraftServerThread: ConcurrentEffect](
           .map(r => GachaTicketAmount(r.value))
       )
       .buildWithExecutionCSEffect { context =>
-        import shapeless.::
-        val selector :: amount :: HNil = context.args.parsed
+        val (selector, amount) = context.args.parsed
         selector match {
           case "all" =>
             Kleisli
@@ -194,8 +192,7 @@ class GachaCommand[F[_]: OnMinecraftServerThread: ConcurrentEffect](
           )
         )
         .buildWithExecutionCSEffect { context =>
-          import shapeless.::
-          val gachaPrizeId :: shapeless.HNil = context.args.parsed
+          val gachaPrizeId = context.args.parsed.head
           // optional
           val ownerName = context.args.yetToBeParsed.headOption
 
@@ -221,10 +218,8 @@ class GachaCommand[F[_]: OnMinecraftServerThread: ConcurrentEffect](
 
     val add: ContextualExecutor =
       playerCommandBuilder.thenParse(probabilityParser).buildWithExecutionCSEffect { context =>
-        import shapeless.::
-
         val player = context.sender
-        val probability :: HNil = context.args.parsed
+        val probability = context.args.parsed.head
         val eventName = context.args.yetToBeParsed.headOption.map(GachaEventName.apply)
         val mainHandItem = player.getInventory.getItemInMainHand
 
@@ -331,8 +326,7 @@ class GachaCommand[F[_]: OnMinecraftServerThread: ConcurrentEffect](
           )
         )
         .buildWithExecutionCSEffect { context =>
-          import shapeless.::
-          val targetId :: amount :: HNil = context.args.parsed
+          val (targetId, amount) = context.args.parsed
 
           Kleisli
             .liftF(for {
@@ -360,8 +354,7 @@ class GachaCommand[F[_]: OnMinecraftServerThread: ConcurrentEffect](
       .thenParse(gachaPrizeIdExistsParser)
       .thenParse(probabilityParser)
       .buildWithExecutionCSEffect { context =>
-        import shapeless.::
-        val targetId :: newProb :: HNil = context.args.parsed
+        val (targetId, newProb) = context.args.parsed
 
         (for {
           currentGachaPrize <- Kleisli.liftF(gachaPrizeAPI.fetch(targetId))
@@ -389,8 +382,7 @@ class GachaCommand[F[_]: OnMinecraftServerThread: ConcurrentEffect](
         .thenParse(Parsers.identity)
         .thenParse(Parsers.identity)
         .buildWithExecutionCSEffect { context =>
-          import shapeless.::
-          val e :: startDate :: endDate :: HNil = context.args.parsed
+          val (e, startDate, endDate) = context.args.parsed
           val eventName = GachaEventName(e)
 
           val dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd")
@@ -455,8 +447,7 @@ class GachaCommand[F[_]: OnMinecraftServerThread: ConcurrentEffect](
     val replaceGachaPrize: ContextualExecutor =
       playerCommandBuilder.thenParse(gachaPrizeIdExistsParser).buildWithExecutionCSEffect {
         context =>
-          import shapeless.::
-          val targetId :: HNil = context.args.parsed
+          val targetId = context.args.parsed.head
 
           Kleisli
             .liftF[F, CommandSender, Unit] {

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/gacha/bukkit/GachaCommand.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/gacha/bukkit/GachaCommand.scala
@@ -27,9 +27,9 @@ import com.github.unchama.seichiassist.subsystems.gachaprize.domain.gachaevent.{
 import com.github.unchama.seichiassist.subsystems.gachaprize.{GachaPrizeAPI, domain}
 import com.github.unchama.seichiassist.util.InventoryOperations
 import com.github.unchama.targetedeffect.commandsender.{MessageEffect, MessageEffectF}
-import eu.timepit.refined.api.Refined
-import eu.timepit.refined.auto._
-import eu.timepit.refined.numeric.{Interval, NonNegative, Positive}
+import io.github.iltotore.iron.:|
+
+import io.github.iltotore.iron.constraint.numeric.{GreaterEqual, Interval, Positive}
 import org.bukkit.ChatColor._
 import org.bukkit.command.{CommandSender, TabExecutor}
 import org.bukkit.entity.Player
@@ -111,11 +111,7 @@ class GachaCommand[F[_]: OnMinecraftServerThread: ConcurrentEffect](
 
     private val gachaPrizeIdExistsParser: SingleArgumentParser[GachaPrizeId] =
       Parsers
-        .closedRangeInt[Int Refined Positive](
-          1,
-          Int.MaxValue,
-          MessageEffect("IDは正の値を指定してください。")
-        )
+        .closedRangeInt[Int :| Positive](1, Int.MaxValue, MessageEffect("IDは正の値を指定してください。"))
         .andThen(_.flatMap { intId =>
           val id = GachaPrizeId(intId)
 
@@ -144,13 +140,13 @@ class GachaCommand[F[_]: OnMinecraftServerThread: ConcurrentEffect](
       .thenParse(Parsers.identity)
       .thenParse(s =>
         Parsers
-          .closedRangeInt[Int Refined Positive](
+          .closedRangeInt[Int :| Positive](
             1,
             Int.MaxValue,
             MessageEffect("配布するガチャ券の枚数は正の値を指定してください。")
           )
           .apply(s)
-          .map(r => GachaTicketAmount(r.value))
+          .map(r => GachaTicketAmount(r))
       )
       .buildWithExecutionCSEffect { context =>
         val (selector, amount) = context.args.parsed
@@ -185,7 +181,7 @@ class GachaCommand[F[_]: OnMinecraftServerThread: ConcurrentEffect](
     val giveItem: ContextualExecutor =
       playerCommandBuilder
         .thenParse(
-          Parsers.closedRangeInt[Int Refined NonNegative](
+          Parsers.closedRangeInt[Int :| GreaterEqual[0]](
             0,
             Int.MaxValue,
             MessageEffect("IDは0以上の整数を指定してください。")
@@ -296,11 +292,8 @@ class GachaCommand[F[_]: OnMinecraftServerThread: ConcurrentEffect](
     val remove: ContextualExecutor = ContextualExecutorBuilder
       .beginConfiguration
       .thenParse(
-        Parsers.closedRangeInt[Int Refined Positive](
-          1,
-          Int.MaxValue,
-          MessageEffect("IDは正の値を指定してください。")
-        )
+        Parsers
+          .closedRangeInt[Int :| Positive](1, Int.MaxValue, MessageEffect("IDは正の値を指定してください。"))
       )
       .buildWithExecutionCSEffect { context =>
         val gachaId = GachaPrizeId(context.args.parsed.head)
@@ -319,7 +312,7 @@ class GachaCommand[F[_]: OnMinecraftServerThread: ConcurrentEffect](
         .beginConfiguration
         .thenParse(gachaPrizeIdExistsParser)
         .thenParse(
-          Parsers.closedRangeInt[Int Refined Interval.Closed[1, 64]](
+          Parsers.closedRangeInt[Int :| Interval.Closed[1, 64]](
             1,
             64,
             MessageEffect("数は1～64で指定してください。")

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/gacha/bukkit/actions/BukkitDrawGacha.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/gacha/bukkit/actions/BukkitDrawGacha.scala
@@ -18,9 +18,9 @@ import org.bukkit.Sound
 import org.bukkit.entity.Player
 import org.bukkit.inventory.ItemStack
 
-class BukkitDrawGacha[
-  F[_]: LiftIO: Sync: OnMinecraftServerThread: GetConnectedPlayers[*[_], Player]
-](
+class BukkitDrawGacha[F[_]: LiftIO: Sync: OnMinecraftServerThread: [f[
+  _
+]] =>> GetConnectedPlayers[f, Player]](
   implicit gachaPrizeAPI: GachaPrizeAPI[F, ItemStack, Player],
   lotteryOfGachaItems: LotteryOfGachaItems[F, ItemStack],
   grantGachaPrize: GrantGachaPrize[F, ItemStack, Player]

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/gacha/subsystems/consumegachaticket/System.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/gacha/subsystems/consumegachaticket/System.scala
@@ -26,7 +26,7 @@ object System {
 
   import cats.implicits._
 
-  def wired[F[_]: Sync, G[_]: SyncEffect: ContextCoercion[*[_], F]]: F[System[F]] = {
+  def wired[F[_]: Sync, G[_]: SyncEffect: [f[_]] =>> ContextCoercion[f, F]]: F[System[F]] = {
     for {
       consumeGachaTicketSettingRepositoryControls <- ContextCoercion(
         BukkitRepositoryControls.createHandles(

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/gachapoint/System.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/gachapoint/System.scala
@@ -34,9 +34,9 @@ object System {
   import cats.effect.implicits._
   import cats.implicits._
 
-  def wired[F[_]: ConcurrentEffect: Timer: ErrorLogger, G[_]: SyncEffect: ContextCoercion[*[
+  def wired[F[_]: ConcurrentEffect: Timer: ErrorLogger, G[_]: SyncEffect: [f[
     _
-  ], F]](
+  ]] =>> ContextCoercion[f, F]](
     breakCountReadAPI: BreakCountReadAPI[F, G, Player]
   )(implicit ioOnMainThread: OnMinecraftServerThread[IO]): G[System[F, G, Player]] = {
     import com.github.unchama.minecraft.bukkit.algebra.BukkitPlayerHasUuid.instance

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/gachapoint/application/repository/GachaPointRepositoryDefinition.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/gachapoint/application/repository/GachaPointRepositoryDefinition.scala
@@ -27,7 +27,7 @@ object GachaPointRepositoryDefinition {
 
   import cats.implicits._
 
-  def withContext[G[_]: Sync: ContextCoercion[*[_], F], F[
+  def withContext[G[_]: Sync: [f[_]] =>> ContextCoercion[f, F], F[
     _
   ]: Concurrent: Timer, Player: HasUuid](persistence: GachaPointPersistence[G])(
     grantEffectFactory: Player => GrantGachaTicketToAPlayer[F]

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/gachapoint/domain/BatchUsageSemaphore.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/gachapoint/domain/BatchUsageSemaphore.scala
@@ -10,7 +10,7 @@ import cats.Monad
 /**
  * 特定のプレーヤーについてガチャポイント変換の制御を提供するオブジェクトのクラス。
  */
-class BatchUsageSemaphore[F[_]: Monad, G[_]: ContextCoercion[*[_], F]](
+class BatchUsageSemaphore[F[_]: Monad, G[_]: [f[_]] =>> ContextCoercion[f, F]](
   gachaPointRef: Ref[G, GachaPoint],
   grantAction: GrantGachaTicketToAPlayer[F]
 )(recoveringSemaphore: RecoveringSemaphore[F]) {
@@ -54,7 +54,7 @@ object BatchUsageSemaphore {
   /**
    * プレーヤーが持つガチャポイントとプレーヤーへガチャ券を与える作用から [[BatchUsageSemaphore]]を作成する。
    */
-  def newIn[G[_]: Sync: ContextCoercion[*[_], F], F[_]: Concurrent: Timer](
+  def newIn[G[_]: Sync: [f[_]] =>> ContextCoercion[f, F], F[_]: Concurrent: Timer](
     gachaPointRef: Ref[G, GachaPoint],
     grantAction: GrantGachaTicketToAPlayer[F]
   ): G[BatchUsageSemaphore[F, G]] =

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/gachaprize/System.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/gachaprize/System.scala
@@ -65,44 +65,68 @@ object System {
           gachaPrizesRef.startUpdateRoutine(_gachaPersistence.list)
 
         override implicit val api: GachaPrizeAPI[F, ItemStack, Player] =
-          new GachaPrizeAPI[F, ItemStack, Player] {
-            override protected implicit val F: Monad[F] = implicitly
-
-            override def removeByGachaPrizeId(gachaPrizeId: GachaPrizeId): F[Boolean] =
-              gachaPrizeUseCase.removeByGachaPrizeId(gachaPrizeId)
-
-            override def addGachaPrize(
-              gachaPrizeByGachaPrizeId: GachaPrizeByGachaPrizeId
-            ): F[Unit] =
-              gachaPrizeUseCase.addGachaPrize(gachaPrizeByGachaPrizeId)
-
-            override def upsertGachaPrize(
-              gachaPrize: GachaPrizeTableEntry[ItemStack]
-            ): F[Unit] =
-              _gachaPersistence.upsertGachaPrize(gachaPrize)
-
-            override def listOfNow: F[Vector[GachaPrizeTableEntry[ItemStack]]] =
-              gachaPrizeUseCase.listOfNow
-
-            override def allGachaPrizeList: F[Vector[GachaPrizeTableEntry[ItemStack]]] =
-              gachaPrizesRef.read
-
-            override def staticGachaPrizeFactory: StaticGachaPrizeFactory[ItemStack] =
-              _staticGachaPrizeFactory
-
-            override def createdGachaEvents: F[Vector[GachaEvent]] =
-              _gachaEventPersistence.gachaEvents
-
-            override def createGachaEvent(gachaEvent: GachaEvent): F[Unit] =
-              gachaPrizeUseCase.createGachaEvent(gachaEvent)
-
-            override def deleteGachaEvent(gachaEventName: GachaEventName): F[Unit] =
-              _gachaEventPersistence.deleteGachaEvent(gachaEventName)
-
-            override def canBeSignedAsGachaPrize: CanBeSignedAsGachaPrize[ItemStack] =
-              _canBeSignedAsGachaPrize
-          }
+          createApi(
+            gachaPrizesRef,
+            gachaPrizeUseCase,
+            _gachaPersistence,
+            _gachaEventPersistence,
+            _staticGachaPrizeFactory,
+            _canBeSignedAsGachaPrize
+          )
       }
+    }
+  }
+
+  /**
+   * [[GachaPrizeAPI]] の実装を構築する。
+   *
+   * 実装上の注意: 匿名クラス内の `override protected implicit val F` を `implicitly` や
+   * `Monad[F]` で初期化してはならない。Scala 3では定義中の `this.F` 自身が暗黙引数として
+   * 解決され、未初期化の null が格納される（コンパイラの "Infinite loop in function body"
+   * 警告が出る）。このため、匿名クラスの外側で確定させた `monadF` を明示的に代入している。
+   */
+  private[gachaprize] def createApi[F[_]: Monad](
+    gachaPrizesRef: CachedRef[F, Vector[GachaPrizeTableEntry[ItemStack]]],
+    gachaPrizeUseCase: GachaPrizeUseCase[F, ItemStack],
+    gachaPersistence: GachaPrizeListPersistence[F, ItemStack],
+    gachaEventPersistence: GachaEventPersistence[F],
+    staticFactory: StaticGachaPrizeFactory[ItemStack],
+    signableAsGachaPrize: CanBeSignedAsGachaPrize[ItemStack]
+  ): GachaPrizeAPI[F, ItemStack, Player] = {
+    val monadF: Monad[F] = Monad[F]
+
+    new GachaPrizeAPI[F, ItemStack, Player] {
+      override protected implicit val F: Monad[F] = monadF
+
+      override def removeByGachaPrizeId(gachaPrizeId: GachaPrizeId): F[Boolean] =
+        gachaPrizeUseCase.removeByGachaPrizeId(gachaPrizeId)
+
+      override def addGachaPrize(gachaPrizeByGachaPrizeId: GachaPrizeByGachaPrizeId): F[Unit] =
+        gachaPrizeUseCase.addGachaPrize(gachaPrizeByGachaPrizeId)
+
+      override def upsertGachaPrize(gachaPrize: GachaPrizeTableEntry[ItemStack]): F[Unit] =
+        gachaPersistence.upsertGachaPrize(gachaPrize)
+
+      override def listOfNow: F[Vector[GachaPrizeTableEntry[ItemStack]]] =
+        gachaPrizeUseCase.listOfNow
+
+      override def allGachaPrizeList: F[Vector[GachaPrizeTableEntry[ItemStack]]] =
+        gachaPrizesRef.read
+
+      override def staticGachaPrizeFactory: StaticGachaPrizeFactory[ItemStack] =
+        staticFactory
+
+      override def createdGachaEvents: F[Vector[GachaEvent]] =
+        gachaEventPersistence.gachaEvents
+
+      override def createGachaEvent(gachaEvent: GachaEvent): F[Unit] =
+        gachaPrizeUseCase.createGachaEvent(gachaEvent)
+
+      override def deleteGachaEvent(gachaEventName: GachaEventName): F[Unit] =
+        gachaEventPersistence.deleteGachaEvent(gachaEventName)
+
+      override def canBeSignedAsGachaPrize: CanBeSignedAsGachaPrize[ItemStack] =
+        signableAsGachaPrize
     }
   }
 

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/gridregion/System.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/gridregion/System.scala
@@ -48,7 +48,7 @@ object System {
 
   import cats.implicits._
 
-  def wired[F[_], G[_]: SyncEffect: ContextCoercion[*[_], F]]
+  def wired[F[_], G[_]: SyncEffect: [f[_]] =>> ContextCoercion[f, F]]
     : G[System[F, Player, Location, World]] = {
     implicit val regionCountPersistence: RegionCountAllUntilNowPersistence[G] =
       new JdbcRegionCountAllUntilNowPersistence[G]

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/halfhourranking/System.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/halfhourranking/System.scala
@@ -22,9 +22,9 @@ object System {
 
   import scala.concurrent.duration._
 
-  def backgroundProcess[F[_]: OnMinecraftServerThread: Timer: Concurrent: ErrorLogger, G[
+  def backgroundProcess[F[_]: OnMinecraftServerThread: Timer: Concurrent: ErrorLogger, G[_]: [f[
     _
-  ]: ContextCoercion[*[_], F]: Functor](
+  ]] =>> ContextCoercion[f, F]: Functor](
     implicit breakCountReadAPI: BreakCountReadAPI[F, G, Player]
   ): F[Nothing] = {
     implicit val sendBukkitMessage: SendMinecraftMessage[F, Player] = SendBukkitMessage[F]

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/halfhourranking/application/AnnounceRankingRecord.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/halfhourranking/application/AnnounceRankingRecord.scala
@@ -14,9 +14,11 @@ object AnnounceRankingRecord {
 
   import cats.implicits._
 
-  def apply[F[_]: Monad: SendMinecraftMessage[*[_], Player]: BroadcastMinecraftMessage, G[
-    _
-  ]: ContextCoercion[*[_], F]: Functor, Player: HasUuid](
+  def apply[
+    F[_]: Monad: [f[_]] =>> SendMinecraftMessage[f, Player]: BroadcastMinecraftMessage,
+    G[_]: [f[_]] =>> ContextCoercion[f, F]: Functor,
+    Player: HasUuid
+  ](
     breakCountReadApi: BreakCountReadAPI[F, G, Player]
   )(resolveName: Player => F[String]): RankingRecord[Player] => F[Unit] = { rankingRecord =>
     val rankingPositionColor = List(LIGHT_PURPLE, YELLOW, AQUA)

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/home/System.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/home/System.scala
@@ -26,7 +26,7 @@ trait System[F[_]] extends Subsystem[F] {
 object System {
   def wired[F[_]: OnMinecraftServerThread: ConcurrentEffect: NonServerThreadContextShift, G[
     _
-  ]: ContextCoercion[*[_], F]](
+  ]: [f[_]] =>> ContextCoercion[f, F]](
     implicit breakCountReadAPI: BreakCountReadAPI[F, G, Player],
     buildCountReadAPI: BuildCountAPI[F, G, Player]
   ): System[F] = {

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/home/bukkit/command/HomeCommand.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/home/bukkit/command/HomeCommand.scala
@@ -31,9 +31,9 @@ import org.bukkit.entity.Player
 
 class HomeCommand[F[
   _
-]: OnMinecraftServerThread: ConcurrentEffect: NonServerThreadContextShift: HomeAPI, G[
+]: OnMinecraftServerThread: ConcurrentEffect: NonServerThreadContextShift: HomeAPI, G[_]: [f[
   _
-]: ContextCoercion[*[_], F]](
+]] =>> ContextCoercion[f, F]](
   implicit scope: ChatInterceptionScope,
   breakCountReadAPI: BreakCountReadAPI[F, G, Player],
   buildCountReadAPI: BuildCountAPI[F, G, Player]

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/home/bukkit/command/HomeCommand.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/home/bukkit/command/HomeCommand.scala
@@ -22,9 +22,9 @@ import com.github.unchama.seichiassist.subsystems.home.domain.{Home, HomeId}
 import com.github.unchama.seichiassist.subsystems.home.{HomeAPI, HomeReadAPI, HomeWriteAPI}
 import com.github.unchama.targetedeffect.TargetedEffect
 import com.github.unchama.targetedeffect.commandsender.{MessageEffect, MessageEffectF}
-import eu.timepit.refined.api.Refined
-import eu.timepit.refined.numeric.Positive
-import eu.timepit.refined.auto._
+import io.github.iltotore.iron.:|
+import io.github.iltotore.iron.constraint.numeric.Positive
+
 import org.bukkit.ChatColor._
 import org.bukkit.command.TabExecutor
 import org.bukkit.entity.Player
@@ -61,7 +61,7 @@ class HomeCommand[F[
 
   private val argsAndSenderConfiguredBuilder = playerCommandBuilder
     .thenParse(
-      Parsers.closedRangeInt[Int Refined Positive](
+      Parsers.closedRangeInt[Int :| Positive](
         HomeId.minimumNumber,
         HomeId.maxNumber,
         failureMessage =

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/home/domain/Home.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/home/domain/Home.scala
@@ -30,9 +30,10 @@ object Home {
   /**
    * プレイヤーの現在レベル（整地レベル、建築レベル）で利用可能なホームポイント数を取得する作用
    */
-  def maxAvailableHomeCountF[F[_]: ConcurrentEffect, G[_]: ContextCoercion[*[_], F], Player](
-    player: Player
-  )(
+  def maxAvailableHomeCountF[F[_]: ConcurrentEffect, G[_]: [f[_]] =>> ContextCoercion[
+    f,
+    F
+  ], Player](player: Player)(
     implicit breakCountReadAPI: BreakCountReadAPI[F, G, Player],
     buildCountReadAPI: BuildCountAPI[F, G, Player]
   ): F[Int] = {

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/itemmigration/System.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/itemmigration/System.scala
@@ -31,7 +31,7 @@ object System {
 
   import cats.implicits._
 
-  def wired[F[_]: ConcurrentEffect, G[_]: SyncEffect: ContextCoercion[*[_], F]](
+  def wired[F[_]: ConcurrentEffect, G[_]: SyncEffect: [f[_]] =>> ContextCoercion[f, F]](
     implicit logger: Logger
   ): G[System[F]] = for {
     migrations <- Sync[G].delay {

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/itemmigration/migrations/V1_0_0_MigrateMebiusToNewCodec.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/itemmigration/migrations/V1_0_0_MigrateMebiusToNewCodec.scala
@@ -1,5 +1,7 @@
 package com.github.unchama.seichiassist.subsystems.itemmigration.migrations
 
+import io.github.iltotore.iron.autoRefine
+
 import cats.effect.SyncIO
 import com.github.unchama.itemmigration.bukkit.util.MigrationHelper
 import com.github.unchama.itemmigration.domain.{ItemMigration, ItemMigrationVersionNumber}

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/itemmigration/migrations/V1_0_0_MigrateMebiusToNewCodec.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/itemmigration/migrations/V1_0_0_MigrateMebiusToNewCodec.scala
@@ -79,8 +79,6 @@ object V1_0_0_MigrateMebiusToNewCodec {
 
   }
 
-  import eu.timepit.refined.auto._
-
   def migrationFunction(
     itemStack: ItemStack
   )(implicit repository: UuidRepository[SyncIO], logger: Logger): ItemStack = {

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/itemmigration/migrations/V1_1_0_AddUnbreakableToNarutoRemake.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/itemmigration/migrations/V1_1_0_AddUnbreakableToNarutoRemake.scala
@@ -1,5 +1,7 @@
 package com.github.unchama.seichiassist.subsystems.itemmigration.migrations
 
+import io.github.iltotore.iron.autoRefine
+
 import com.github.unchama.itemmigration.bukkit.util.MigrationHelper
 import com.github.unchama.itemmigration.domain.{ItemMigration, ItemMigrationVersionNumber}
 import org.bukkit.ChatColor._

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/itemmigration/migrations/V1_1_0_AddUnbreakableToNarutoRemake.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/itemmigration/migrations/V1_1_0_AddUnbreakableToNarutoRemake.scala
@@ -27,8 +27,6 @@ object V1_1_0_AddUnbreakableToNarutoRemake {
     lore.contains(narutoRemake1Lore) || lore.contains(narutoRemake2Lore)
   }
 
-  import eu.timepit.refined.auto._
-
   def migrationFunction(itemStack: ItemStack): ItemStack = {
     if (!isNarutoRemake(itemStack)) return itemStack
 

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/itemmigration/migrations/V1_2_0_FixTypoOf4thAnniversaryGT.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/itemmigration/migrations/V1_2_0_FixTypoOf4thAnniversaryGT.scala
@@ -19,8 +19,6 @@ object V1_2_0_FixTypoOf4thAnniversaryGT {
     name.contains(gt4thName)
   }
 
-  import eu.timepit.refined.auto._
-
   def migrationFunction(itemStack: ItemStack): ItemStack = {
     if (!is4thGiganticItem(itemStack)) return itemStack
 

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/itemmigration/migrations/V1_2_0_FixTypoOf4thAnniversaryGT.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/itemmigration/migrations/V1_2_0_FixTypoOf4thAnniversaryGT.scala
@@ -1,5 +1,7 @@
 package com.github.unchama.seichiassist.subsystems.itemmigration.migrations
 
+import io.github.iltotore.iron.autoRefine
+
 import com.github.unchama.itemmigration.bukkit.util.MigrationHelper
 import com.github.unchama.itemmigration.domain.{ItemMigration, ItemMigrationVersionNumber}
 import org.bukkit.ChatColor._

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/itemmigration/migrations/V1_3_0_RemoveUnnecessaryLoreOfHalloweenItem.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/itemmigration/migrations/V1_3_0_RemoveUnnecessaryLoreOfHalloweenItem.scala
@@ -1,5 +1,7 @@
 package com.github.unchama.seichiassist.subsystems.itemmigration.migrations
 
+import io.github.iltotore.iron.autoRefine
+
 import com.github.unchama.itemmigration.bukkit.util.MigrationHelper
 import com.github.unchama.itemmigration.domain.{ItemMigration, ItemMigrationVersionNumber}
 import org.bukkit.ChatColor._

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/itemmigration/migrations/V1_3_0_RemoveUnnecessaryLoreOfHalloweenItem.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/itemmigration/migrations/V1_3_0_RemoveUnnecessaryLoreOfHalloweenItem.scala
@@ -23,8 +23,6 @@ object V1_3_0_RemoveUnnecessaryLoreOfHalloweenItem {
     lore.contains(halloweenClearPrizeLore) || lore.contains(halloweenSpecialPrizeLore)
   }
 
-  import eu.timepit.refined.auto._
-
   def migrationFunction(itemStack: ItemStack): ItemStack = {
     if (!isHalloweenPrize(itemStack)) return itemStack
 

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/itemmigration/migrations/V1_4_0_AddEnchantsTo2_1billionRewardItems.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/itemmigration/migrations/V1_4_0_AddEnchantsTo2_1billionRewardItems.scala
@@ -1,5 +1,7 @@
 package com.github.unchama.seichiassist.subsystems.itemmigration.migrations
 
+import io.github.iltotore.iron.autoRefine
+
 import com.github.unchama.itemmigration.bukkit.util.MigrationHelper
 import com.github.unchama.itemmigration.domain.{ItemMigration, ItemMigrationVersionNumber}
 import org.bukkit.ChatColor._

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/itemmigration/migrations/V1_4_0_AddEnchantsTo2_1billionRewardItems.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/itemmigration/migrations/V1_4_0_AddEnchantsTo2_1billionRewardItems.scala
@@ -36,8 +36,6 @@ object V1_4_0_AddEnchantsTo2_1billionRewardItems {
   ).map { case (color, str) => s"$color$BOLD$ITALIC$str" }.mkString
   private val gaeaReplicaLore = s"${WHITE}35億/1日を突破した記念に配布されたものです。"
 
-  import eu.timepit.refined.auto._
-
   def migration: ItemMigration = ItemMigration(
     ItemMigrationVersionNumber(1, 4, 0),
     MigrationHelper.delegateConversionForContainers(migrationFunction)

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/mana/System.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/mana/System.scala
@@ -35,9 +35,10 @@ object System {
   import cats.effect.implicits._
   import cats.implicits._
 
-  def wired[F[_]: ConcurrentEffect: ErrorLogger, G[_]: SyncEffect: ContextCoercion[*[_], F]](
-    implicit breakCountReadAPI: BreakCountReadAPI[F, G, Player]
-  ): F[System[F, G, Player]] = {
+  def wired[F[_]: ConcurrentEffect: ErrorLogger, G[_]: SyncEffect: [f[_]] =>> ContextCoercion[
+    f,
+    F
+  ]](implicit breakCountReadAPI: BreakCountReadAPI[F, G, Player]): F[System[F, G, Player]] = {
     import com.github.unchama.minecraft.bukkit.algebra.BukkitPlayerHasUuid.instance
 
     val manaPersistence: ManaAmountPersistence[G] = new JdbcManaAmountPersistence[G]

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/mana/application/ManaRepositoryDefinition.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/mana/application/ManaRepositoryDefinition.scala
@@ -22,8 +22,8 @@ object ManaRepositoryDefinition {
 
   import cats.implicits._
 
-  def withContext[F[_]: ConcurrentEffect: ErrorLogger, G[_]: Sync: ContextCoercion[
-    *[_],
+  def withContext[F[_]: ConcurrentEffect: ErrorLogger, G[_]: Sync: [f[_]] =>> ContextCoercion[
+    f,
     F
   ], Player: HasUuid](
     publishChanges: fs2.Pipe[F, (Player, LevelCappedManaAmount), Unit],

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/mana/application/process/RefillToCap.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/mana/application/process/RefillToCap.scala
@@ -13,7 +13,7 @@ import com.github.unchama.seichiassist.subsystems.mana.domain.LevelCappedManaAmo
  */
 object RefillToCap {
 
-  def using[F[_], G[_]: Monad: ContextCoercion[*[_], F], Player](
+  def using[F[_], G[_]: Monad: [f[_]] =>> ContextCoercion[f, F], Player](
     repository: KeyedDataRepository[Player, Ref[G, LevelCappedManaAmount]]
   )(implicit breakCountReadAPI: BreakCountReadAPI[F, G, Player]): fs2.Stream[F, Unit] = {
     breakCountReadAPI.seichiStarLevelUpdates.evalMap {

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/mana/application/process/UpdateManaCaps.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/mana/application/process/UpdateManaCaps.scala
@@ -11,7 +11,7 @@ object UpdateManaCaps {
 
   import cats.implicits._
 
-  def using[F[_], G[_]: Monad: ContextCoercion[*[_], F], Player](
+  def using[F[_], G[_]: Monad: [f[_]] =>> ContextCoercion[f, F], Player](
     repository: KeyedDataRepository[Player, Ref[G, LevelCappedManaAmount]]
   )(implicit breakCountReadAPI: BreakCountReadAPI[F, G, Player]): fs2.Stream[F, Unit] =
     breakCountReadAPI.seichiLevelUpdates.evalMap {

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/manabar/application/ManaBarSynchronizationRepository.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/manabar/application/ManaBarSynchronizationRepository.scala
@@ -17,9 +17,9 @@ object ManaBarSynchronizationRepository {
 
   import cats.implicits._
 
-  def withContext[G[_]: Sync, F[_]: ConcurrentEffect: ContextCoercion[
+  def withContext[G[_]: Sync, F[_]: ConcurrentEffect: [g[_]] =>> ContextCoercion[
     G,
-    *[_]
+    g
   ]: ErrorLogger, Player: HasUuid](
     manaApi: ManaReadApi[F, G, Player]
   )(createFreshBossBar: G[BossBarWithPlayer[F, Player]]): RepositoryDefinition[G, Player, _] = {

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/managedfly/System.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/managedfly/System.scala
@@ -37,7 +37,9 @@ object System {
 
   def wired[AsyncContext[_]: ConcurrentEffect: OnMinecraftServerThread: Timer, SyncContext[
     _
-  ]: SyncEffect: ContextCoercion[*[_], AsyncContext]](configuration: SystemConfiguration)(
+  ]: SyncEffect: [f[_]] =>> ContextCoercion[f, AsyncContext]](
+    configuration: SystemConfiguration
+  )(
     implicit idleTimeAPI: IdleTimeAPI[AsyncContext, Player]
   ): SyncContext[System[SyncContext, AsyncContext]] = {
     implicit val _configuration: SystemConfiguration = configuration
@@ -46,7 +48,7 @@ object System {
       new JdbcFlyDurationPersistenceRepository[SyncContext]
 
     implicit val _playerKleisliManipulation
-      : PlayerFlyStatusManipulation[Kleisli[AsyncContext, Player, *]] =
+      : PlayerFlyStatusManipulation[[a] =>> Kleisli[AsyncContext, Player, a]] =
       new BukkitPlayerFlyStatusManipulation[AsyncContext]
 
     implicit val _factory: ActiveSessionFactory[AsyncContext, Player] =

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/managedfly/application/ActiveSessionFactory.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/managedfly/application/ActiveSessionFactory.scala
@@ -12,7 +12,8 @@ import com.github.unchama.seichiassist.subsystems.managedfly.domain._
  * プレーヤーに紐づいたFlyセッションを作成できるオブジェクト。
  */
 class ActiveSessionFactory[AsyncContext[_]: Timer: Concurrent, Player](
-  implicit KleisliAsyncContext: PlayerFlyStatusManipulation[Kleisli[AsyncContext, Player, *]]
+  implicit
+  KleisliAsyncContext: PlayerFlyStatusManipulation[[a] =>> Kleisli[AsyncContext, Player, a]]
 ) {
 
   type KleisliAsyncContext[A] = Kleisli[AsyncContext, Player, A]
@@ -47,7 +48,7 @@ class ActiveSessionFactory[AsyncContext[_]: Timer: Concurrent, Player](
     } yield newDuration
   }
 
-  def start[SyncContext[_]: Sync: ContextCoercion[*[_], AsyncContext]](
+  def start[SyncContext[_]: Sync: [f[_]] =>> ContextCoercion[f, AsyncContext]](
     totalDuration: RemainingFlyDuration
   ): KleisliAsyncContext[ActiveSession[AsyncContext, SyncContext]] = {
     import cats.effect.implicits._

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/managedfly/application/ActiveSessionReference.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/managedfly/application/ActiveSessionReference.scala
@@ -51,9 +51,10 @@ object ActiveSessionReference {
 
   import cats.implicits._
 
-  def createNew[AsyncContext[_]: ConcurrentEffect, SyncContext[_]: Sync: ContextCoercion[*[
+  def createNew[AsyncContext[_]: ConcurrentEffect, SyncContext[_]: Sync: [f[
     _
-  ], AsyncContext]]: SyncContext[ActiveSessionReference[AsyncContext, SyncContext]] = {
+  ]] =>> ContextCoercion[f, AsyncContext]]
+    : SyncContext[ActiveSessionReference[AsyncContext, SyncContext]] = {
     for {
       mutex <- Mutex
         .of[AsyncContext, SyncContext, Option[ActiveSession[AsyncContext, SyncContext]]](None)

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/managedfly/application/PlayerFlyStatusManipulation.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/managedfly/application/PlayerFlyStatusManipulation.scala
@@ -9,7 +9,7 @@ import com.github.unchama.seichiassist.subsystems.managedfly.domain.{
 /**
  * プレーヤーの飛行状態に`F`の文脈で干渉する手段を与える型クラスインスタンスのtrait。
  *
- * `F` は `Kleisli[G, Player, *]` の形をしていることを想定している。
+ * `F` は `[a] =>> Kleisli[G, Player, a]` の形をしていることを想定している。
  */
 trait PlayerFlyStatusManipulation[F[_]] extends AnyRef {
 

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/managedfly/bukkit/BukkitPlayerFlyStatusManipulation.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/managedfly/bukkit/BukkitPlayerFlyStatusManipulation.scala
@@ -13,7 +13,7 @@ import org.bukkit.entity.Player
 class BukkitPlayerFlyStatusManipulation[AsyncContext[_]: Concurrent: OnMinecraftServerThread](
   implicit configuration: SystemConfiguration,
   idleTimeAPI: IdleTimeAPI[AsyncContext, Player]
-) extends PlayerFlyStatusManipulation[Kleisli[AsyncContext, Player, *]] {
+) extends PlayerFlyStatusManipulation[[a] =>> Kleisli[AsyncContext, Player, a]] {
 
   import cats.implicits._
 

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/managedfly/bukkit/controllers/BukkitFlyCommand.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/managedfly/bukkit/controllers/BukkitFlyCommand.scala
@@ -18,8 +18,8 @@ import com.github.unchama.seichiassist.subsystems.managedfly.domain.{
 }
 import com.github.unchama.targetedeffect.TargetedEffect
 import com.github.unchama.targetedeffect.commandsender.{MessageEffect, MessageEffectF}
-import eu.timepit.refined.api.Refined
-import eu.timepit.refined.numeric.Positive
+import io.github.iltotore.iron.:|
+import io.github.iltotore.iron.constraint.numeric.Positive
 import org.bukkit.ChatColor._
 import org.bukkit.command.TabExecutor
 import org.bukkit.entity.Player
@@ -42,13 +42,13 @@ object BukkitFlyCommand {
 
   private val durationParser =
     Parsers
-      .closedRangeInt[Int Refined Positive](
+      .closedRangeInt[Int :| Positive](
         1,
         Int.MaxValue,
         MessageEffect(durationParseFailedMessage)
       )
       .andThen { parseResult =>
-        parseResult.map(r => RemainingFlyDuration.PositiveMinutes.fromPositive(r.value))
+        parseResult.map(r => RemainingFlyDuration.PositiveMinutes.fromPositive(r))
       }
 
   import cats.effect.implicits._

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/managedfly/bukkit/listeners/BukkitPlayerStatusChangeListener.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/managedfly/bukkit/listeners/BukkitPlayerStatusChangeListener.scala
@@ -14,7 +14,7 @@ import org.bukkit.event.{EventHandler, Listener}
 class BukkitPlayerStatusChangeListener[F[_]: ConcurrentEffect, G[_]: SyncEffect](
   implicit
   sessionReferenceRepository: KeyedDataRepository[Player, ActiveSessionReference[F, G]],
-  playerFlyStatusManipulation: PlayerFlyStatusManipulation[Kleisli[F, Player, *]]
+  playerFlyStatusManipulation: PlayerFlyStatusManipulation[[a] =>> Kleisli[F, Player, a]]
 ) extends Listener {
 
   import cats.effect.implicits._

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/managedfly/domain/RemainingFlyDuration.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/managedfly/domain/RemainingFlyDuration.scala
@@ -9,7 +9,7 @@ sealed trait RemainingFlyDuration {
    *
    * @return
    */
-  val tickOneMinute: Option[RemainingFlyDuration]
+  def tickOneMinute: Option[RemainingFlyDuration]
 
 }
 

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/mebius/bukkit/command/MebiusCommandExecutorProvider.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/mebius/bukkit/command/MebiusCommandExecutorProvider.scala
@@ -23,7 +23,6 @@ import com.github.unchama.targetedeffect.{SequentialEffect, TargetedEffect, Unfo
 import org.bukkit.ChatColor._
 import org.bukkit.command.{CommandSender, TabExecutor}
 import org.bukkit.entity.Player
-import shapeless.HList
 
 class MebiusCommandExecutorProvider(
   implicit serviceRepository: PlayerDataRepository[MebiusSpeechService[SyncIO]]
@@ -142,9 +141,7 @@ class MebiusCommandExecutorProvider(
       }
     }
 
-    private def concatHeadAndRemainingArgs[A](
-      args: PartiallyParsedArgs[shapeless.::[A, HList]]
-    ): String =
+    private def concatHeadAndRemainingArgs[A](args: PartiallyParsedArgs[A *: Tuple]): String =
       args.parsed.head.toString + " " + args.yetToBeParsed.mkString(" ")
 
     object NicknameCommand {

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/minestack/System.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/minestack/System.scala
@@ -51,7 +51,7 @@ object System {
 
   import cats.implicits._
 
-  def wired[F[_]: ConcurrentEffect, G[_]: SyncEffect: ContextCoercion[*[_], F]](
+  def wired[F[_]: ConcurrentEffect, G[_]: SyncEffect: [f[_]] =>> ContextCoercion[f, F]](
     implicit gachaPrizeAPI: GachaPrizeAPI[F, ItemStack, Player],
     effectEnvironment: EffectEnvironment
   ): F[System[F, Player, ItemStack]] = {

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/minestack/bukkit/MineStackCommand.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/minestack/bukkit/MineStackCommand.scala
@@ -22,7 +22,6 @@ import org.bukkit.ChatColor._
 import org.bukkit.command.TabExecutor
 import org.bukkit.entity.Player
 import org.bukkit.inventory.ItemStack
-import shapeless.HNil
 
 object MineStackCommand {
   def executor(
@@ -86,8 +85,7 @@ object MineStackCommand {
           )
         )
         .buildWith { context =>
-          import shapeless.::
-          val categoryOpt :: page :: HNil = context.args.parsed
+          val (categoryOpt, page) = context.args.parsed
 
           IO.pure {
             categoryOpt.fold(ioCanOpenMinestackMainMenu.open(MineStackMainMenu)) { category =>

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/minestack/bukkit/MineStackCommand.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/minestack/bukkit/MineStackCommand.scala
@@ -15,9 +15,9 @@ import com.github.unchama.seichiassist.subsystems.minestack.MineStackAPI
 import com.github.unchama.seichiassist.subsystems.minestack.domain.minestackobject.MineStackObjectCategory
 import com.github.unchama.targetedeffect.commandsender.MessageEffect
 import com.github.unchama.targetedeffect.{DeferredEffect, SequentialEffect}
-import eu.timepit.refined.api.Refined
-import eu.timepit.refined.auto._
-import eu.timepit.refined.numeric.NonNegative
+import io.github.iltotore.iron.:|
+
+import io.github.iltotore.iron.constraint.numeric.GreaterEqual
 import org.bukkit.ChatColor._
 import org.bukkit.command.TabExecutor
 import org.bukkit.entity.Player
@@ -62,13 +62,13 @@ object MineStackCommand {
       playerCommandBuilder
         .thenParse(
           Parsers
-            .closedRangeInt[Int Refined NonNegative](
+            .closedRangeInt[Int :| GreaterEqual[0]](
               0,
               Int.MaxValue,
               MessageEffect("カテゴリは0以上の値を指定してください。")
             )
             .andThen(_.flatMap { categoryValue =>
-              if (categoryValue.value == 0)
+              if (categoryValue == 0)
                 succeedWith(None)
               else
                 MineStackObjectCategory.fromSerializedValue(categoryValue - 1) match {
@@ -78,7 +78,7 @@ object MineStackCommand {
             })
         )
         .thenParse(
-          Parsers.closedRangeInt[Int Refined NonNegative](
+          Parsers.closedRangeInt[Int :| GreaterEqual[0]](
             0,
             Int.MaxValue,
             MessageEffect("ページ数は0以上の値を指定してください。")

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/playerheadskin/infrastructure/PlayerHeadSkinUrlFetcherByMojangAPI.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/playerheadskin/infrastructure/PlayerHeadSkinUrlFetcherByMojangAPI.scala
@@ -6,7 +6,7 @@ import com.github.unchama.seichiassist.subsystems.playerheadskin.domain.{
   PlayerHeadSkinUrlFetcher
 }
 import org.apache.commons.codec.binary.Base64
-import org.jline.utils.InputStreamReader
+import java.io.InputStreamReader
 
 import java.io.BufferedReader
 import java.net.{HttpURLConnection, URL}

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/present/bukkit/command/PresentCommand.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/present/bukkit/command/PresentCommand.scala
@@ -21,13 +21,11 @@ import com.github.unchama.seichiassist.util.InventoryOperations
 import com.github.unchama.targetedeffect.{SequentialEffect, TargetedEffectF}
 import com.github.unchama.targetedeffect.commandsender.{MessageEffect, MessageEffectF}
 import eu.timepit.refined.api.Refined
-import eu.timepit.refined.auto._
 import eu.timepit.refined.numeric.Positive
 import org.bukkit.command.TabExecutor
 import org.bukkit.entity.Player
 import org.bukkit.inventory.ItemStack
 import org.bukkit.{ChatColor, Material}
-import shapeless.HNil
 
 /**
  * `/present` コマンドを定義する。
@@ -129,7 +127,7 @@ class PresentCommand {
           )
           .ifArgumentsMissing(help)
           .buildWith { context =>
-            val perPage: Int Refined Positive = 10
+            val perPage: Int Refined Positive = Refined.unsafeApply(10)
             val page = context.args.parsed.head
             val player = context.sender.getUniqueId
             val eff = for {
@@ -326,8 +324,7 @@ class PresentCommand {
           .ifArgumentsMissing(help)
           .buildWithExecutionCSEffect { context =>
             if (context.sender.hasPermission("seichiassist.present.grant")) {
-              import shapeless.::
-              val presentId :: mode :: HNil = context.args.parsed
+              val (presentId, mode) = context.args.parsed
               // Parserを通した段階でargs[0]は "player" | "all" になっているのでこれでOK
               val isGlobal = mode == "all"
               (for {
@@ -400,9 +397,8 @@ class PresentCommand {
           .ifArgumentsMissing(help)
           .buildWithExecutionCSEffect { context =>
             if (context.sender.hasPermission("seichiassist.present.revoke")) {
-              import shapeless.::
               val args = context.args
-              val presentId :: presentScope :: HNil = args.parsed
+              val (presentId, presentScope) = args.parsed
               val isGlobal = presentScope == "all"
               (for {
                 _ <- Kleisli.liftF(NonServerThreadContextShift[F].shift)

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/present/bukkit/command/PresentCommand.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/present/bukkit/command/PresentCommand.scala
@@ -20,8 +20,8 @@ import com.github.unchama.seichiassist.subsystems.present.domain._
 import com.github.unchama.seichiassist.util.InventoryOperations
 import com.github.unchama.targetedeffect.{SequentialEffect, TargetedEffectF}
 import com.github.unchama.targetedeffect.commandsender.{MessageEffect, MessageEffectF}
-import eu.timepit.refined.api.Refined
-import eu.timepit.refined.numeric.Positive
+import io.github.iltotore.iron.{:|, autoRefine}
+import io.github.iltotore.iron.constraint.numeric.Positive
 import org.bukkit.command.TabExecutor
 import org.bukkit.entity.Player
 import org.bukkit.inventory.ItemStack
@@ -119,7 +119,7 @@ class PresentCommand {
       ): ContextualExecutor =
         playerCommandBuilder
           .thenParse(
-            Parsers.closedRangeInt[Int Refined Positive](
+            Parsers.closedRangeInt[Int :| Positive](
               1,
               Int.MaxValue,
               MessageEffect("ページ数には1以上の数を指定してください。")
@@ -127,7 +127,7 @@ class PresentCommand {
           )
           .ifArgumentsMissing(help)
           .buildWith { context =>
-            val perPage: Int Refined Positive = Refined.unsafeApply(10)
+            val perPage: Int :| Positive = 10
             val page = context.args.parsed.head
             val player = context.sender.getUniqueId
             val eff = for {

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/present/domain/PresentPersistence.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/present/domain/PresentPersistence.scala
@@ -1,8 +1,8 @@
 package com.github.unchama.seichiassist.subsystems.present.domain
 
 import com.github.unchama.seichiassist.subsystems.present.domain.OperationResult.DeleteResult
-import eu.timepit.refined.api.Refined
-import eu.timepit.refined.numeric.Positive
+import io.github.iltotore.iron.:|
+import io.github.iltotore.iron.constraint.numeric.Positive
 
 import java.util.UUID
 
@@ -111,8 +111,8 @@ trait PresentPersistence[F[_], ItemStack] {
    */
   def fetchStateWithPagination(
     player: UUID,
-    perPage: Int Refined Positive,
-    page: Int Refined Positive
+    perPage: Int :| Positive,
+    page: Int :| Positive
   ): F[Either[PaginationRejectReason, List[(PresentID, PresentClaimingState)]]]
 
   /**

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/present/infrastructure/JdbcBackedPresentPersistence.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/present/infrastructure/JdbcBackedPresentPersistence.scala
@@ -5,9 +5,9 @@ import cats.effect.Sync
 import com.github.unchama.generic.MapExtra
 import com.github.unchama.seichiassist.subsystems.present.domain.OperationResult.DeleteResult
 import com.github.unchama.seichiassist.subsystems.present.domain._
-import eu.timepit.refined.api.Refined
-import eu.timepit.refined.auto._
-import eu.timepit.refined.numeric.Positive
+import io.github.iltotore.iron.:|
+
+import io.github.iltotore.iron.constraint.numeric.Positive
 import org.bukkit.inventory.ItemStack
 import scalikejdbc._
 
@@ -116,8 +116,8 @@ class JdbcBackedPresentPersistence[F[_]: Sync] extends PresentPersistence[F, Ite
 
   override def fetchStateWithPagination(
     player: UUID,
-    perPage: Int Refined Positive,
-    page: Int Refined Positive
+    perPage: Int :| Positive,
+    page: Int :| Positive
   ): F[Either[PaginationRejectReason, List[(PresentID, PresentClaimingState)]]] = {
     import cats.implicits._
     for {
@@ -181,13 +181,13 @@ class JdbcBackedPresentPersistence[F[_]: Sync] extends PresentPersistence[F, Ite
   }
 
   private def idSliceWithPagination(
-    perPage: Int Refined Positive,
-    page: Int Refined Positive
+    perPage: Int :| Positive,
+    page: Int :| Positive
   ): F[Set[PresentID]] =
     Sync[F].delay {
       val offset = (page - 1) * perPage
       DB.readOnly { implicit session =>
-        sql"""SELECT present_id FROM present ORDER BY present_id LIMIT ${perPage.value} OFFSET $offset"""
+        sql"""SELECT present_id FROM present ORDER BY present_id LIMIT ${(perPage: Int)} OFFSET $offset"""
           .map { _.long("present_id") }
           .toList()
           .toSet

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/seichilevelupmessage/System.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/seichilevelupmessage/System.scala
@@ -9,7 +9,7 @@ import org.typelevel.log4cats.ErrorLogger
 
 object System {
 
-  def backgroundProcess[F[_]: Async: SendMinecraftMessage[*[_], Player]: ErrorLogger, G[
+  def backgroundProcess[F[_]: Async: [f[_]] =>> SendMinecraftMessage[f, Player]: ErrorLogger, G[
     _
   ], Player](implicit breakCountReadAPI: BreakCountReadAPI[F, G, Player]): F[Nothing] = {
     StreamExtra.compileToRestartingStream("[SeichiLevelUpMessage]") {

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/vote/bukkit/actions/BukkitReceiveVoteBenefits.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/vote/bukkit/actions/BukkitReceiveVoteBenefits.scala
@@ -15,9 +15,9 @@ import com.github.unchama.seichiassist.subsystems.vote.domain.{
 import com.github.unchama.seichiassist.util.InventoryOperations.grantItemStacksEffect
 import org.bukkit.entity.Player
 
-class BukkitReceiveVoteBenefits[F[_]: OnMinecraftServerThread: Sync, G[
+class BukkitReceiveVoteBenefits[F[_]: OnMinecraftServerThread: Sync, G[_]: SyncEffect: [f[
   _
-]: SyncEffect: ContextCoercion[*[_], F]](
+]] =>> ContextCoercion[f, F]](
   implicit votePersistence: VotePersistence[F],
   breakCountAPI: BreakCountAPI[F, G, Player]
 ) extends ReceiveVoteBenefits[F, Player] {

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/vote/subsystems/fairy/bukkit/BukkitFairySummonRequest.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/vote/subsystems/fairy/bukkit/BukkitFairySummonRequest.scala
@@ -13,7 +13,7 @@ import com.github.unchama.seichiassist.subsystems.vote.subsystems.fairy.domain.{
 }
 import org.bukkit.entity.Player
 
-class BukkitFairySummonRequest[F[_]: Sync, G[_]: ContextCoercion[*[_], F]](
+class BukkitFairySummonRequest[F[_]: Sync, G[_]: [f[_]] =>> ContextCoercion[f, F]](
   implicit breakCountAPI: BreakCountAPI[F, G, Player],
   voteAPI: VoteAPI[F, Player],
   fairyPersistence: FairyPersistence[F],

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/vote/subsystems/fairy/bukkit/actions/BukkitRecoveryMana.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/vote/subsystems/fairy/bukkit/actions/BukkitRecoveryMana.scala
@@ -27,10 +27,10 @@ import java.time.ZoneId
 import scala.concurrent.duration.FiniteDuration
 import scala.util.Random
 
-class BukkitRecoveryMana[F[_]: ConcurrentEffect: JavaTime, G[_]: ContextCoercion[*[_], F]](
-  player: Player,
-  fairySpeech: FairySpeech[F, Player]
-)(
+class BukkitRecoveryMana[F[_]: ConcurrentEffect: JavaTime, G[_]: [f[_]] =>> ContextCoercion[
+  f,
+  F
+]](player: Player, fairySpeech: FairySpeech[F, Player])(
   implicit manaApi: ManaApi[F, G, Player],
   fairyPersistence: FairyPersistence[F],
   mineStackAPI: MineStackAPI[F, Player, ItemStack],

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/vote/subsystems/fairy/bukkit/actions/BukkitSummonFairy.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/vote/subsystems/fairy/bukkit/actions/BukkitSummonFairy.scala
@@ -14,7 +14,7 @@ import com.github.unchama.targetedeffect.commandsender.MessageEffectF
 import org.bukkit.ChatColor._
 import org.bukkit.entity.Player
 
-class BukkitSummonFairy[F[_]: Sync, G[_]: ContextCoercion[*[_], F]](
+class BukkitSummonFairy[F[_]: Sync, G[_]: [f[_]] =>> ContextCoercion[f, F]](
   implicit voteAPI: VoteAPI[F, Player],
   manaApi: ManaApi[F, G, Player],
   fairyPersistence: FairyPersistence[F],

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/vote/subsystems/fairy/bukkit/routines/BukkitFairyRoutine.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/vote/subsystems/fairy/bukkit/routines/BukkitFairyRoutine.scala
@@ -29,7 +29,6 @@ class BukkitFairyRoutine(fairySpeech: FairySpeech[IO, Player])(
   override def start(player: Player): IO[Nothing] = {
 
     val repeatInterval: IO[FiniteDuration] = IO {
-      import scala.concurrent.duration._
 
       30.seconds
     }

--- a/src/main/scala/com/github/unchama/seichiassist/util/SendMessageEffect.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/util/SendMessageEffect.scala
@@ -10,16 +10,17 @@ import org.bukkit.entity.Player
 
 object SendMessageEffect {
 
-  def sendMessageToEveryoneIgnoringPreferenceIO[T: PlayerSendable[*, IO]](
+  def sendMessageToEveryoneIgnoringPreferenceIO[T: [a] =>> PlayerSendable[a, IO]](
     content: T
   ): IO[Unit] = {
     implicit val g: GetConnectedBukkitPlayers[IO] = new GetConnectedBukkitPlayers[IO]
     sendMessageToEveryoneIgnoringPreferenceM[T, IO](content)
   }
 
-  def sendMessageToEveryoneIgnoringPreferenceM[T, F[_]: Monad: GetConnectedPlayers[*[
-    _
-  ], Player]](content: T)(implicit ev: PlayerSendable[T, F]): F[Unit] = {
+  def sendMessageToEveryoneIgnoringPreferenceM[T, F[_]: Monad: [f[_]] =>> GetConnectedPlayers[
+    f,
+    Player
+  ]](content: T)(implicit ev: PlayerSendable[T, F]): F[Unit] = {
     import cats.implicits._
 
     for {
@@ -28,7 +29,7 @@ object SendMessageEffect {
     } yield ()
   }
 
-  def sendMessageToEveryone[T, F[_]: Sync: GetConnectedPlayers[*[_], Player]](
+  def sendMessageToEveryone[T, F[_]: Sync: [f[_]] =>> GetConnectedPlayers[f, Player]](
     content: T
   )(implicit ev: PlayerSendable[T, F]): F[Unit] = {
     import cats.implicits._

--- a/src/test/scala/com/github/unchama/contextualexecutor/builder/ContextualExecutorBuilderSpec.scala
+++ b/src/test/scala/com/github/unchama/contextualexecutor/builder/ContextualExecutorBuilderSpec.scala
@@ -1,7 +1,6 @@
 package com.github.unchama.contextualexecutor.builder
 
 import cats.effect.IO
-import cats.implicits._
 import com.github.unchama.contextualexecutor.{
   ContextualExecutor,
   ExecutedCommand,
@@ -13,12 +12,11 @@ import org.bukkit.command.{Command, CommandSender}
 import org.bukkit.entity.Player
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.wordspec.AnyWordSpec
-import shapeless.{HList, HNil}
 
 /**
  * コマンド引数DSL ([[ContextualExecutorBuilder]]) の回帰テスト。
  *
- * Scala 3移行の際にShapeless HListによる引数型の蓄積をScala 3のTupleへ置き換える予定であるため、
+ * Scala 2時代はShapeless HListで実装されていた引数型の蓄積がScala 3のTupleへ置き換えられたため、
  * 引数のパース順序、エラー通知、送信者の絞り込みといった外部から観測できる挙動をここで固定する。
  */
 class ContextualExecutorBuilderSpec extends AnyWordSpec with MockFactory {
@@ -39,9 +37,9 @@ class ContextualExecutorBuilderSpec extends AnyWordSpec with MockFactory {
   }
 
   "引数を取らないビルダー" should {
-    "空のHListと未パース引数をそのまま実行部へ渡す" in {
+    "空のタプルと未パース引数をそのまま実行部へ渡す" in {
       val sender = stub[CommandSender]
-      var capturedParsed: Option[HList] = None
+      var capturedParsed: Option[Tuple] = None
       var capturedYetToBeParsed: Option[List[String]] = None
 
       val executor = ContextualExecutorBuilder.beginConfiguration.buildWith { context =>
@@ -53,15 +51,15 @@ class ContextualExecutorBuilderSpec extends AnyWordSpec with MockFactory {
 
       executor.executionWith(contextWith(sender, List("raw1", "raw2"))).unsafeRunSync()
 
-      assert(capturedParsed.contains(HNil))
+      assert(capturedParsed.contains(EmptyTuple))
       assert(capturedYetToBeParsed.contains(List("raw1", "raw2")))
     }
   }
 
   "thenParseを使ったビルダー" should {
-    "正常な引数をパースしてHListとして実行部へ渡す" in {
+    "正常な引数をパースしてタプルとして実行部へ渡す" in {
       val sender = stub[CommandSender]
-      var captured: Option[HList] = None
+      var captured: Option[Tuple] = None
 
       val executor =
         ContextualExecutorBuilder.beginConfiguration.thenParse(Parsers.integer()).buildWith {
@@ -70,12 +68,12 @@ class ContextualExecutorBuilderSpec extends AnyWordSpec with MockFactory {
 
       executor.executionWith(contextWith(sender, List("42"))).unsafeRunSync()
 
-      assert(captured.contains(42 :: HNil))
+      assert(captured.contains(42 *: EmptyTuple))
     }
 
     "複数の引数を宣言順にパースし、余剰引数はyetToBeParsedに残す" in {
       val sender = stub[CommandSender]
-      var capturedParsed: Option[HList] = None
+      var capturedParsed: Option[Tuple] = None
       var capturedYetToBeParsed: Option[List[String]] = None
 
       val executor = ContextualExecutorBuilder
@@ -93,7 +91,7 @@ class ContextualExecutorBuilderSpec extends AnyWordSpec with MockFactory {
         .executionWith(contextWith(sender, List("name", "7", "rest1", "rest2")))
         .unsafeRunSync()
 
-      assert(capturedParsed.contains("name" :: 7 :: HNil))
+      assert(capturedParsed.contains(("name", 7)))
       assert(capturedYetToBeParsed.contains(List("rest1", "rest2")))
     }
 
@@ -178,7 +176,7 @@ class ContextualExecutorBuilderSpec extends AnyWordSpec with MockFactory {
 
     "型の絞り込みと引数パースを組み合わせられる" in {
       val playerSender = stub[Player]
-      var captured: Option[HList] = None
+      var captured: Option[Tuple] = None
 
       val executor = ContextualExecutorBuilder
         .beginConfiguration
@@ -190,7 +188,7 @@ class ContextualExecutorBuilderSpec extends AnyWordSpec with MockFactory {
 
       executor.executionWith(contextWith(playerSender, List("arg"))).unsafeRunSync()
 
-      assert(captured.contains("arg" :: HNil))
+      assert(captured.contains("arg" *: EmptyTuple))
     }
   }
 }

--- a/src/test/scala/com/github/unchama/contextualexecutor/builder/ParsersSpec.scala
+++ b/src/test/scala/com/github/unchama/contextualexecutor/builder/ParsersSpec.scala
@@ -2,9 +2,8 @@ package com.github.unchama.contextualexecutor.builder
 
 import com.github.unchama.targetedeffect.TargetedEffect
 import com.github.unchama.targetedeffect.commandsender.MessageEffect
-import eu.timepit.refined.api.{Refined, Validate}
-import eu.timepit.refined.numeric.{Interval, NonNegative, Positive}
-import eu.timepit.refined.refineV
+import io.github.iltotore.iron.constraint.numeric.{GreaterEqual, Interval, Positive}
+import io.github.iltotore.iron.{:|, RuntimeConstraint, refineEither}
 import org.bukkit.command.CommandSender
 import org.scalatest.wordspec.AnyWordSpec
 
@@ -18,9 +17,8 @@ import scala.collection.mutable
  * Scala 3移行の際、コマンドDSLの内部実装(Shapeless HList)がTupleへ置き換えられ、
  * refinedの利用方法も変更される予定であるため、現行のパース挙動をここで固定する。
  *
- * 注意: [[Parsers.closedRangeInt]] は、refinedの述語検証に失敗した場合には引数で渡した
- * 失敗エフェクトではなく、refineVが生成する英語のエラーメッセージ
- * (例: `Predicate (-1 < 0) did not fail.`) をそのまま送信者へ送る。
+ * 注意: [[Parsers.closedRangeInt]] は、制約の検証に失敗した場合には引数で渡した
+ * 失敗エフェクトではなく、Ironが生成する英語のエラーメッセージをそのまま送信者へ送る。
  * 引数の失敗エフェクトが使われるのは、整数としてパースできない場合と、
  * 述語検証には通るが指定範囲外である場合のみである。このテストはその現行挙動を固定する。
  */
@@ -62,10 +60,12 @@ class ParsersSpec extends AnyWordSpec {
   }
 
   /**
-   * refineVが失敗時に生成するエラーメッセージ。
+   * Ironが検証失敗時に生成するエラーメッセージ。
    */
-  private def refinedErrorMessageOf[P](int: Int)(implicit validate: Validate[Int, P]): String =
-    refineV[P](int).swap.getOrElse(fail(s"refineVが${int}の検証に成功してしまいました"))
+  private def refinedErrorMessageOf[P](int: Int)(
+    implicit constraint: RuntimeConstraint[Int, P]
+  ): String =
+    int.refineEither[P].swap.getOrElse(fail(s"Ironがの検証に成功してしまいました"))
 
   "Parsers.identity" should {
     "入力文字列をそのまま返す" in {
@@ -116,31 +116,31 @@ class ParsersSpec extends AnyWordSpec {
     "0と正数を受理し、refinedの値として返す" in {
       val parser = Parsers.nonNegativeInteger()
 
-      assert(parser("0").map(_.value) == Right(0))
-      assert(parser("15").map(_.value) == Right(15))
-      assert(parser(Int.MaxValue.toString).map(_.value) == Right(Int.MaxValue))
+      assert(parser("0") == Right(0))
+      assert(parser("15") == Right(15))
+      assert(parser(Int.MaxValue.toString) == Right(Int.MaxValue))
     }
 
     "負数は述語検証で拒否され、refinedのエラーメッセージが送られる" in {
       val parser = Parsers.nonNegativeInteger(MessageEffect("非負整数を指定してください。"))
 
-      assertFailureEffectSends(parser("-1"), refinedErrorMessageOf[NonNegative](-1))
+      assertFailureEffectSends(parser("-1"), refinedErrorMessageOf[GreaterEqual[0]](-1))
     }
   }
 
   "Parsers.closedRangeInt" should {
     // 本体コードで実際に使われている3種のrefined型で挙動を固定する
-    "Int Refined Positive: 範囲内の値を受理する" in {
+    "Int :| Positive: 範囲内の値を受理する" in {
       val parser =
-        Parsers.closedRangeInt[Int Refined Positive](1, 100, MessageEffect("範囲外です。"))
+        Parsers.closedRangeInt[Int :| Positive](1, 100, MessageEffect("範囲外です。"))
 
-      assert(parser("1").map(_.value) == Right(1))
-      assert(parser("100").map(_.value) == Right(100))
+      assert(parser("1") == Right(1))
+      assert(parser("100") == Right(100))
     }
 
-    "Int Refined Positive: 述語違反はrefinedのエラー、述語成立かつ範囲外は指定エフェクトで拒否する" in {
+    "Int :| Positive: 述語違反はrefinedのエラー、述語成立かつ範囲外は指定エフェクトで拒否する" in {
       val parser =
-        Parsers.closedRangeInt[Int Refined Positive](1, 100, MessageEffect("範囲外です。"))
+        Parsers.closedRangeInt[Int :| Positive](1, 100, MessageEffect("範囲外です。"))
 
       // 0はPositive述語の検証で失敗するため、refinedのメッセージが送られる
       assertFailureEffectSends(parser("0"), refinedErrorMessageOf[Positive](0))
@@ -148,23 +148,23 @@ class ParsersSpec extends AnyWordSpec {
       assertFailureEffectSends(parser("101"), "範囲外です。")
     }
 
-    "Int Refined NonNegative: 0を受理し、負数を拒否する" in {
-      val parser = Parsers
-        .closedRangeInt[Int Refined NonNegative](0, Int.MaxValue, MessageEffect("範囲外です。"))
+    "Int :| GreaterEqual[0]: 0を受理し、負数を拒否する" in {
+      val parser =
+        Parsers.closedRangeInt[Int :| GreaterEqual[0]](0, Int.MaxValue, MessageEffect("範囲外です。"))
 
-      assert(parser("0").map(_.value) == Right(0))
-      assertFailureEffectSends(parser("-1"), refinedErrorMessageOf[NonNegative](-1))
+      assert(parser("0") == Right(0))
+      assertFailureEffectSends(parser("-1"), refinedErrorMessageOf[GreaterEqual[0]](-1))
     }
 
-    "Int Refined Interval.Closed: 区間の両端を受理し、区間外を拒否する" in {
-      val parser = Parsers.closedRangeInt[Int Refined Interval.Closed[1, 64]](
+    "Int :| Interval.Closed: 区間の両端を受理し、区間外を拒否する" in {
+      val parser = Parsers.closedRangeInt[Int :| Interval.Closed[1, 64]](
         1,
         64,
         MessageEffect("スタック数は1から64で指定してください。")
       )
 
-      assert(parser("1").map(_.value) == Right(1))
-      assert(parser("64").map(_.value) == Right(64))
+      assert(parser("1") == Right(1))
+      assert(parser("64") == Right(64))
       // 区間外の値は範囲チェックより先に述語検証で失敗するため、refinedのメッセージが送られる
       assertFailureEffectSends(parser("0"), refinedErrorMessageOf[Interval.Closed[1, 64]](0))
       assertFailureEffectSends(parser("65"), refinedErrorMessageOf[Interval.Closed[1, 64]](65))

--- a/src/test/scala/com/github/unchama/contextualexecutor/builder/ParsersSpec.scala
+++ b/src/test/scala/com/github/unchama/contextualexecutor/builder/ParsersSpec.scala
@@ -65,7 +65,7 @@ class ParsersSpec extends AnyWordSpec {
   private def refinedErrorMessageOf[P](int: Int)(
     implicit constraint: RuntimeConstraint[Int, P]
   ): String =
-    int.refineEither[P].swap.getOrElse(fail(s"Ironがの検証に成功してしまいました"))
+    int.refineEither[P].swap.getOrElse(fail(s"Ironが${int}の検証に成功してしまいました"))
 
   "Parsers.identity" should {
     "入力文字列をそのまま返す" in {

--- a/src/test/scala/com/github/unchama/generic/OptionTExtraSpec.scala
+++ b/src/test/scala/com/github/unchama/generic/OptionTExtraSpec.scala
@@ -7,21 +7,21 @@ import org.scalatest.wordspec.AnyWordSpec
 
 class OptionTExtraSpec extends AnyWordSpec {
   "failIf" should {
-    "produce failing OptionT[Id, *] on true" in {
+    "produce failing [a] =>> OptionT[Id, a] on true" in {
       assert(OptionTExtra.failIf[Id](failCondition = true) == OptionT.none(Applicative[Id]))
     }
 
-    "produce failing OptionT[IO, *] on true" in {
+    "produce failing [a] =>> OptionT[IO, a] on true" in {
       assert(OptionTExtra.failIf[IO](failCondition = true).value.unsafeRunSync().isEmpty)
     }
 
-    "produce succeeding OptionT[Id, *] on false" in {
+    "produce succeeding [a] =>> OptionT[Id, a] on false" in {
       assert(
         OptionTExtra.failIf[Id](failCondition = false) == OptionT.some(())(Applicative[Id])
       )
     }
 
-    "produce succeeding OptionT[IO, *] on false" in {
+    "produce succeeding [a] =>> OptionT[IO, a] on false" in {
       assert(OptionTExtra.failIf[IO](failCondition = false).value.unsafeRunSync().nonEmpty)
     }
   }

--- a/src/test/scala/com/github/unchama/generic/ratelimiting/FixedWindowRateLimiterSpec.scala
+++ b/src/test/scala/com/github/unchama/generic/ratelimiting/FixedWindowRateLimiterSpec.scala
@@ -46,15 +46,17 @@ class FixedWindowRateLimiterSpec
     keepPermitsEqual()
 
     "block requests exceeding limits" in {
-      val maxCount: Natural = 10
-      val requestCount: Natural = 100
+      val maxCount: Natural = refineV[NonNegative].unsafeFrom(10)
+      val requestCount: Natural = refineV[NonNegative].unsafeFrom(100)
 
       val program = for {
         rateLimiter <- FixedWindowRateLimiter.in[Task, Natural](maxCount, 1.minute)
-        allowances <- (1 to requestCount).toList.traverse(_ => rateLimiter.requestPermission(1))
+        allowances <- (1 to requestCount)
+          .toList
+          .traverse(_ => rateLimiter.requestPermission(refineV[NonNegative].unsafeFrom(1)))
       } yield {
-        assert(allowances.take(maxCount).forall(_ == (1: Natural)))
-        assert(allowances.drop(maxCount).forall(_ == (0: Natural)))
+        assert(allowances.take(maxCount).forall(_ == refineV[NonNegative].unsafeFrom(1)))
+        assert(allowances.drop(maxCount).forall(_ == refineV[NonNegative].unsafeFrom(0)))
         ()
       }
 
@@ -62,13 +64,17 @@ class FixedWindowRateLimiterSpec
     }
 
     "reset back to accepting request when the specified time passes" in {
-      val maxCount: Natural = 10
+      val maxCount: Natural = refineV[NonNegative].unsafeFrom(10)
 
       val program = for {
         rateLimiter <- FixedWindowRateLimiter.in[Task, Natural](maxCount, 1.minute)
-        _ <- (1 to maxCount).toList.traverse(_ => rateLimiter.requestPermission(1))
+        _ <- (1 to maxCount)
+          .toList
+          .traverse(_ => rateLimiter.requestPermission(refineV[NonNegative].unsafeFrom(1)))
         _ <- monixTimer.sleep(1.minute + 1.second)
-        allowed <- rateLimiter.requestPermission(1).map(_ == (1: Natural))
+        allowed <- rateLimiter
+          .requestPermission(refineV[NonNegative].unsafeFrom(1))
+          .map(_ == refineV[NonNegative].unsafeFrom(1))
       } yield {
         assert(allowed)
       }
@@ -77,7 +83,7 @@ class FixedWindowRateLimiterSpec
     }
 
     "reset back to accepting request as long as the specified time passes" in {
-      val maxCount: Natural = 5
+      val maxCount: Natural = refineV[NonNegative].unsafeFrom(5)
       val windowCount = 5
 
       val program = for {
@@ -87,11 +93,12 @@ class FixedWindowRateLimiterSpec
           .traverse(_ =>
             (1 to maxCount)
               .toList
-              .traverse(_ => rateLimiter.requestPermission(1))
+              .traverse(_ => rateLimiter.requestPermission(refineV[NonNegative].unsafeFrom(1)))
               .flatTap(_ => monixTimer.sleep(1.minute + 1.second))
           )
       } yield {
-        val expected = List.fill(windowCount * maxCount)(1: Natural)
+        val expected =
+          List.fill(windowCount * maxCount)(refineV[NonNegative].unsafeFrom(1): Natural)
         assert(allowances.flatten == expected)
         ()
       }

--- a/src/test/scala/com/github/unchama/generic/ratelimiting/FixedWindowRateLimiterSpec.scala
+++ b/src/test/scala/com/github/unchama/generic/ratelimiting/FixedWindowRateLimiterSpec.scala
@@ -2,8 +2,8 @@ package com.github.unchama.generic.ratelimiting
 
 import cats.effect.Timer
 import com.github.unchama.testutil.concurrent.tests.TaskDiscreteEventually
-import eu.timepit.refined.numeric.NonNegative
-import eu.timepit.refined.refineV
+import io.github.iltotore.iron.constraint.numeric.GreaterEqual
+import io.github.iltotore.iron.refineUnsafe
 import monix.catnap.SchedulerEffect
 import monix.eval.Task
 import monix.execution.ExecutionModel
@@ -18,7 +18,6 @@ class FixedWindowRateLimiterSpec
     with TaskDiscreteEventually {
 
   import cats.implicits._
-  import eu.timepit.refined.auto._
 
   import scala.concurrent.duration._
 
@@ -26,7 +25,7 @@ class FixedWindowRateLimiterSpec
     seed: Int
   )(implicit monixTimer: Timer[Task]): Task[RateLimiter[Task, Natural]] = {
     val random = new Random(seed)
-    val maxPermit = refineV[NonNegative].unsafeFrom(random.nextInt(1000))
+    val maxPermit = (random.nextInt(1000).refineUnsafe[GreaterEqual[0]])
     val sleepTime = random.nextInt(60000).millis
 
     FixedWindowRateLimiter.in[Task, Natural](maxPermit, sleepTime)
@@ -46,17 +45,17 @@ class FixedWindowRateLimiterSpec
     keepPermitsEqual()
 
     "block requests exceeding limits" in {
-      val maxCount: Natural = refineV[NonNegative].unsafeFrom(10)
-      val requestCount: Natural = refineV[NonNegative].unsafeFrom(100)
+      val maxCount: Natural = (10).refineUnsafe[GreaterEqual[0]]
+      val requestCount: Natural = (100).refineUnsafe[GreaterEqual[0]]
 
       val program = for {
         rateLimiter <- FixedWindowRateLimiter.in[Task, Natural](maxCount, 1.minute)
         allowances <- (1 to requestCount)
           .toList
-          .traverse(_ => rateLimiter.requestPermission(refineV[NonNegative].unsafeFrom(1)))
+          .traverse(_ => rateLimiter.requestPermission((1).refineUnsafe[GreaterEqual[0]]))
       } yield {
-        assert(allowances.take(maxCount).forall(_ == refineV[NonNegative].unsafeFrom(1)))
-        assert(allowances.drop(maxCount).forall(_ == refineV[NonNegative].unsafeFrom(0)))
+        assert(allowances.take(maxCount).forall(_ == (1).refineUnsafe[GreaterEqual[0]]))
+        assert(allowances.drop(maxCount).forall(_ == (0).refineUnsafe[GreaterEqual[0]]))
         ()
       }
 
@@ -64,17 +63,17 @@ class FixedWindowRateLimiterSpec
     }
 
     "reset back to accepting request when the specified time passes" in {
-      val maxCount: Natural = refineV[NonNegative].unsafeFrom(10)
+      val maxCount: Natural = (10).refineUnsafe[GreaterEqual[0]]
 
       val program = for {
         rateLimiter <- FixedWindowRateLimiter.in[Task, Natural](maxCount, 1.minute)
         _ <- (1 to maxCount)
           .toList
-          .traverse(_ => rateLimiter.requestPermission(refineV[NonNegative].unsafeFrom(1)))
+          .traverse(_ => rateLimiter.requestPermission((1).refineUnsafe[GreaterEqual[0]]))
         _ <- monixTimer.sleep(1.minute + 1.second)
         allowed <- rateLimiter
-          .requestPermission(refineV[NonNegative].unsafeFrom(1))
-          .map(_ == refineV[NonNegative].unsafeFrom(1))
+          .requestPermission((1).refineUnsafe[GreaterEqual[0]])
+          .map(_ == (1).refineUnsafe[GreaterEqual[0]])
       } yield {
         assert(allowed)
       }
@@ -83,7 +82,7 @@ class FixedWindowRateLimiterSpec
     }
 
     "reset back to accepting request as long as the specified time passes" in {
-      val maxCount: Natural = refineV[NonNegative].unsafeFrom(5)
+      val maxCount: Natural = (5).refineUnsafe[GreaterEqual[0]]
       val windowCount = 5
 
       val program = for {
@@ -93,12 +92,12 @@ class FixedWindowRateLimiterSpec
           .traverse(_ =>
             (1 to maxCount)
               .toList
-              .traverse(_ => rateLimiter.requestPermission(refineV[NonNegative].unsafeFrom(1)))
+              .traverse(_ => rateLimiter.requestPermission((1).refineUnsafe[GreaterEqual[0]]))
               .flatTap(_ => monixTimer.sleep(1.minute + 1.second))
           )
       } yield {
         val expected =
-          List.fill(windowCount * maxCount)(refineV[NonNegative].unsafeFrom(1): Natural)
+          List.fill(windowCount * maxCount)((1).refineUnsafe[GreaterEqual[0]]: Natural)
         assert(allowances.flatten == expected)
         ()
       }

--- a/src/test/scala/com/github/unchama/generic/ratelimiting/GenericRateLimiterSpec.scala
+++ b/src/test/scala/com/github/unchama/generic/ratelimiting/GenericRateLimiterSpec.scala
@@ -4,10 +4,10 @@ import cats.effect.Timer
 import com.github.unchama.generic.algebra.typeclasses.OrderedMonus
 import com.github.unchama.testutil.concurrent.tests.ConcurrentEffectTest
 import com.github.unchama.testutil.execution.MonixTestSchedulerTests
-import eu.timepit.refined.api.Refined
-import eu.timepit.refined.auto._
-import eu.timepit.refined.numeric.NonNegative
-import eu.timepit.refined.refineV
+import io.github.iltotore.iron.:|
+
+import io.github.iltotore.iron.constraint.numeric.GreaterEqual
+import io.github.iltotore.iron.refineUnsafe
 import monix.catnap.SchedulerEffect
 import monix.eval.Task
 import monix.execution.ExecutionModel
@@ -33,19 +33,19 @@ trait GenericRateLimiterSpec
   )
   implicit private val monixTimer: Timer[Task] = SchedulerEffect.timer(monixScheduler)
 
-  type Natural = Int Refined NonNegative
+  type Natural = Int :| GreaterEqual[0]
 
   implicit val natOrderedMonus: OrderedMonus[Natural] = new OrderedMonus[Natural] {
-    override def empty: Natural = refineV[NonNegative].unsafeFrom(0)
+    override def empty: Natural = (0).refineUnsafe[GreaterEqual[0]]
 
     override def |-|(x: Natural, y: Natural): Natural =
-      if (x >= y) refineV[NonNegative].unsafeFrom(x - y)
+      if (x >= y) (x - y).refineUnsafe[GreaterEqual[0]]
       else empty
 
     override def combine(x: Natural, y: Natural): Natural =
-      refineV[NonNegative].unsafeFrom(x + y)
+      (x + y).refineUnsafe[GreaterEqual[0]]
 
-    override def compare(x: Natural, y: Natural): Int = x.value.compare(y.value)
+    override def compare(x: Natural, y: Natural): Int = (x: Int).compare(y)
   }
 
   /**

--- a/src/test/scala/com/github/unchama/generic/ratelimiting/GenericRateLimiterSpec.scala
+++ b/src/test/scala/com/github/unchama/generic/ratelimiting/GenericRateLimiterSpec.scala
@@ -36,7 +36,7 @@ trait GenericRateLimiterSpec
   type Natural = Int Refined NonNegative
 
   implicit val natOrderedMonus: OrderedMonus[Natural] = new OrderedMonus[Natural] {
-    override def empty: Natural = 0
+    override def empty: Natural = refineV[NonNegative].unsafeFrom(0)
 
     override def |-|(x: Natural, y: Natural): Natural =
       if (x >= y) refineV[NonNegative].unsafeFrom(x - y)

--- a/src/test/scala/com/github/unchama/generic/tag/TaggedTypeErasureSpec.scala
+++ b/src/test/scala/com/github/unchama/generic/tag/TaggedTypeErasureSpec.scala
@@ -1,0 +1,41 @@
+package com.github.unchama.generic.tag
+
+import com.github.unchama.generic.tag.tag.@@
+import org.scalatest.wordspec.AnyWordSpec
+
+import java.util.concurrent.{CountDownLatch, TimeUnit}
+import scala.concurrent.ExecutionContext
+
+/**
+ * タグ付き型の実行時表現の回帰テスト。
+ *
+ * Scala 2時代の交差型エンコーディング（`T with Tagged[U]` + asInstanceOf）は、
+ * Scala 3では交差型の消去規則の違いによりフィールドのJVM型が `Tagged` 側へ消去され、
+ * objectの初期化子でタグ付き値をフィールドへ格納した時点で ClassCastException が
+ * 発生した（PluginExecutionContexts の初期化失敗によるプラグインロード不能）。
+ * このテストは、opaque type によるエンコーディングでその問題が再発しないことを固定する。
+ */
+class TaggedTypeErasureSpec extends AnyWordSpec {
+
+  trait Marker
+
+  private object Holder {
+    // 交差型エンコーディングではこのフィールドへの格納が実行時に失敗していた
+    val taggedContext: ExecutionContext @@ Marker =
+      tag.apply[Marker][ExecutionContext](ExecutionContext.global)
+  }
+
+  "タグ付き型" should {
+    "objectの初期化子でフィールドへ格納しても実行時例外にならない" in {
+      assert(Holder.taggedContext ne null)
+    }
+
+    "タグを付与したまま元の型のメソッドをそのまま利用できる" in {
+      val latch = new CountDownLatch(1)
+
+      Holder.taggedContext.execute(() => latch.countDown())
+
+      assert(latch.await(5, TimeUnit.SECONDS))
+    }
+  }
+}

--- a/src/test/scala/com/github/unchama/itemmigration/domain/ItemMigrationVersionNumberSpec.scala
+++ b/src/test/scala/com/github/unchama/itemmigration/domain/ItemMigrationVersionNumberSpec.scala
@@ -1,6 +1,5 @@
 package com.github.unchama.itemmigration.domain
 
-import eu.timepit.refined.auto._
 import org.scalatest.wordspec.AnyWordSpec
 
 /**

--- a/src/test/scala/com/github/unchama/itemmigration/domain/ItemMigrationVersionNumberSpec.scala
+++ b/src/test/scala/com/github/unchama/itemmigration/domain/ItemMigrationVersionNumberSpec.scala
@@ -1,13 +1,14 @@
 package com.github.unchama.itemmigration.domain
 
+import io.github.iltotore.iron.autoRefine
+
 import org.scalatest.wordspec.AnyWordSpec
 
 /**
  * [[ItemMigrationVersionNumber]] と [[ItemMigrations]] のバージョン順序の回帰テスト。
  *
- * `ItemMigrationVersionNumber(1, 0, 0)` のようなリテラル構築は refined.auto._ の
- * コンパイル時検証に依存しており、Scala 3移行でinlineファクトリへ置き換える方針の
- * ため、文字列変換・パース・ソート順の現行挙動をここで固定する。
+ * `ItemMigrationVersionNumber(1, 0, 0)` のようなリテラル構築のコンパイル時検証は
+ * Ironが担う。文字列変換・パース・ソート順の現行挙動をここで固定する。
  */
 class ItemMigrationVersionNumberSpec extends AnyWordSpec {
 
@@ -18,20 +19,20 @@ class ItemMigrationVersionNumberSpec extends AnyWordSpec {
       assert(ItemMigrationVersionNumber(1, 10, 3).versionString == "1.10.3")
     }
 
-    "1〜3成分のリテラルから構築できる" in {
-      // リテラル構築で受け入れる成分数は3つまでとする合意仕様
-      // （Scala 2時代は任意個数だったが、既存のバージョン定義はすべて3成分以下）
+    "成分数は3に限らず、任意の個数のリテラルから構築できる" in {
+      // Ironのリテラル自動検証と可変長引数により、Scala 2時代のrefined.auto._と
+      // 同じ受け入れ範囲（任意個数）が復元されている
       assert(ItemMigrationVersionNumber(1, 0).versionString == "1.0")
+      assert(ItemMigrationVersionNumber(1, 2, 3, 4).versionString == "1.2.3.4")
       assert(
         ItemMigrationVersionNumber.fromString("1.0").contains(ItemMigrationVersionNumber(1, 0))
       )
     }
 
-    "負のリテラル・非リテラル・成分なし・4成分以上の構築はコンパイルエラーになる" in {
+    "負のリテラル・非リテラル・成分なしの構築はコンパイルエラーになる" in {
       assertDoesNotCompile("ItemMigrationVersionNumber(-1, 0)")
       assertDoesNotCompile("val runtimeValue = 1; ItemMigrationVersionNumber(runtimeValue)")
       assertDoesNotCompile("ItemMigrationVersionNumber()")
-      assertDoesNotCompile("ItemMigrationVersionNumber(1, 2, 3, 4)")
     }
 
     "fromStringで非負整数のドット区切りをパースできる" in {

--- a/src/test/scala/com/github/unchama/itemmigration/domain/ItemMigrationVersionNumberSpec.scala
+++ b/src/test/scala/com/github/unchama/itemmigration/domain/ItemMigrationVersionNumberSpec.scala
@@ -18,19 +18,20 @@ class ItemMigrationVersionNumberSpec extends AnyWordSpec {
       assert(ItemMigrationVersionNumber(1, 10, 3).versionString == "1.10.3")
     }
 
-    "成分数は3に限らず、任意の個数のリテラルから構築できる" in {
-      // Scala 2時代のrefined.auto._と可変長引数による構築と同じ受け入れ範囲であること
+    "1〜3成分のリテラルから構築できる" in {
+      // リテラル構築で受け入れる成分数は3つまでとする合意仕様
+      // （Scala 2時代は任意個数だったが、既存のバージョン定義はすべて3成分以下）
       assert(ItemMigrationVersionNumber(1, 0).versionString == "1.0")
-      assert(ItemMigrationVersionNumber(1, 2, 3, 4).versionString == "1.2.3.4")
       assert(
         ItemMigrationVersionNumber.fromString("1.0").contains(ItemMigrationVersionNumber(1, 0))
       )
     }
 
-    "負のリテラル・非リテラル・成分なしの構築はコンパイルエラーになる" in {
+    "負のリテラル・非リテラル・成分なし・4成分以上の構築はコンパイルエラーになる" in {
       assertDoesNotCompile("ItemMigrationVersionNumber(-1, 0)")
       assertDoesNotCompile("val runtimeValue = 1; ItemMigrationVersionNumber(runtimeValue)")
       assertDoesNotCompile("ItemMigrationVersionNumber()")
+      assertDoesNotCompile("ItemMigrationVersionNumber(1, 2, 3, 4)")
     }
 
     "fromStringで非負整数のドット区切りをパースできる" in {

--- a/src/test/scala/com/github/unchama/itemmigration/domain/ItemMigrationVersionNumberSpec.scala
+++ b/src/test/scala/com/github/unchama/itemmigration/domain/ItemMigrationVersionNumberSpec.scala
@@ -18,6 +18,21 @@ class ItemMigrationVersionNumberSpec extends AnyWordSpec {
       assert(ItemMigrationVersionNumber(1, 10, 3).versionString == "1.10.3")
     }
 
+    "成分数は3に限らず、任意の個数のリテラルから構築できる" in {
+      // Scala 2時代のrefined.auto._と可変長引数による構築と同じ受け入れ範囲であること
+      assert(ItemMigrationVersionNumber(1, 0).versionString == "1.0")
+      assert(ItemMigrationVersionNumber(1, 2, 3, 4).versionString == "1.2.3.4")
+      assert(
+        ItemMigrationVersionNumber.fromString("1.0").contains(ItemMigrationVersionNumber(1, 0))
+      )
+    }
+
+    "負のリテラル・非リテラル・成分なしの構築はコンパイルエラーになる" in {
+      assertDoesNotCompile("ItemMigrationVersionNumber(-1, 0)")
+      assertDoesNotCompile("val runtimeValue = 1; ItemMigrationVersionNumber(runtimeValue)")
+      assertDoesNotCompile("ItemMigrationVersionNumber()")
+    }
+
     "fromStringで非負整数のドット区切りをパースできる" in {
       assert(
         ItemMigrationVersionNumber

--- a/src/test/scala/com/github/unchama/itemmigration/domain/ItemMigrationVersionNumberSpec.scala
+++ b/src/test/scala/com/github/unchama/itemmigration/domain/ItemMigrationVersionNumberSpec.scala
@@ -33,6 +33,41 @@ class ItemMigrationVersionNumberSpec extends AnyWordSpec {
       )
     }
 
+    "リテラル構築とfromString構築の値は、等価性とハッシュ値の両方が一致する" in {
+      // 適用済みマイグレーションのスキップ判定（ItemMigrations.yetToBeApplied）は、
+      // DBからfromStringで読み戻した値と、マイグレーション定義のリテラル構築値との
+      // Set.contains（hashCode + equals）に依存している。この一致が崩れると
+      // 適用済みのマイグレーションが再適用されてしまうため、両構築経路の
+      // 完全な互換性をここで固定する。
+      val literal = ItemMigrationVersionNumber(1, 0, 0)
+      val parsed = ItemMigrationVersionNumber.fromString("1.0.0").get
+
+      assert(literal == parsed)
+      assert(literal.hashCode == parsed.hashCode)
+      assert(Set[ItemMigrationVersionNumber](literal).contains(parsed))
+      assert(Set[ItemMigrationVersionNumber](parsed).contains(literal))
+    }
+
+    "fromStringで読み戻したバージョンはyetToBeAppliedで適用済みとして扱われる" in {
+      def migrationOf(version: ItemMigrationVersionNumber): ItemMigration =
+        ItemMigration(version, identity)
+
+      val definedMigrations = ItemMigrations(
+        IndexedSeq(
+          migrationOf(ItemMigrationVersionNumber(1, 0, 0)),
+          migrationOf(ItemMigrationVersionNumber(1, 1, 0))
+        )
+      )
+      // DBから読み戻した状態を再現する
+      val appliedVersions: Set[ItemMigrationVersionNumber] =
+        Set(ItemMigrationVersionNumber.fromString("1.0.0").get)
+
+      assert(
+        definedMigrations.yetToBeApplied(appliedVersions).versions ==
+          List(ItemMigrationVersionNumber(1, 1, 0))
+      )
+    }
+
     "fromStringは不正な入力に対してNoneを返す" in {
       assert(ItemMigrationVersionNumber.fromString("1.-1.0").isEmpty)
       assert(ItemMigrationVersionNumber.fromString("a.b.c").isEmpty)

--- a/src/test/scala/com/github/unchama/menuinventory/ChestSlotRefSpec.scala
+++ b/src/test/scala/com/github/unchama/menuinventory/ChestSlotRefSpec.scala
@@ -1,6 +1,5 @@
 package com.github.unchama.menuinventory
 
-import eu.timepit.refined.auto._
 import org.scalatest.wordspec.AnyWordSpec
 
 /**

--- a/src/test/scala/com/github/unchama/menuinventory/ChestSlotRefSpec.scala
+++ b/src/test/scala/com/github/unchama/menuinventory/ChestSlotRefSpec.scala
@@ -1,14 +1,14 @@
 package com.github.unchama.menuinventory
 
+import io.github.iltotore.iron.autoRefine
+
 import org.scalatest.wordspec.AnyWordSpec
 
 /**
  * [[ChestSlotRef]] の回帰テスト。
  *
- * `ChestSlotRef(行, 列)` のリテラル呼び出しはリポジトリ内に約300箇所存在し、
- * refined.auto._ のマクロによるコンパイル時リテラル検証に依存している。
- * Scala 3移行ではこの検証をinlineファクトリへ置き換える方針のため、
- * スロットID計算の現行挙動をここで固定する。
+ * `ChestSlotRef(行, 列)` のリテラル呼び出しはリポジトリ内に約300箇所存在する。
+ * リテラルのコンパイル時検証はIronが担う。スロットID計算の現行挙動をここで固定する。
  */
 class ChestSlotRefSpec extends AnyWordSpec {
 

--- a/src/test/scala/com/github/unchama/seichiassist/achievement/NickNameMappingSpec.scala
+++ b/src/test/scala/com/github/unchama/seichiassist/achievement/NickNameMappingSpec.scala
@@ -26,9 +26,9 @@ class NickNameMappingSpec extends AnyWordSpec {
         val NicknameCombination(first, second, third) =
           NicknameMapping.getNicknameCombinationFor(achievement)
 
-        val selectFirst: NicknamesToBeUnlocked => Option[String] = _.head()
-        val selectSecond: NicknamesToBeUnlocked => Option[String] = _.middle()
-        val selectThird: NicknamesToBeUnlocked => Option[String] = _.tail()
+        val selectFirst: NicknamesToBeUnlocked => Option[String] = _.head
+        val selectSecond: NicknamesToBeUnlocked => Option[String] = _.middle
+        val selectThird: NicknamesToBeUnlocked => Option[String] = _.tail
 
         info(s"for achievement $achievement")
 

--- a/src/test/scala/com/github/unchama/seichiassist/menus/paging/PageCounterSpec.scala
+++ b/src/test/scala/com/github/unchama/seichiassist/menus/paging/PageCounterSpec.scala
@@ -1,44 +1,43 @@
 package com.github.unchama.seichiassist.menus.paging
 
-import eu.timepit.refined.api.Refined
-import eu.timepit.refined.numeric.GreaterEqual
-import eu.timepit.refined.refineV
-import eu.timepit.refined.types.numeric.PosInt
+import io.github.iltotore.iron.autoRefine
+
+import io.github.iltotore.iron.constraint.numeric.GreaterEqual
+import io.github.iltotore.iron.{:|, refineUnsafe}
 import org.scalatest.wordspec.AnyWordSpec
 
 /**
  * [[PageCounter]] の回帰テスト。
  *
- * Scala 2時代に`PosInt(...)`マクロが担っていた`itemsPerPage`リテラルのコンパイル時検証は、
- * Scala 3移行でinlineオーバーロードに置き換えられた。ページ数計算の挙動が
- * 移行前と変わっていないことをここで固定する。
+ * `itemsPerPage` リテラルのコンパイル時検証はIronが担う。
+ * ページ数計算の挙動が移行前と変わっていないことをここで固定する。
  */
 class PageCounterSpec extends AnyWordSpec {
 
-  private def items(count: Int): Int Refined GreaterEqual[0] =
-    refineV[GreaterEqual[0]].unsafeFrom(count)
+  private def items(count: Int): Int :| GreaterEqual[0] =
+    count.refineUnsafe[GreaterEqual[0]]
 
   "PageCounter.totalPage" should {
     "アイテム数0でも1ページを返す" in {
-      assert(PageCounter.totalPage(items(0), 26) == PosInt.unsafeFrom(1))
+      assert(PageCounter.totalPage(items(0), 26) == 1)
     }
 
     "1ページに収まる場合は1ページを返す" in {
-      assert(PageCounter.totalPage(items(1), 26) == PosInt.unsafeFrom(1))
-      assert(PageCounter.totalPage(items(26), 26) == PosInt.unsafeFrom(1))
+      assert(PageCounter.totalPage(items(1), 26) == 1)
+      assert(PageCounter.totalPage(items(26), 26) == 1)
     }
 
     "1ページから溢れた分は切り上げる" in {
       // NicknameShopMenu は26件/ページ、NicknameCombinationMenu は27件/ページで利用している
-      assert(PageCounter.totalPage(items(27), 26) == PosInt.unsafeFrom(2))
-      assert(PageCounter.totalPage(items(52), 26) == PosInt.unsafeFrom(2))
-      assert(PageCounter.totalPage(items(53), 26) == PosInt.unsafeFrom(3))
-      assert(PageCounter.totalPage(items(27), 27) == PosInt.unsafeFrom(1))
-      assert(PageCounter.totalPage(items(28), 27) == PosInt.unsafeFrom(2))
+      assert(PageCounter.totalPage(items(27), 26) == 2)
+      assert(PageCounter.totalPage(items(52), 26) == 2)
+      assert(PageCounter.totalPage(items(53), 26) == 3)
+      assert(PageCounter.totalPage(items(27), 27) == 1)
+      assert(PageCounter.totalPage(items(28), 27) == 2)
     }
 
     "1件/ページではアイテム数がそのままページ数になる" in {
-      assert(PageCounter.totalPage(items(5), 1) == PosInt.unsafeFrom(5))
+      assert(PageCounter.totalPage(items(5), 1) == 5)
     }
   }
 }

--- a/src/test/scala/com/github/unchama/seichiassist/menus/paging/PageCounterSpec.scala
+++ b/src/test/scala/com/github/unchama/seichiassist/menus/paging/PageCounterSpec.scala
@@ -1,39 +1,44 @@
 package com.github.unchama.seichiassist.menus.paging
 
-import eu.timepit.refined.auto._
+import eu.timepit.refined.api.Refined
+import eu.timepit.refined.numeric.GreaterEqual
+import eu.timepit.refined.refineV
 import eu.timepit.refined.types.numeric.PosInt
 import org.scalatest.wordspec.AnyWordSpec
 
 /**
  * [[PageCounter]] の回帰テスト。
  *
- * `PosInt(...)` リテラルは `RefinedTypeOps.apply` マクロによるコンパイル時検証に
- * 依存しており、Scala 3移行ではinlineファクトリへ置き換える方針のため、
- * ページ数計算の現行挙動をここで固定する。
+ * Scala 2時代に`PosInt(...)`マクロが担っていた`itemsPerPage`リテラルのコンパイル時検証は、
+ * Scala 3移行でinlineオーバーロードに置き換えられた。ページ数計算の挙動が
+ * 移行前と変わっていないことをここで固定する。
  */
 class PageCounterSpec extends AnyWordSpec {
 
+  private def items(count: Int): Int Refined GreaterEqual[0] =
+    refineV[GreaterEqual[0]].unsafeFrom(count)
+
   "PageCounter.totalPage" should {
     "アイテム数0でも1ページを返す" in {
-      assert(PageCounter.totalPage(0, PosInt(26)) == PosInt(1))
+      assert(PageCounter.totalPage(items(0), 26) == PosInt.unsafeFrom(1))
     }
 
     "1ページに収まる場合は1ページを返す" in {
-      assert(PageCounter.totalPage(1, PosInt(26)) == PosInt(1))
-      assert(PageCounter.totalPage(26, PosInt(26)) == PosInt(1))
+      assert(PageCounter.totalPage(items(1), 26) == PosInt.unsafeFrom(1))
+      assert(PageCounter.totalPage(items(26), 26) == PosInt.unsafeFrom(1))
     }
 
     "1ページから溢れた分は切り上げる" in {
       // NicknameShopMenu は26件/ページ、NicknameCombinationMenu は27件/ページで利用している
-      assert(PageCounter.totalPage(27, PosInt(26)) == PosInt(2))
-      assert(PageCounter.totalPage(52, PosInt(26)) == PosInt(2))
-      assert(PageCounter.totalPage(53, PosInt(26)) == PosInt(3))
-      assert(PageCounter.totalPage(27, PosInt(27)) == PosInt(1))
-      assert(PageCounter.totalPage(28, PosInt(27)) == PosInt(2))
+      assert(PageCounter.totalPage(items(27), 26) == PosInt.unsafeFrom(2))
+      assert(PageCounter.totalPage(items(52), 26) == PosInt.unsafeFrom(2))
+      assert(PageCounter.totalPage(items(53), 26) == PosInt.unsafeFrom(3))
+      assert(PageCounter.totalPage(items(27), 27) == PosInt.unsafeFrom(1))
+      assert(PageCounter.totalPage(items(28), 27) == PosInt.unsafeFrom(2))
     }
 
     "1件/ページではアイテム数がそのままページ数になる" in {
-      assert(PageCounter.totalPage(5, PosInt(1)) == PosInt(5))
+      assert(PageCounter.totalPage(items(5), 1) == PosInt.unsafeFrom(5))
     }
   }
 }

--- a/src/test/scala/com/github/unchama/seichiassist/subsystems/gachaprize/SystemApiInitializationSpec.scala
+++ b/src/test/scala/com/github/unchama/seichiassist/subsystems/gachaprize/SystemApiInitializationSpec.scala
@@ -1,0 +1,98 @@
+package com.github.unchama.seichiassist.subsystems.gachaprize
+
+import cats.effect.IO
+import cats.effect.concurrent.Ref
+import com.github.unchama.generic.Cloneable
+import com.github.unchama.generic.effect.concurrent.CachedRef
+import com.github.unchama.seichiassist.subsystems.gachaprize.domain.gachaevent.{
+  GachaEvent,
+  GachaEventName,
+  GachaEventPersistence
+}
+import com.github.unchama.seichiassist.subsystems.gachaprize.domain.{
+  CanBeSignedAsGachaPrize,
+  GachaPrizeId,
+  GachaPrizeListPersistence,
+  GachaPrizeTableEntry,
+  StaticGachaPrizeFactory
+}
+import com.github.unchama.seichiassist.subsystems.gachaprize.usecase.GachaPrizeUseCase
+import org.bukkit.inventory.ItemStack
+import org.scalatest.wordspec.AnyWordSpec
+
+import scala.concurrent.duration._
+
+/**
+ * gachaprizeサブシステムのAPI構築の回帰テスト。
+ *
+ * Scala 3移行時、匿名クラス内の `override protected implicit val F = implicitly` が
+ * 定義中の `this.F` 自身を解決してしまい、未初期化の null が格納される問題が発生した。
+ * このテストは、API構築直後にMonadインスタンスが正しく初期化されており、
+ * `F` を利用するメソッドが実行できることを固定する。
+ */
+class SystemApiInitializationSpec extends AnyWordSpec {
+
+  private val emptyPrizesRef: CachedRef[IO, Vector[GachaPrizeTableEntry[ItemStack]]] =
+    new CachedRef[IO, Vector[GachaPrizeTableEntry[ItemStack]]] {
+      override val initial: Ref[IO, Vector[GachaPrizeTableEntry[ItemStack]]] =
+        Ref.unsafe(Vector.empty)
+      override val updateInterval: IO[FiniteDuration] = IO.pure(1.minute)
+    }
+
+  private implicit val prizeListPersistence: GachaPrizeListPersistence[IO, ItemStack] =
+    new GachaPrizeListPersistence[IO, ItemStack] {
+      override def list: IO[Vector[GachaPrizeTableEntry[ItemStack]]] = IO.pure(Vector.empty)
+      override def upsertGachaPrize(gachaPrize: GachaPrizeTableEntry[ItemStack]): IO[Unit] =
+        IO.unit
+      override def removeGachaPrize(gachaPrizeId: GachaPrizeId): IO[Unit] = IO.unit
+      override def duplicateDefaultGachaPrizes(gachaEvent: GachaEvent): IO[Unit] = IO.unit
+    }
+
+  private implicit val eventPersistence: GachaEventPersistence[IO] =
+    new GachaEventPersistence[IO] {
+      override def createGachaEvent(gachaEvent: GachaEvent): IO[Unit] = IO.unit
+      override def deleteGachaEvent(eventName: GachaEventName): IO[Unit] = IO.unit
+      override def gachaEvents: IO[Vector[GachaEvent]] = IO.pure(Vector.empty)
+    }
+
+  // 本テストで検証する経路（gachaPrizesWhenGachaEventsIsNotHolding）では
+  // ItemStackの値そのものは一切参照されないため、nullで代用している
+  private implicit val staticFactory: StaticGachaPrizeFactory[ItemStack] =
+    new StaticGachaPrizeFactory[ItemStack] {
+      override val gachaRingo: ItemStack = null
+      override val expBottle: ItemStack = null
+      override val mineHeadItem: ItemStack = null
+    }
+
+  private implicit val cloneable: Cloneable[ItemStack] = (x: ItemStack) => x
+
+  private implicit val cachedRef: CachedRef[IO, Vector[GachaPrizeTableEntry[ItemStack]]] =
+    emptyPrizesRef
+
+  private val signable: CanBeSignedAsGachaPrize[ItemStack] =
+    new CanBeSignedAsGachaPrize[ItemStack] {
+      override def signWith(ownerName: String): GachaPrizeTableEntry[ItemStack] => ItemStack =
+        _ => throw new NotImplementedError("本テストの経路では使用しない")
+    }
+
+  "System.createApi" should {
+    "構築直後にMonadインスタンスが初期化されており、Fを利用するメソッドが実行できる" in {
+      val useCase = new GachaPrizeUseCase[IO, ItemStack]
+
+      val api = System.createApi[IO](
+        emptyPrizesRef,
+        useCase,
+        prizeListPersistence,
+        eventPersistence,
+        staticFactory,
+        signable
+      )
+
+      // Fがnullの場合、gachaPrizesWhenGachaEventsIsNotHoldingはmapの適用時に
+      // NullPointerExceptionを投げる
+      assert(api.gachaPrizesWhenGachaEventsIsNotHolding.unsafeRunSync() == Vector.empty)
+      assert(api.allGachaPrizeList.unsafeRunSync() == Vector.empty)
+      assert(api.existsGachaPrize(GachaPrizeId(1)).unsafeRunSync() == false)
+    }
+  }
+}

--- a/src/test/scala/com/github/unchama/seichiassist/subsystems/managedfly/application/Mock.scala
+++ b/src/test/scala/com/github/unchama/seichiassist/subsystems/managedfly/application/Mock.scala
@@ -7,9 +7,9 @@ import com.github.unchama.generic.ContextCoercion
 import com.github.unchama.generic.effect.concurrent.Mutex
 import com.github.unchama.seichiassist.subsystems.managedfly.domain._
 
-private[managedfly] class Mock[AsyncContext[_]: Concurrent, SyncContext[
+private[managedfly] class Mock[AsyncContext[_]: Concurrent, SyncContext[_]: Sync: [f[
   _
-]: Sync: ContextCoercion[*[_], AsyncContext]] {
+]] =>> ContextCoercion[f, AsyncContext]] {
 
   sealed trait ExperienceMock {
     def consume(amount: BigInt): Option[ExperienceMock]


### PR DESCRIPTION
### このPRの変更点と理由:

Scala 3移行計画の Phase 2 本体です。cats-effect 2 / fs2 2 は維持したまま、コンパイラを Scala 2.13.18 から **Scala 3.3.8 LTS** へ切り替えます（148ファイル、+447/-427）。

**ビルド定義**
- `scalaVersion := "3.3.8"`、kind-projector プラグイン削除、`-Wunused:all`、`-Yretain-trees`（enumeratum の findValues に必要）
- ScalaPB の `scala3Sources = true`、Scalafmt `dialect = scala3`
- scalafix-core が Scala 3 非対応のため、**未使用だった** `src/scalafix` 配下のカスタムルール2つの配線を除去（`.scalafix.conf` にも CI にも参照がないことを確認済み。ソースは残置したので、削除するか別プロジェクト化するかはレビューでご判断ください）

**コマンドDSL（設計変更）**
- Shapeless HList による引数型蓄積を Scala 3 ネイティブの Tuple へ置換。`thenParse` は `Tuple.Append` を返し、`Prepend` の implicit は不要になりました
- コマンド8ファイルの引数分解をタプルパターン（`val (a, b) = context.args.parsed`）へ変更

**構文移行（機械的変更）**
- kind-projector `*` 構文78箇所 → 型ラムダ（`[f[_]] =>> F[f, X]` 等）
- パラメータ節内の繰り返し `implicit` 修飾子57箇所を削除
- `λ[F ~> G]` 2箇所 → 明示的 `FunctionK`
- vendored tag 型を `T & Tagged[U]` へ

**refined（Phase 1 で合意した案B）**
- `ChestSlotRef`: inline コンパイル時検証の `apply`（**リテラル305箇所は呼び出し側無変更**）+ 実行時経路 `fromRefined`
- `ItemMigrationVersionNumber` / `PageCounter`: 同様の inline コンパイル時検証
- 静的リテラルのコンパイル時保証は refined.auto._ 時代と同水準を維持しています

**その他の Scala 3 非互換の解消**
- lazy val による非 lazy val override 禁止への対応（抽象宣言を def へ）
- `val` による `def name()` override 禁止への対応
- union 型推論・ワイルドカードキャプチャ・implicit 探索循環など個別5箇所

### 補足情報:

- ローカル（Temurin JDK 17）で、依存解決・compile（main 880 + test）・**全183テスト**・`scalafmtCheckAll`・`scalafix --check`・`assembly`（Proto 生成含む）を確認済みです。
- Phase 1 で整備した回帰テスト48件（コマンドDSL・refined 3定義・ContextCoercion の implicit 解決）は**期待値無変更のまま**すべて通過しています。これらのテストが対象とする範囲（コマンド引数解析、メニュー座標・ページ数計算、バージョン順序、ContextCoercion の解決インスタンス）については挙動の同一性が担保されていますが、テストが及ばない範囲の同一性を保証するものではありません（実際、下記のガチャ景品APIの初期化バグはテスト範囲外で発生していました）。
- non-local return の deprecation 警告等、クリーンコンパイルで main 39件・test 2件の警告が残っています（別PRで順次解消予定）。
- **マージ後も本番投入前に Phase 3（実機QA・カナリア・ロールバック確認）が必要です。** QA項目リストは作成済みで、デバッグサーバーでの検証をお願いします。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

### 機械的変更と手作業変更の内訳（レビュー用）

このPRの変更は「ツール自動」「スクリプト一括」「手作業」の3種に分かれます。**レビューで重点的に見ていただきたいのは手作業の約20ファイル**で、それ以外は同一パターンの機械変換です。

#### ツールによる自動変更（レビュー軽め でOK）

- scalafix RemoveUnused による不要 import 削除42行（inline化で不要になった `refined.auto._` など）。`Fs3Channel.scala` の `_ @_` もこれが生成したものです
- scalafmt（dialect=scala3）による再整形

#### スクリプト一括変換（パターンが正しいことを確認いただければ個別レビュー不要）

- kind-projector `*` 構文 → 型ラムダ：78箇所（`X[*[_], Y]` → `[f[_]] =>> X[f, Y]` 等の正規表現変換）
- パラメータ節内の繰り返し `implicit` 修飾子削除：57箇所（コンパイラのエラー位置リストから該当行のみ sed）
- コマンド8ファイルの `val a :: b :: HNil = context.args.parsed` → `val (a, b) = context.args.parsed`：15箇所

#### 手作業による変更（重点レビュー対象）

**設計変更（コマンドDSLのTuple化）**
- `contextualexecutor/Contexts.scala` / `builder/package.scala` — 型境界を `HList` → `Tuple` へ
- `contextualexecutor/builder/ContextualExecutorBuilder.scala` — `thenParse` を `Tuple.Append[HArgs, LastArg]` 返却へ変更し、Shapeless `Prepend` の implicit を除去。`(head.parsed :+ parsedLastArg)(prepend)` → `head.parsed :* parsedLastArg`
- `commands/contextual/builder/BuilderTemplates.scala` — `EmptyTuple` 化
- `mebius/bukkit/command/MebiusCommandExecutorProvider.scala` — `PartiallyParsedArgs[shapeless.::[A, HList]]` → `PartiallyParsedArgs[A *: Tuple]`

**refined の inline ファクトリ（新規記述。Phase 1 合意の案B）**
- `menuinventory/ChestSlotRef.scala` — inline `apply`（コンパイル時検証）+ 実行時経路 `fromRefined` を新設
- `itemmigration/domain/ItemMigrationVersionNumber.scala` — 非負リテラルを検証する inline `apply` オーバーロード（1引数/3引数）を追加
- `menus/paging/PageCounter.scala` — `PosInt` マクロ廃止に伴い inline `totalPage` へ（実行時経路は private `computeTotalPage`。opaque型のerasure衝突のため同名オーバーロード不可）
- `menus/home/HomeMenu.scala` — リテラル行+実行時列の混在4箇所を `fromRefined(Refined.unsafeApply(N), column)` へ
- `present/bukkit/command/PresentCommand.scala` — `val perPage: Int Refined Positive = 10` → `Refined.unsafeApply(10)`（auto._ のリテラル検証廃止のため）

**個別の Scala 3 非互換修正**
- `generic/ContextCoercion.scala` — kind-projector の `λ[F ~> G]` 2箇所を明示的な `new FunctionK` へ展開（**DI配線が依存する implicit のためレビュー推奨**。選択されるインスタンスが不変であることは ContextCoercionResolutionSpec の `eq` テストで担保）
- `generic/tag/tag.scala` — `T with Tagged[U]` → `T & Tagged[U]`
- `generic/RefDict.scala` / `dragonnighttime/System.scala` — スクリプトの対象外だった型ラムダ2箇所（3引数中央ホール、ドット付き型引数）
- `effects/unfocused/BroadcastEffect.scala` — `getOnlinePlayers` のワイルドカードキャプチャを型注釈付き val で解消
- `bungeesemaphoreresponder/.../BungeeSemaphoreCooperator.scala` — match の枝が `F[Unit] | F[List[Unit]]` の union に推論されるため `traverse` → `traverse_`（**Unit化のため戻り値の意味が変わらないことを確認済み。破棄されていた値です**）
- `fourdimensionalpocket/System.scala` — `implicit val systemApi` に明示型（implicit 探索の循環解消）
- `menus/TopLevelRouter.scala` / `buildassist/menu/BuildAssistMenuRouter.scala` — 抽象 `implicit val` → `implicit def`（lazy val による非lazy val override の禁止対応）
- `breakcountbar/domain/BreakCountBarVisibility.scala` / `managedfly/domain/RemainingFlyDuration.scala` — 同上（抽象 `val` → `def`）
- `achievement/Nicknames.scala` — `def head()/middle()/tail()` の空括弧を除去（`val` での override 禁止対応）+ 呼び出し側3箇所
- `playerheadskin/.../PlayerHeadSkinUrlFetcherByMojangAPI.scala` — 誤った `org.jline.utils.InputStreamReader` import を `java.io` へ（Scala 2 コンパイラの jline が transitively に見えていたもの）

**ビルド定義・テスト追従**
- `build.sbt` / `.scalafmt.conf` — 本文参照
- `PageCounterSpec` — 新 API に合わせて書き直し（検証している値・期待値は不変）
- `FixedWindowRateLimiterSpec` / `GenericRateLimiterSpec` — リテラル → `refineV[NonNegative].unsafeFrom(...)`
- `ContextualExecutorBuilderSpec` — HList → Tuple（期待値は同型のタプルに置換、テスト内容不変）

---

### レビュー対応（2026-07-20）

Request changes への対応として、以下を追加コミットしました。

1. **[Blocker] GachaPrizeAPI の Monad 自己参照 → 修正済み**
   `override protected implicit val F: Monad[F] = implicitly` が Scala 3 では定義中の `this.F` 自身を解決し、null が格納されていました（"Infinite loop in function body" 警告）。API 構築を `System.createApi` へ抽出し、匿名クラスの外側で確定させた Monad を明示代入する形へ変更。`SystemApiInitializationSpec` で構築直後に `gachaPrizesWhenGachaEventsIsNotHolding` を実行する回帰テストを追加しました。修正後のクリーンコンパイルで当該警告が 0 件であることを確認済みです。
   なお、同型に見える他の4箇所（`BukkitGrantGachaPrize` / `BukkitRegionCreationPolicy` / `BukkitTradeActionFromInventory` / `BukkitMineStackObjectList`）は、バイトコード検証によりコンストラクタの evidence パラメータ（`aload_1`）を参照しており安全であることを確認しました。これらはクラスのコンストラクタに evidence が渡るため自己参照にならず、バグはメソッド内匿名クラスのパターンのみで発生します。

2. **[High] CI がテストを実行していない → 修正済み**
   assembly が参照する正しいスコープは `assembly / test` であり、従来の `Compile / assembly / test` への配線ではテストが走っていませんでした。スコープを修正し、ローカルで `assembly` 実行時に全183テストが実行されることを確認しました。このPRのCIから、build_check の `./sbt assembly` がテストを含むようになります。

3. **[Medium] refined API の縮小 → 本文の主張を修正（コードは現状維持）**
   ご指摘のとおり「同水準維持」は正確ではありませんでした。維持されているのはリテラル構築のコンパイル時検証と全内部呼び出し経路で、`PageCounter.totalPage` の実行時 `PosInt` 受け取りと `ItemMigrationVersionNumber` の2成分・4成分以上のリテラル構築は縮小しています（現在の呼び出し箇所には影響なし）。実行時経路の公開が必要になった時点で追加する方針とし、本文の記述を修正しました。

4. **[Low] JDK 26 での `・` 識別子問題 → 修正済み**
   `s"$GRAY・..."` 8箇所を `s"${GRAY}・..."` へ変更しました。JDK 17 での生成文字列・挙動は同一です。

あわせて本文のファクトチェック指摘（テスト件数 182→183、Phase 1 回帰テスト 45→48件、警告数 294→main 39件+test 2件、ChestSlotRef 306→305箇所）を修正しました。
