### PR TITLE
docs: CONTRIBUTING.mdをScala 3移行後の状態に合わせて更新する

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,8 +12,8 @@
 | :-------------------- | :---------------------------------------------------- | :----------------------------------------------------------------------------------------------------------- |
 | **統合開発環境 (IDE)** | IntelliJ IDEA                                         | [公式サイト](https://www.jetbrains.com/idea/) を推奨                                                            |
 | **Java Development Kit** | AdoptOpenJDK 17 (Temurin)                             | [Adoptium](https://adoptium.net/temurin/releases/?version=17)                                                |
-| **ビルドツール** | sbt 1.9                                               | [公式ドキュメント](https://www.scala-sbt.org/1.x/docs/Setup.html)                                                  |
-| **プログラミング言語** | Scala 2.13                                            | sbt により自動でインストールされます                                                                             |
+| **ビルドツール** | sbt 1.12                                              | [公式ドキュメント](https://www.scala-sbt.org/1.x/docs/Setup.html)                                                  |
+| **プログラミング言語** | Scala 3.3                                             | sbt により自動でインストールされます                                                                             |
 | **Minecraft サーバー** | Paper 1.18.2                                         | Docker コンテナ経由で提供されます                                                                                |
 | **コンテナ** | Docker                                                | [公式サイト](https://www.docker.com/) (Docker Desktop など)                                                       |
 | **バージョン管理** | Git                                                   | [公式サイト](https://git-scm.com/)                                                                               |


### PR DESCRIPTION
## 概要
- Scalaが2.13系から3.3系へ移行済み（#2936 等）だが、CONTRIBUTING.mdの開発環境準備セクションが移行前のバージョン表記のままだった
- 「プログラミング言語」欄を Scala 2.13 → Scala 3.3 に更新
- 併せて、build.sbt / project/build.properties の現状に合わせて「ビルドツール」欄を sbt 1.9 → sbt 1.12 に更新

## 確認事項
- `build.sbt` の `scalaVersion` が `3.3.8`、`project/build.properties` の `sbt.version` が `1.12.14` であることを確認した上で記載を合わせた
- CONTRIBUTING.md 内に他に Scala 2 系を前提とした記述（バージョン番号や言語機能の言及）が残っていないか grep で確認済み

🤖 Generated with Claude Code