### PR TITLE
refactor: FairyBaseRecoveryManaの型をIron化

### DIFF
--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/vote/subsystems/fairy/domain/property/FairyBaseRecoveryMana.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/vote/subsystems/fairy/domain/property/FairyBaseRecoveryMana.scala
@@ -13,10 +13,12 @@ import io.github.iltotore.iron.refineEither
  * @see [[com.github.unchama.seichiassist.subsystems.vote.subsystems.fairy.domain.property.FairyBaseRecoveryMana]]
  *      召喚時の回復量決定ロジック
  */
-case class FairyBaseRecoveryMana(amount: Int :| GreaterEqual[200]) {}
+opaque type FairyBaseRecoveryMana = Int :| GreaterEqual[200]
 
 object FairyBaseRecoveryMana {
-  def tryFromRaw(raw: Int): FairyBaseRecoveryMana = {
+  def apply(raw: Int :| GreaterEqual[200]): FairyBaseRecoveryMana = raw
+
+  def applyUnsafe(raw: Int): FairyBaseRecoveryMana = {
     val amount = raw
       .refineEither[GreaterEqual[200]]
       .getOrElse(throw new IllegalArgumentException("FairyBaseRecoveryManaの回復量が200未満です"))
@@ -47,8 +49,12 @@ object FairyBaseRecoveryMana {
     require(randomRoll >= 0.0 && randomRoll < 1.0, "randomRollは [0.0, 1.0) の範囲で指定してください。")
     val maxJitterSteps = (levelCappedManaAmount / 20).toInt
     val jitter = (maxJitterSteps * randomRoll) / 2.9
-    FairyBaseRecoveryMana.tryFromRaw(
+    FairyBaseRecoveryMana.applyUnsafe(
       (levelCappedManaAmount / 10 - levelCappedManaAmount / 30 + jitter).toInt + 200
     )
+  }
+
+  extension (self: FairyBaseRecoveryMana) {
+    def amount: Int :| GreaterEqual[200] = self
   }
 }

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/vote/subsystems/fairy/domain/property/FairyBaseRecoveryMana.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/vote/subsystems/fairy/domain/property/FairyBaseRecoveryMana.scala
@@ -1,8 +1,7 @@
 package com.github.unchama.seichiassist.subsystems.vote.subsystems.fairy.domain.property
 
-import io.github.iltotore.iron.:|
+import io.github.iltotore.iron.{:|, RefinedType}
 import io.github.iltotore.iron.constraint.numeric.GreaterEqual
-import io.github.iltotore.iron.refineEither
 
 /**
  * 妖精の1回の回復サイクルあたりのマナ回復量。
@@ -13,19 +12,9 @@ import io.github.iltotore.iron.refineEither
  * @see [[com.github.unchama.seichiassist.subsystems.vote.subsystems.fairy.domain.property.FairyBaseRecoveryMana]]
  *      召喚時の回復量決定ロジック
  */
-opaque type FairyBaseRecoveryMana = Int :| GreaterEqual[200]
+type FairyBaseRecoveryMana = FairyBaseRecoveryMana.T
 
-object FairyBaseRecoveryMana {
-  def apply(raw: Int :| GreaterEqual[200]): FairyBaseRecoveryMana = raw
-
-  def applyUnsafe(raw: Int): FairyBaseRecoveryMana = {
-    val amount = raw
-      .refineEither[GreaterEqual[200]]
-      .getOrElse(throw new IllegalArgumentException("FairyBaseRecoveryManaの回復量が200未満です"))
-
-    FairyBaseRecoveryMana(amount)
-  }
-
+object FairyBaseRecoveryMana extends RefinedType[Int, GreaterEqual[200]] {
   /**
    * 妖精召喚時の基本マナ回復量を計算する。
    *
@@ -55,6 +44,6 @@ object FairyBaseRecoveryMana {
   }
 
   extension (self: FairyBaseRecoveryMana) {
-    def amount: Int :| GreaterEqual[200] = self
+    def amount: Int :| GreaterEqual[200] = self.value
   }
 }

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/vote/subsystems/fairy/domain/property/FairyBaseRecoveryMana.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/vote/subsystems/fairy/domain/property/FairyBaseRecoveryMana.scala
@@ -15,6 +15,7 @@ import io.github.iltotore.iron.constraint.numeric.GreaterEqual
 type FairyBaseRecoveryMana = FairyBaseRecoveryMana.T
 
 object FairyBaseRecoveryMana extends RefinedType[Int, GreaterEqual[200]] {
+
   /**
    * 妖精召喚時の基本マナ回復量を計算する。
    *

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/vote/subsystems/fairy/domain/property/FairyBaseRecoveryMana.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/vote/subsystems/fairy/domain/property/FairyBaseRecoveryMana.scala
@@ -1,5 +1,9 @@
 package com.github.unchama.seichiassist.subsystems.vote.subsystems.fairy.domain.property
 
+import io.github.iltotore.iron.:|
+import io.github.iltotore.iron.constraint.numeric.GreaterEqual
+import io.github.iltotore.iron.refineEither
+
 /**
  * 妖精の1回の回復サイクルあたりのマナ回復量。
  *
@@ -9,11 +13,16 @@ package com.github.unchama.seichiassist.subsystems.vote.subsystems.fairy.domain.
  * @see [[com.github.unchama.seichiassist.subsystems.vote.subsystems.fairy.domain.property.FairyBaseRecoveryMana]]
  *      召喚時の回復量決定ロジック
  */
-case class FairyBaseRecoveryMana(amount: Int) {
-  require(amount >= 0)
-}
+case class FairyBaseRecoveryMana(amount: Int :| GreaterEqual[200]) {}
 
 object FairyBaseRecoveryMana {
+  def tryFromRaw(raw: Int): FairyBaseRecoveryMana = {
+    val amount = raw
+      .refineEither[GreaterEqual[200]]
+      .getOrElse(throw new IllegalArgumentException("FairyBaseRecoveryManaの回復量が200未満です"))
+
+    FairyBaseRecoveryMana(amount)
+  }
 
   /**
    * 妖精召喚時の基本マナ回復量を計算する。
@@ -38,7 +47,7 @@ object FairyBaseRecoveryMana {
     require(randomRoll >= 0.0 && randomRoll < 1.0, "randomRollは [0.0, 1.0) の範囲で指定してください。")
     val maxJitterSteps = (levelCappedManaAmount / 20).toInt
     val jitter = (maxJitterSteps * randomRoll) / 2.9
-    FairyBaseRecoveryMana(
+    FairyBaseRecoveryMana.tryFromRaw(
       (levelCappedManaAmount / 10 - levelCappedManaAmount / 30 + jitter).toInt + 200
     )
   }

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/vote/subsystems/fairy/infrastructure/JdbcFairyPersistence.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/vote/subsystems/fairy/infrastructure/JdbcFairyPersistence.scala
@@ -100,7 +100,7 @@ class JdbcFairyPersistence[F[_]: Sync] extends FairyPersistence[F] {
           .map(_.int("fairy_recovery_mana_value"))
           .single()
           .get
-      FairyBaseRecoveryMana.tryFromRaw(recoveryMana)
+      FairyBaseRecoveryMana.applyUnsafe(recoveryMana)
     }
   }
 

--- a/src/main/scala/com/github/unchama/seichiassist/subsystems/vote/subsystems/fairy/infrastructure/JdbcFairyPersistence.scala
+++ b/src/main/scala/com/github/unchama/seichiassist/subsystems/vote/subsystems/fairy/infrastructure/JdbcFairyPersistence.scala
@@ -100,7 +100,7 @@ class JdbcFairyPersistence[F[_]: Sync] extends FairyPersistence[F] {
           .map(_.int("fairy_recovery_mana_value"))
           .single()
           .get
-      FairyBaseRecoveryMana(recoveryMana)
+      FairyBaseRecoveryMana.tryFromRaw(recoveryMana)
     }
   }
 

--- a/src/test/scala/com/github/unchama/seichiassist/subsystems/fairy/domain/FairyManaRecoverySpec.scala
+++ b/src/test/scala/com/github/unchama/seichiassist/subsystems/fairy/domain/FairyManaRecoverySpec.scala
@@ -2,9 +2,10 @@ package com.github.unchama.seichiassist.subsystems.fairy.domain
 
 import com.github.unchama.seichiassist.subsystems.vote.subsystems.fairy.domain.FairyManaRecovery
 import com.github.unchama.seichiassist.subsystems.vote.subsystems.fairy.domain.property.{
-  FairyManaRecoveryState,
-  FairyBaseRecoveryMana
+  FairyBaseRecoveryMana,
+  FairyManaRecoveryState
 }
+import io.github.iltotore.iron.autoRefine
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
@@ -18,7 +19,7 @@ class FairyManaRecoverySpec extends AnyWordSpec with ScalaCheckPropertyChecks wi
       val baseManaRecoveryRatio = 0.7
       val result =
         FairyManaRecovery.compute(mana, 100L, 0.5, isDragonNight = false)
-      result.finalRecoveredMana shouldBe mana.amount * baseManaRecoveryRatio +- 0.001
+      result.finalRecoveredMana shouldBe (mana.amount * baseManaRecoveryRatio +- 0.001)
       result.consumedGachaAppleCount shouldBe 0
       result.state shouldBe FairyManaRecoveryState.RecoverWithoutAppleButLessThanAApple
     }
@@ -28,7 +29,7 @@ class FairyManaRecoverySpec extends AnyWordSpec with ScalaCheckPropertyChecks wi
       val baseManaRecoveryRatio = 0.7
       val result =
         FairyManaRecovery.compute(mana, 0L, 0.5, isDragonNight = false)
-      result.finalRecoveredMana shouldBe mana.amount * baseManaRecoveryRatio +- 0.001
+      result.finalRecoveredMana shouldBe (mana.amount * baseManaRecoveryRatio +- 0.001)
       result.consumedGachaAppleCount shouldBe 0
       result.state shouldBe FairyManaRecoveryState.RecoverWithoutAppleButLessThanAApple
     }
@@ -46,28 +47,29 @@ class FairyManaRecoverySpec extends AnyWordSpec with ScalaCheckPropertyChecks wi
       val bonusManaPerApple = 0.3
       val result = FairyManaRecovery.compute(mana, 1L, 0.03, isDragonNight = false)
 
-      result.manaBeforeDragonNightMultiplier shouldBe
+      result.manaBeforeDragonNightMultiplier shouldBe (
         ((mana.amount * baseManaRecoveryRatio) * 0.5 + bonusManaPerApple) +- 0.001
+      )
     }
 
     "bonusRoll > 0.03 のときボーナスなし" in {
       val mana = FairyBaseRecoveryMana(600)
       val result = FairyManaRecovery.compute(mana, 10L, 0.5, isDragonNight = false)
       val baseAmount = 600 * 0.7
-      result.manaBeforeDragonNightMultiplier shouldBe baseAmount +- 0.001
+      result.manaBeforeDragonNightMultiplier shouldBe (baseAmount +- 0.001)
     }
 
     "isDragonNight = true のときマナ回復量が2倍になる" in {
       val mana = FairyBaseRecoveryMana(600)
       val normal = FairyManaRecovery.compute(mana, 10L, 0.5, isDragonNight = false)
       val dragon = FairyManaRecovery.compute(mana, 10L, 0.5, isDragonNight = true)
-      dragon.finalRecoveredMana shouldBe normal.finalRecoveredMana * 2.0 +- 0.001
+      dragon.finalRecoveredMana shouldBe (normal.finalRecoveredMana * 2.0 +- 0.001)
     }
 
     "isDragonNight = false のときボーナスが付かない" in {
       val mana = FairyBaseRecoveryMana(600)
       val result = FairyManaRecovery.compute(mana, 10L, 0.5, isDragonNight = false)
-      result.finalRecoveredMana shouldBe result.manaBeforeDragonNightMultiplier +- 0.001
+      result.finalRecoveredMana shouldBe (result.manaBeforeDragonNightMultiplier +- 0.001)
     }
 
     "mineStackedAmount < pureAppleConsumeAmount のとき、がちゃりんご消費数が持っている分に丸められる" in {

--- a/src/test/scala/com/github/unchama/seichiassist/subsystems/fairy/domain/FairyManaRecoverySpec.scala
+++ b/src/test/scala/com/github/unchama/seichiassist/subsystems/fairy/domain/FairyManaRecoverySpec.scala
@@ -5,7 +5,6 @@ import com.github.unchama.seichiassist.subsystems.vote.subsystems.fairy.domain.p
   FairyBaseRecoveryMana,
   FairyManaRecoveryState
 }
-import io.github.iltotore.iron.autoRefine
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks


### PR DESCRIPTION
close #2833

----

### このPRの変更点と理由:

- 変更点: ランタイムアサーションをIronに移行
- 理由と代替手段: 単純なアサーションなのでIronのほうが適任。required関数の閾値だけを変更すると、事前条件が型レベルに表現されず、実装と期待される制約が将来的に乖離する可能性があるため。