### PR TITLE
chore: sbt依存のRenovate PRをCI通過後に自動マージする

### DIFF
--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -14,17 +14,33 @@ on:
       - .github/workflows/**.yml
       - .github/actions/**/**.yml
   pull_request:
-    paths:
-      - src/**
-      - build.sbt
-      - .scalafix.conf
-      - .scalafmt.conf
-      - project/*
-      - .github/workflows/**.yml
-      - .github/actions/**/**.yml
 
 jobs:
+  changes:
+    runs-on: ubuntu-24.04
+    outputs:
+      sbt: ${{ steps.filter.outputs.sbt }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+
+      - name: Detect changed paths
+        uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
+        id: filter
+        with:
+          filters: |
+            sbt:
+              - src/**
+              - build.sbt
+              - .scalafix.conf
+              - .scalafmt.conf
+              - project/*
+              - .github/workflows/**.yml
+              - .github/actions/**/**.yml
+
   build_check:
+    needs: changes
+    if: needs.changes.outputs.sbt == 'true'
     runs-on: ubuntu-24.04
     container: ghcr.io/giganticminecraft/seichiassist-builder-v2:776da10
     steps:
@@ -51,3 +67,15 @@ jobs:
       - name: Upload dependency graph
         if: github.ref == 'refs/heads/develop'
         uses: scalacenter/sbt-dependency-submission@d84eef4c09e633bcf5f113bcad7fd5e9af1baee9 # v3.2.3
+
+  ci-gate:
+    name: CI Gate
+    needs:
+      - changes
+      - build_check
+    if: always()
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Check required CI jobs
+        run: |
+          echo '${{ toJson(needs) }}' | jq -e 'all(.[]; .result == "success" or .result == "skipped")'

--- a/renovate.json
+++ b/renovate.json
@@ -12,5 +12,13 @@
     "net.coreprotect:coreprotect",
     "com.sk89q.worldguard:worldguard-bukkit",
     "docker-registry1.mariadb.com/library/mariadb"
+  ],
+  "packageRules": [
+    {
+      "matchManagers": ["sbt"],
+      "automerge": true,
+      "automergeType": "pr",
+      "platformAutomerge": true
+    }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -16,6 +16,7 @@
   "packageRules": [
     {
       "matchManagers": ["sbt"],
+      "matchUpdateTypes": ["minor", "patch", "digest"],
       "automerge": true,
       "automergeType": "pr",
       "platformAutomerge": true


### PR DESCRIPTION
## 概要
- sbt(build.sbt / project/plugins.sbt / project/build.properties)のRenovate依存更新PRについて、CI通過後に自動マージされるようにrenovate.jsonへpackageRulesを追加(`matchManagers: ["sbt"]` に `automerge: true` / `automergeType: "pr"` / `platformAutomerge: true`)。
- あわせて develop ブランチ保護に必須ステータスチェック `build_check` を追加済み(この変更とは別に直接GitHub側で設定)。承認1件必須の要件は維持。
- 完全自動化には renovate-approve アプリ (https://github.com/apps/renovate-approve) のインストールが別途必要(GitHub App のインストールはWeb UIでの管理者操作が必要なため、この変更には含まれない)。

## 確認事項
- renovate.json の変更内容を確認し、対象を `matchManagers: ["sbt"]` に限定していることを確認。他のRenovate PR(GitHub Actionsのバージョン更新等)には影響しない。
- develop のブランチ保護設定を `gh api` で確認し、`required_status_checks.checks` に `build_check` が追加されたことを確認済み。

## 補足
- renovate-approve アプリのインストールが未実施のため、現時点ではsbt PRの自動マージは「CI通過 + 人によるApprove」までの半自動状態。アプリ導入後に完全自動化される。

🤖 Generated with Claude Code